### PR TITLE
minicli: updated .filter, new API.

### DIFF
--- a/src/minicli/minicli.go
+++ b/src/minicli/minicli.go
@@ -134,6 +134,15 @@ func ProcessCommand(c *Command, record bool) chan Responses {
 	return respChan
 }
 
+func MustCompile(input string) *Command {
+	c, err := CompileCommand(input)
+	if err != nil {
+		log.Fatal("unable to compile `%s` -- %v", input, err)
+	}
+
+	return c
+}
+
 // Create a command from raw input text. An error is returned if parsing the
 // input text failed.
 func CompileCommand(input string) (*Command, error) {


### PR DESCRIPTION
Added inverted filter (field!=value). Also added a `MustCompile` method
that runs CompileCommand and calls log.Fatal if there was an error.

Fixes issue #153.