### PR TITLE
Finish package building process

### DIFF
--- a/packaging/debian/build-package.sh
+++ b/packaging/debian/build-package.sh
@@ -17,3 +17,7 @@ cp -r $mm_root/doc $dest_opt
 mkdir -p ./minimega/usr/share/doc/minimega
 cp $mm_root/LICENSES/* ./minimega/usr/share/doc/minimega/
 echo COPIED FILES
+
+echo BUILDING PACKAGE...
+fakeroot dpkg-deb -b minimega
+echo DONE


### PR DESCRIPTION
This is the last bit to complete the script for building a Debian package. Just run the script from the packaging/debian directory and it will create a .deb