### PR TITLE
minimega: check for reserved words.

### DIFF
--- a/src/minimega/bridge_cli.go
+++ b/src/minimega/bridge_cli.go
@@ -102,6 +102,11 @@ func cliHostTap(c *minicli.Command) *minicli.Response {
 			bridge = DEFAULT_BRIDGE
 		}
 
+		if isReserved(bridge) {
+			resp.Error = fmt.Sprintf("`%s` is a reserved word -- cannot use for bridge name", bridge)
+			return resp
+		}
+
 		ip := c.StringArgs["ip"]
 		if c.BoolArgs["dhcp"] {
 			ip = "dhcp"
@@ -109,13 +114,17 @@ func cliHostTap(c *minicli.Command) *minicli.Response {
 			ip = "none"
 		}
 
-		tapName := c.StringArgs["tap"]
+		tap := c.StringArgs["tap"]
+		if isReserved(tap) {
+			resp.Error = fmt.Sprintf("`%s` is a reserved word -- cannot use for tap name", tap)
+			return resp
+		}
 
-		tapName, err := hostTapCreate(bridge, vlan, ip, tapName)
+		tap, err := hostTapCreate(bridge, vlan, ip, tap)
 		if err != nil {
 			resp.Error = err.Error()
 		} else {
-			resp.Response = tapName
+			resp.Response = tap
 		}
 	} else if c.BoolArgs["delete"] {
 		err := hostTapDelete(c.StringArgs["id"])

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -44,8 +44,10 @@ var (
 	f_attach     = flag.Bool("attach", false, "attach the minimega command line to a running instance of minimega")
 	f_cli        = flag.Bool("cli", false, "print the minimega cli, in markdown, to stdout and exit")
 	f_panic      = flag.Bool("panic", false, "panic on quit, producing stack traces for debugging")
-	vms          VMs
-	hostname     string
+
+	vms      VMs
+	hostname string
+	reserved = []string{Wildcard}
 )
 
 const (
@@ -102,6 +104,10 @@ func main() {
 	hostname, err = os.Hostname()
 	if err != nil {
 		log.Fatalln(err)
+	}
+
+	if isReserved(hostname) {
+		log.Warn("hostname `%s` is a reserved word -- abandon all hope, ye who enter here", hostname)
 	}
 
 	vms = make(map[int]*vmInfo)

--- a/src/minimega/misc.go
+++ b/src/minimega/misc.go
@@ -288,3 +288,15 @@ func hasCommand(cmd *minicli.Command, prefix string) bool {
 	return strings.HasPrefix(cmd.Original, prefix) ||
 		(cmd.Subcommand != nil && hasCommand(cmd.Subcommand, prefix))
 }
+
+// isReserved checks whether the provided string is a reserved identifier.
+func isReserved(s string) bool {
+	for _, r := range reserved {
+		if r == s {
+			return true
+		}
+	}
+
+	return false
+
+}

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -860,6 +860,13 @@ func cliVmLaunch(c *minicli.Command) *minicli.Response {
 		return resp
 	}
 
+	for _, name := range vmNames {
+		if isReserved(name) {
+			resp.Error = fmt.Sprintf("`%s` is a reserved word -- cannot use for vm name", name)
+			return resp
+		}
+	}
+
 	log.Info("launching %v vms", len(vmNames))
 
 	ack := make(chan int)


### PR DESCRIPTION
Make sure users don't name vms/taps/bridges reserved words. Currently,
the only reserved word is the wildcard: `all`.

Fixes #111.