### PR TITLE
Apropos

### DIFF
--- a/src/minicli/command.go
+++ b/src/minicli/command.go
@@ -61,11 +61,23 @@ outer:
 		case item.Type&stringItem != 0:
 			cmd.StringArgs[item.Key] = input.items[i].Value
 		case item.Type&choiceItem != 0:
+			// holds the match
+			matched := ""
 			for _, choice := range item.Options {
-				if choice == input.items[i].Value {
-					cmd.BoolArgs[choice] = true
-					continue outer
+				// Check if item matches as apropos
+				if strings.HasPrefix(choice, input.items[i].Value) {
+					if matched != "" {
+						// We already found a match.
+						// Collision.
+						return nil, i
+					}
+					matched = choice
 				}
+			}
+
+			if matched != "" {
+				cmd.BoolArgs[matched] = true
+				continue outer
 			}
 
 			// Invalid choice

--- a/src/minicli/command.go
+++ b/src/minicli/command.go
@@ -4,6 +4,11 @@
 
 package minicli
 
+import (
+	log "minilog"
+	"strings"
+)
+
 type Command struct {
 	Pattern  string // the specific pattern that was matched
 	Original string // original raw input
@@ -46,8 +51,12 @@ outer:
 
 		switch {
 		case item.Type == literalItem:
-			if input.items[i].Value != item.Text {
+			if !strings.HasPrefix(item.Text, input.items[i].Value) {
 				return nil, i
+			}
+
+			if input.items[i].Value != item.Text {
+				log.Debug("matched apropos literal %v : %v", item.Text, input.items[i].Value)
 			}
 		case item.Type&stringItem != 0:
 			cmd.StringArgs[item.Key] = input.items[i].Value

--- a/src/minicli/command.go
+++ b/src/minicli/command.go
@@ -27,7 +27,8 @@ type Command struct {
 	noOp bool
 }
 
-func newCommand(pattern patternItems, input *Input, call CLIFunc) (*Command, int) {
+func newCommand(pattern patternItems, input *Input, call CLIFunc) (*Command, int, bool) {
+	exact := true
 	cmd := Command{
 		Pattern:    pattern.String(),
 		Original:   input.Original,
@@ -43,20 +44,21 @@ outer:
 			// Check if the remaining item is optional
 			if item.Type&optionalItem != 0 {
 				// Matched!
-				return &cmd, i
+				return &cmd, i, exact
 			}
 
-			return nil, i
+			return nil, i, exact
 		}
 
 		switch {
 		case item.Type == literalItem:
 			if !strings.HasPrefix(item.Text, input.items[i].Value) {
-				return nil, i
+				return nil, i, exact
 			}
 
 			if input.items[i].Value != item.Text {
 				log.Debug("matched apropos literal %v : %v", item.Text, input.items[i].Value)
+				exact = false
 			}
 		case item.Type&stringItem != 0:
 			cmd.StringArgs[item.Key] = input.items[i].Value
@@ -66,10 +68,13 @@ outer:
 			for _, choice := range item.Options {
 				// Check if item matches as apropos
 				if strings.HasPrefix(choice, input.items[i].Value) {
+					if choice != input.items[i].Value {
+						exact = false
+					}
 					if matched != "" {
 						// We already found a match.
 						// Collision.
-						return nil, i
+						return nil, i, exact
 					}
 					matched = choice
 				}
@@ -81,7 +86,7 @@ outer:
 			}
 
 			// Invalid choice
-			return nil, i
+			return nil, i, exact
 		case item.Type&listItem != 0:
 			res := make([]string, len(input.items)-i)
 			for i, v := range input.items[i:] {
@@ -89,16 +94,16 @@ outer:
 			}
 
 			cmd.ListArgs[item.Key] = res
-			return &cmd, i
+			return &cmd, i, exact
 		case item.Type == commandItem:
 			// Parse the subcommand
 			subCmd, err := CompileCommand(input.items[i:].String())
 			if err != nil {
-				return nil, i
+				return nil, i, exact
 			}
 
 			cmd.Subcommand = subCmd
-			return &cmd, i
+			return &cmd, i, exact
 		}
 	}
 
@@ -107,8 +112,8 @@ outer:
 	// problematic as we have commands: "vm info" and "vm info search <terms>"
 	// that share the same prefix.
 	if len(pattern) != len(input.items) {
-		return nil, len(pattern) - 1
+		return nil, len(pattern) - 1, exact
 	}
 
-	return &cmd, len(pattern) - 1
+	return &cmd, len(pattern) - 1, exact
 }

--- a/src/minicli/handler.go
+++ b/src/minicli/handler.go
@@ -29,13 +29,17 @@ type Handler struct {
 // builds a command based on the input. If there was no match, the returned
 // Command will be nil. The second return value is the number of elements of the
 // Handler's pattern that were matched. This can be used to determine which
-// handler was the closest match.
-func (h *Handler) compile(input *Input) (*Command, int) {
+// handler was the closest match. The third return value is true if there
+// pattern is an exact match, not an apropos match.
+func (h *Handler) compile(input *Input) (*Command, int, bool) {
 	var maxMatchLen int
+	var cmd *Command
+	var matchLen int
+	var exact bool
 	for _, pattern := range h.PatternItems {
-		cmd, matchLen := newCommand(pattern, input, h.Call)
+		cmd, matchLen, exact = newCommand(pattern, input, h.Call)
 		if cmd != nil {
-			return cmd, matchLen
+			return cmd, matchLen, exact
 		}
 
 		if matchLen > maxMatchLen {
@@ -43,7 +47,7 @@ func (h *Handler) compile(input *Input) (*Command, int) {
 		}
 	}
 
-	return nil, maxMatchLen
+	return nil, maxMatchLen, false
 }
 
 func (h *Handler) suggest(input *Input) []string {

--- a/src/minicli/util.go
+++ b/src/minicli/util.go
@@ -50,17 +50,28 @@ func closestMatch(input *Input) (*Handler, *Command) {
 	// Keep track of what was the closest
 	var closestHandler *Handler
 	var longestMatch int
+	var matchedHandler *Handler
+	var matchedCmd *Command
 
 	for _, h := range handlers {
 		cmd, matchLen := h.compile(input)
 		if cmd != nil {
-			return h, cmd
+			if matchedHandler != nil { // multiple apropos matches
+				return nil, nil
+			}
+			matchedHandler = h
+			matchedCmd = cmd
 		}
 
 		if matchLen > longestMatch {
 			closestHandler = h
 			longestMatch = matchLen
 		}
+	}
+
+	// return the handler/cmd on perfect or apropos matches
+	if matchedHandler != nil {
+		return matchedHandler, matchedCmd
 	}
 
 	if longestMatch == 0 {

--- a/src/minicli/util.go
+++ b/src/minicli/util.go
@@ -54,8 +54,11 @@ func closestMatch(input *Input) (*Handler, *Command) {
 	var matchedCmd *Command
 
 	for _, h := range handlers {
-		cmd, matchLen := h.compile(input)
+		cmd, matchLen, exact := h.compile(input)
 		if cmd != nil {
+			if exact {
+				return h, cmd
+			}
 			if matchedHandler != nil { // multiple apropos matches
 				return nil, nil
 			}


### PR DESCRIPTION
This lets you do shorthand commands, similar to Cisco's command line.

You only have to type enough to match a pattern. For example, although minimega has the commands "vm cdrom" and "vm config", it is sufficient to type "vm c" to run "vm config", because "vm cdrom" requires additional arguments and thus cannot match "vm c". Similarly, "vm c e 0" matches "vm cdrom eject 0", because "vm config" does not register any patterns which would match "vm c e 0".