### PR TITLE
minimega: dirty hacks.

### DIFF
--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -516,7 +516,7 @@ func ParseVmState(s string) (VmState, error) {
 // Get the VM info from all hosts optionally applying column/row filters.
 // Returns a map with keys for the hostnames and values as the tabular data
 // from the host.
-func globalVmInfo(masks []string, filters []string) map[string]VMs {
+func globalVmInfo(masks []string, filters []string) (map[string]VMs, map[string]minicli.Responses) {
 	cmdStr := "vm info"
 	for _, v := range filters {
 		cmdStr = fmt.Sprintf(".filter %s %s", v, cmdStr)
@@ -526,6 +526,7 @@ func globalVmInfo(masks []string, filters []string) map[string]VMs {
 	}
 
 	res := map[string]VMs{}
+	res2 := map[string]minicli.Responses{}
 
 	for resps := range runCommandGlobally(minicli.MustCompile(cmdStr), false) {
 		for _, resp := range resps {
@@ -540,10 +541,12 @@ func globalVmInfo(masks []string, filters []string) map[string]VMs {
 			default:
 				log.Error("unknown data field in vm info")
 			}
+
+			res2[resp.Host] = append(res2[resp.Host], resp)
 		}
 	}
 
-	return res
+	return res, res2
 }
 
 // mustFindMask returns the index of the specified mask in vmMasks. If the


### PR DESCRIPTION
Work arounds for not all VM state being stored in the VM struct.
Fallback on the Tabular data from minicli.Response to populate VM info
fields that are dynamically generated (ip, ip6, cc_active). This code
should be deleted as soon as the state for these is moved into the VM
struct.

Fixes #175