### PR TITLE
documentation: define naming conventions and apply them across the repo

### DIFF
--- a/doc/content/articles/igor.article
+++ b/doc/content/articles/igor.article
@@ -39,7 +39,7 @@ Now, you can fetch and buld the minimega source:
 
 This will build and test each of the libraries and tools in the minimega distribution and create a bin/ sudirectory containing each of the minimega tools. If you have a windows cross compiler for Go setup, it will also build windows binaries of several tools.
 
-The Igor binary will be in the bin/ subdirectory.
+The igor binary will be in the bin/ subdirectory.
 
 ** Installation
 
@@ -107,7 +107,7 @@ prefer a big grid, you can set rackheight = sqrt(# nodes) and
 rackwidth = sqrt(# nodes). This will just show one big grid of all
 your nodes.
 
-* Using Igor
+* Using igor
 
 Generally, to use igor you will check what nodes are reserved, make
 your own reservation with some un-used nodes, and then delete the
@@ -115,7 +115,7 @@ reservation when you're done. When creating a reservation, you can
 specify a duration (default 12 hours); after this expires, your
 reservation is automatically deleted.
 
-Igor includes built-in help; you can run "igor help" to get started.
+igor includes built-in help; you can run "igor help" to get started.
 
 ** Checking status
 

--- a/doc/content/articles/powerbot.article
+++ b/doc/content/articles/powerbot.article
@@ -1,17 +1,17 @@
-Powerbot: A Power-Control Tool
+powerbot: A Power-Control Tool
 3 Mar 2015
 
 * Introduction
 
-Powerbot is a tool in the vein of LLNL's "powerman" ([[https://code.google.com/p/powerman/][google code]]), which can control networked Power Distribution Units (PDUs). We use it to turn our cluster nodes on and off; because the nodes netboot and don't maintain a root filesystem on disk, the fastest and easiest way to reboot them is by cycling power.
+powerbot is a tool in the vein of LLNL's "powerman" ([[https://code.google.com/p/powerman/][google code]]), which can control networked Power Distribution Units (PDUs). We use it to turn our cluster nodes on and off; because the nodes netboot and don't maintain a root filesystem on disk, the fastest and easiest way to reboot them is by cycling power.
 
 ** Compatibility
 
-Powerbot was built to meet our specific needs at Sandia, so it currently only supports the PDUs we have used: a ServerTech device and a TrippLite. Because our needs are pretty simple, it should hopefully work on most ServerTech or TrippLite devices. It is also extremely easy to implement support for other devices, see tripplite.go and servertech.go for examples.
+powerbot was built to meet our specific needs at Sandia, so it currently only supports the PDUs we have used: a ServerTech device and a TrippLite. Because our needs are pretty simple, it should hopefully work on most ServerTech or TrippLite devices. It is also extremely easy to implement support for other devices, see tripplite.go and servertech.go for examples.
 
 * Usage
 
-Powerbot commands consist of an action (on/off/cycle/status) and a list of nodes for which to perform the action. You can use ranges to specify multiple nodes. Here are some example commands:
+powerbot commands consist of an action (on/off/cycle/status) and a list of nodes for which to perform the action. You can use ranges to specify multiple nodes. Here are some example commands:
 
         powerbot on ccc1                # Turn on ccc1
         powerbot off ccc[1-10]          # Turn off ccc1 through ccc10
@@ -22,7 +22,7 @@ Powerbot commands consist of an action (on/off/cycle/status) and a list of nodes
 
 ** Building
 
-Powerbot ships in the minimega distribution. First, ensure that you have a [[http://golang.org][Go compiler]], libpcap headers, and libreadline headers installed. On a debian type system, you can install compile-time dependencies with:
+powerbot ships in the minimega distribution. First, ensure that you have a [[http://golang.org][Go compiler]], libpcap headers, and libreadline headers installed. On a debian type system, you can install compile-time dependencies with:
 
 	apt-get install libpcap-dev libreadline-dev
 
@@ -34,7 +34,7 @@ Then obtain the minimega source and run the all.bash script from the top of the 
 
 ** Installation
 
-The Powerbot binary will be at minimega/bin/powerbot. Copy this somewhere convenient, like /usr/local/bin.
+The powerbot binary will be at minimega/bin/powerbot. Copy this somewhere convenient, like /usr/local/bin.
 
 You'll also need a config file in /etc/powerbot.conf. An example is provided in the minimega/src/powerbot directory and is reproduced here:
 

--- a/doc/content/articles/quickstart.article
+++ b/doc/content/articles/quickstart.article
@@ -1,4 +1,4 @@
-Minimega Quickstart
+minimega Quickstart
 
 John Floren
 17 Mar 2015
@@ -64,7 +64,7 @@ For our simple purposes, we just need to tell it to use the disk we just created
 
 ** Configure the network
 
-Minimega can do a lot of complex things with the network. For this quickstart, we'll do the following:
+minimega can do a lot of complex things with the network. For this quickstart, we'll do the following:
 
 - Put the VM onto virtual network #100
 - Connect the host to that same virtual network
@@ -100,9 +100,9 @@ Our "test" VM should now be booting!
 
 * Step 4: Connect to the VM
 
-Although we've started the VM, it would be nice to be able to interact with it. Minimega provides VNC access to the VM's console, either directly or through the web interface.
+Although we've started the VM, it would be nice to be able to interact with it. minimega provides VNC access to the VM's console, either directly or through the web interface.
 
-Note that most VMBetter configurations provided with minimega will set up passwordless login for the root user.
+Note that most vmbetter configurations provided with minimega will set up passwordless login for the root user.
 
 ** Web interface
 

--- a/doc/content/articles/usage.article
+++ b/doc/content/articles/usage.article
@@ -181,7 +181,7 @@ You can also broadcast a command to all nodes on the mesh from any other node, e
 
 ** Output rendering modes
 
-Minimega supports a number of ways to output data as well. By default, output will be tabular (pretty printed) if tabular data is present, and a simple string otherwise. Additionally, with mesh commands, like responses will be grouped into a single response prefixed with a list of the nodes that had that response.
+minimega supports a number of ways to output data as well. By default, output will be tabular (pretty printed) if tabular data is present, and a simple string otherwise. Additionally, with mesh commands, like responses will be grouped into a single response prefixed with a list of the nodes that had that response.
 
 You can override this behavior with a number of builtin output operators, including JSON, csv, etc., all prefixed with the `.` character. For example, to output tabular data in csv instead of pretty-printing, set csv mode with `.csv true`:
 
@@ -283,7 +283,7 @@ And look at the config one last time:
 
 ** Launching Virtual Machines
 
-We'll start with a VM configuration that uses a disk image and 2048 MB of RAM. We're going to launch more than one VM with this image, so we want to make sure that the VM doesn't have the ability to write to the disk image. In QEMU language, this is called snapshot mode. Minimega has snapshot mode *on* by default, but we'll make sure just to be safe:
+We'll start with a VM configuration that uses a disk image and 2048 MB of RAM. We're going to launch more than one VM with this image, so we want to make sure that the VM doesn't have the ability to write to the disk image. In QEMU language, this is called snapshot mode. minimega has snapshot mode *on* by default, but we'll make sure just to be safe:
 
 	minimega$ vm config disk /tmp/foo.qcow2
 	minimega$ vm config snapshot true
@@ -549,7 +549,7 @@ minimega will list the hostnames of all connected nodes with the number of runni
 
 * Multi-node Usage
 
-Minimega is designed to scale by running instances on individual nodes that communicate over a message passing protocol, meshage. The goal is to make minimega use the same command set on any number of participating nodes by starting commands with a designation of which nodes (one, some, or all) should execute the command.
+minimega is designed to scale by running instances on individual nodes that communicate over a message passing protocol, meshage. The goal is to make minimega use the same command set on any number of participating nodes by starting commands with a designation of which nodes (one, some, or all) should execute the command.
 
 ** Meshage
 
@@ -557,11 +557,11 @@ Meshage is a mesh-based message passing and connectivity protocol designed to su
 
 *** Node connections
 
-Minimega connects to other minimega instances (which are communicated to via the `mesh`send` command) using the meshage package. When a minimega instance connects to another instance (either through auto-discovery or the `mesh`dial` command), a simple handshake occurs to verify connection prerequisites and to check the connection namespace. If using auto-discovery and the namespaces are not the same, the connection is dropped. If using `mesh`dial`, namespaces are ignored. This allows two minimega networks to be forcibly joined.
+minimega connects to other minimega instances (which are communicated to via the `mesh`send` command) using the meshage package. When a minimega instance connects to another instance (either through auto-discovery or the `mesh`dial` command), a simple handshake occurs to verify connection prerequisites and to check the connection namespace. If using auto-discovery and the namespaces are not the same, the connection is dropped. If using `mesh`dial`, namespaces are ignored. This allows two minimega networks to be forcibly joined.
 
 *** Auto-discovery
 
-Minimega instances can auto-discover other instances on a network using the auto-discovery model provided by meshage. This is enabled by using the `-degree` flag at startup or the `mesh`degree` command at runtime. These commands set the minimum mesh degree to attempt to maintain. If non-zero, meshage will broadcast over UDP solicitations for other nodes to attempt a connection to the soliciting node. Other listening nodes, even if they already have enough connections, will attempt to initiate a new connection as described above. When a node meets its degree requirements, it simply stops broadcasting solicitations. To reduce broadcast traffic, nodes uses an exponential backoff function to throttle the rate of solicitation broadcasts. When the number of connections to a given node decreases below the specified degree, the node will resume soliciting connections.
+minimega instances can auto-discover other instances on a network using the auto-discovery model provided by meshage. This is enabled by using the `-degree` flag at startup or the `mesh`degree` command at runtime. These commands set the minimum mesh degree to attempt to maintain. If non-zero, meshage will broadcast over UDP solicitations for other nodes to attempt a connection to the soliciting node. Other listening nodes, even if they already have enough connections, will attempt to initiate a new connection as described above. When a node meets its degree requirements, it simply stops broadcasting solicitations. To reduce broadcast traffic, nodes uses an exponential backoff function to throttle the rate of solicitation broadcasts. When the number of connections to a given node decreases below the specified degree, the node will resume soliciting connections.
 
 Because nodes that are solicited will attempt to make connections regardless of how many connections they have, it is possible for nodes to have more connections than specified using the degree field.
 

--- a/doc/content/naming.article
+++ b/doc/content/naming.article
@@ -1,0 +1,23 @@
+Project Naming Conventions
+3 Apr 2015
+
+* Introduction
+
+The various components of the project use a specific naming convention: the name is always lower-case, even when starting a sentence. This document defines the canonical usage; please conform to these conventions when writing documentation:
+
+- minimega
+- miniccc
+- minidoc
+- protonuke
+- igor
+- vmbetter
+- powerbot
+
+Good:
+
+    minimega is a tool for managing virtual machines.
+
+Bad:
+
+    Igor, MiniMega, and MiniCCC work together to manage a cluster.
+    

--- a/doc/content/releases/minimega-2.0.article
+++ b/doc/content/releases/minimega-2.0.article
@@ -225,7 +225,7 @@ See the [[/articles/api.article#TOC_5.6.][cc API]] for more information.
 
 *** IP learning now bridge specific
 
-Minimega snoops ARP and neighbor discovery traffic on local VMs in order to
+minimega snoops ARP and neighbor discovery traffic on local VMs in order to
 associate IP addresses at runtime with VMs, as reflected in `vm`info`. In
 previous versions, minimega simply inspected all bridges for this information.
 This was problematic if VMs with identical MAC addresses existed on different

--- a/doc/content/tools.html
+++ b/doc/content/tools.html
@@ -27,11 +27,11 @@
 			<h2>VMBetter: Create Virtual Machine Images</h2>
 			<p>VMBetter is a tool that takes a configuration file and outputs a minimega-bootable, Debian-based VM. It can create custom initrd images, CD ISOs, or QEMU-compatible hard disk images. You can specify a list of Debian packages to install, insert any additional files you wish, and give a list of commands to run after the filesystem has been built (to perform any last-minute configuration).</p>
 
-			<h2>Igor: Cluster Reservations</h2>
-			<p>Igor lets you make reservations and, on properly-configured clusters, set up reserved nodes to boot from user-specified kernel+initrd files. See <a href="/articles/igor.article">Igor's documentation</a> for more information.</p>
+			<h2>igor: Cluster Reservations</h2>
+			<p>igor lets you make reservations and, on properly-configured clusters, set up reserved nodes to boot from user-specified kernel+initrd files. See <a href="/articles/igor.article">igor's documentation</a> for more information.</p>
 
-			<h2>Powerbot: Networked PDU Control</h2>
-			<p>Powerbot allows you to control outlets on networked Power Distribution Units. It currently supports TrippLite and Server Tech PDUs, and it's easy to add support for additonal devices! <a href="/articles/powerbot.article">Powerbot's documentation</a> describes how to set up and use it.</p>
+			<h2>powerbot: Networked PDU Control</h2>
+			<p>powerbot allows you to control outlets on networked Power Distribution Units. It currently supports TrippLite and Server Tech PDUs, and it's easy to add support for additonal devices! <a href="/articles/powerbot.article">powerbot's documentation</a> describes how to set up and use it.</p>
 		</div>
 	</body>
 </html>

--- a/doc/content_templates/api.template
+++ b/doc/content_templates/api.template
@@ -22,7 +22,7 @@ Builtins are commands that impact how responses to commands are rendered. Some b
 
 * Mesh Commands
 
-Mesh commands control the behavior and operation of communication between minimega nodes on a network. Minimega is fully distributed, and commands to other minimega nodes can be issued from any other participating minimega node. For example, you can get the hostname of all minimega nodes (exclusive of the issuing node) with `mesh`send`all`host`name`. 
+Mesh commands control the behavior and operation of communication between minimega nodes on a network. minimega is fully distributed, and commands to other minimega nodes can be issued from any other participating minimega node. For example, you can get the hostname of all minimega nodes (exclusive of the issuing node) with `mesh`send`all`host`name`. 
 
 Generally, `mesh`send` will be the only mesh command you will use. The other commands provided are for manually dialing other nodes and controlling network behavior. 
 

--- a/src/igor/README
+++ b/src/igor/README
@@ -1,10 +1,10 @@
-Igor is a tool for managing reservations on a cluster.
+igor is a tool for managing reservations on a cluster.
 
 Users make reservations with igor, requesting either a number of nodes
 or a specific set of nodes. They also specify a kernel and initial
 ramdisk which their nodes should boot. Reservations are deleted when
 they run out of time, but users can add additional time to the
-reservation. Igor now only allows a reservation's owner to delete the
+reservation. igor now only allows a reservation's owner to delete the
 reservation; experience with using igor in a real setting has shown
 that this is needed.
 

--- a/src/igor/main.go
+++ b/src/igor/main.go
@@ -192,7 +192,7 @@ func main() {
 	exit()
 }
 
-var usageTemplate = `Igor is a scheduler for Mega-style clusters.
+var usageTemplate = `igor is a scheduler for Mega-style clusters.
 
 Usage:
 

--- a/src/powerbot/README
+++ b/src/powerbot/README
@@ -1,7 +1,7 @@
-Powerbot: A Power Control Tool
+powerbot: A Power Control Tool
 =================================
 
-Powerbot is a tool for turning ports on networked PDUs on and off. Currently it is designed specifically for use in a cluster environment, where every node's hostname is of the form <prefix><number>, such as ccc1 or kn402.
+powerbot is a tool for turning ports on networked PDUs on and off. Currently it is designed specifically for use in a cluster environment, where every node's hostname is of the form <prefix><number>, such as ccc1 or kn402.
 
 Motivation
 ----------
@@ -13,7 +13,7 @@ I wanted something that was extensible like powerman, so I could use it with dif
 Usage
 -------
 
-Powerbot commands consist of an action (on/off/cycle/status) and a list of nodes for which to perform the action. You can use ranges to specify multiple nodes. Here are some example commands:
+powerbot commands consist of an action (on/off/cycle/status) and a list of nodes for which to perform the action. You can use ranges to specify multiple nodes. Here are some example commands:
 
 	powerbot on ccc1		# Turn on ccc1
 	powerbot off ccc[1-10]		# Turn off ccc1 through ccc10

--- a/src/powerbot/powerbot.go
+++ b/src/powerbot/powerbot.go
@@ -21,7 +21,7 @@ var (
 )
 
 func usage() {
-	fmt.Print(`Powerbot: control a PDU.
+	fmt.Print(`powerbot: control a PDU.
 Usage, <arg> = required, [arg] = optional:
 	powerbot on <nodelist>
 	powerbot off <nodelist>


### PR DESCRIPTION
We need to use the same capitalization and naming conventions everywhere. I created naming.article to define those conventions, then went through and enforced them everywhere.