### PR TITLE
documentation: added a tutorial on vmbetter

### DIFF
--- a/doc/content/articles/vmbetter.article
+++ b/doc/content/articles/vmbetter.article
@@ -1,0 +1,117 @@
+Make a Custom LiveCD with vmbetter
+6 Apr 2015
+
+* Introduction
+
+vmbetter is a versatile tool for making customized Debian-based environments. It can generate kernel+initramfs pairs, QCOW hard disk images, and ISO CDROM images. This document focuses on the latter, specifically on how you can use vmbetter to easily make a customized LiveCD.
+
+In this article, we'll create a LiveCD which boots you straight into a GUI with Wireshark running--it's just an example, but one that could be useful for someone trying to make a ready-to-deploy security toolkit ala Kali Linux.
+
+** Set up vmbetter
+
+To get vmbetter, you'll want to download and compile the minimega repository. First, make sure you have a [[http://golang.org][Go compiler]] installed. Then, install some libraries needed to build minimega and the associated tools:
+
+	# fetch pre-requisites
+	$ sudo apt-get install libpcap-dev libreadline-dev syslinux
+
+With those installed, you can pull down the minimega repo and build:
+
+	# get the repository
+	$ git clone git@github.com:sandia-minimega/minimega.git
+	$ cd minimega
+	$ ./all.bash
+
+There should now be a binary called `vmbetter` in the `bin` subdirectory.
+
+* Making a vmbetter config
+
+vmbetter builds images based on rules specified in a configuration file. It also inserts any additional files you may want into the filesystem of the image it creates.
+
+** Write the config file
+
+We'll start by creating our configuration file. From the minimega repository root, open a new file called `misc/vmbetter_configs/wireshark.conf`. This directory contains several other configurations which could be instructive, but for now just paste the following text into the file and save it:
+
+	parents = "default_amd64.conf"
+	packages = "traceroute dnsutils wget tcpdump telnet wireshark xserver-xorg-core xserver-xorg-input-all xserver-xorg-video-fbdev xserver-xorg-video-cirrus xterm xinit blackbox"
+	overlay = "misc/vmbetter_configs/wireshark_overlay"
+	postbuild = `
+		sed -i 's/nullok_secure/nullok/' /etc/pam.d/common-auth
+		sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+		sed -i 's/PermitEmptyPasswords no/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
+		passwd -d root
+	`
+
+The configuration file specifies several important options: one or more parent configs, a list of packages to install, the "overlay" directory, and the "postbuild" commands. The overlay directory contains any files you want to add to the disc's filesystem. The postbuild commands are a list of shell commands to be run as the final step of the building process; we use it here to set up passwordless root login for convenience.
+
+Note that `wireshark.conf` has a parent configuration, `default_amd64.conf`. That file contains some very basic packages which you'll want in almost every case, so most configurations will want to either include `default_amd64.conf` as a parent, or set their parent to another configuration which uses `default_amd64.conf` as *its* parent.
+
+You'll see that we install Wireshark, the basic X.org packages, and some bare minimum X utilities: xterm, xinit, blackbox. If you want additional programs, you can add their package names to the list. vmbetter will automatically figure out any dependencies they may have and install them for you.
+
+** Populate the overlay filesystem
+
+Our configuration file says we're going to put any additional files we want into `misc/vmbetter_configs/wireshark_overlay`. This directory contains a hierarchy of files and directories, based at /, that we want copied into the image we build. Let's start by copying over an existing overlay to get a baseline:
+
+	$ cp -r misc/vmbetter_configs/generic_vm_overlay misc/vmbetter_configs/wireshark_overlay
+
+If you look in that directory, you'll see a few basic files in a hierarchy:
+
+	$ du -a misc/vmbetter_configs/wireshark_overlay/
+	4       generic_vm_overlay/init
+	4       generic_vm_overlay/etc/rc.local
+	8       generic_vm_overlay/etc
+	16      generic_vm_overlay/
+
+In order to make the LiveCD automatically launch X and Wireshark as soon as we log in as root, we can set up a few configuration files:
+
+	$ cd misc/vmbetter_configs/wireshark_overlay
+	$ mkdir -p root
+	$ cat > root/.profile << EOF
+	#!/bin/sh
+	xinit -- /usr/bin/Xorg &
+	EOF
+	$ cat > root/.xinitrc << EOF
+	#!/bin/sh
+	wireshark &
+	exec blackbox
+	EOF
+	$ cd ../../..	# go back to the root of the minimega repo
+
+Our `.profile` launches X automatically as soon as root logs in, and then `.xinitrc` starts Wireshark and the Blackbox window manager once X starts.
+
+* Build the image
+
+Now that we've specified *how* to build the image, we can fire up vmbetter and actually *build* it. Here's the command I used to build:
+
+	$ sudo ./bin/vmbetter -branch unstable -iso -level debug  -mbr /usr/lib/syslinux/mbr/mbr.bin misc/vmbetter_configs/wireshark.conf 
+
+It's rather complex, so I'll break down each part:
+
+- `-branch`unstable` : specifies that vmbetter should use the Debian unstable branch to build
+- `-iso` : specifies that we want an ISO image
+- `-level`debug` : specifies that we want lots of debug output
+- `-mbr`/usr/lib/syslinux/mbr/mbr.bin` : On Debian Unstable, the `syslinux` package puts the `mbr.bin` file in a different place than expected by vmbetter
+- `misc/vmbetter_configs/wireshark.conf` : the path to the configuration file
+
+(Depending on your system, you may not need to specify the `-mbr` flag, or you may find that `mbr.bin` is in yet a different location.)
+
+When you run vmbetter, it will print lots of debugging information as it calculates dependencies, fetches packages (this will take a long time), installs the packages in a temporary environment, and finally creates an ISO image. If all goes well, you should end up with a file called `wireshark.iso` in the current directory
+
+* Test the image
+
+If everything worked right, you should have a file called `wireshark.iso` in the current directory. We can test it using minimega:
+
+	$ sudo ./bin/minimega
+	minimega$ vm config cdrom wireshark.iso
+	minimega$ vm launch 1
+	minimega$ vm start all
+	minimega$ web
+
+Now, if you point your web browser at [[http://localhost:9001/][http://localhost:9001]], you should be able to see minimega's web front-end. There should be one VM listed on the main page; click the screenshot to open a VNC session to it.
+
+Once you're in the VNC session, you will probably see a login prompt. Log in as `root`, no password necessary. As soon as you log in, it should start up X, run the window manager, and start up Wireshark.
+
+If you want to run the image on real computers, simply burn `wireshark.iso` to a CD and use it to boot.
+
+* Conclusion
+
+This article shows how you can quickly and easily make a customized LiveCD image. You can specify exactly which packages you want installed and configure programs to run automatically. Once the image is generated, minimega makes it easy to test it before burning to a CD for use in real computers.


### PR DESCRIPTION
A little tutorial that tells you how to use vmbetter to make a custom livecd. I did it as a livecd because that's useful outside the context of VMs, but in the end we still use minimega to test the ISO.