### PR TITLE
minicli: fixes 187.

### DIFF
--- a/src/minicli/builtins.go
+++ b/src/minicli/builtins.go
@@ -264,7 +264,12 @@ func cliColumns(c *Command, out chan Responses) {
 outer:
 	for resps := range runSubCommand(c) {
 		for _, r := range resps {
-			if r.Header == nil || r.Tabular == nil {
+			if r.Header == nil {
+				continue
+			}
+
+			if r.Tabular == nil {
+				r.Header = columns
 				continue
 			}
 


### PR DESCRIPTION
.columns wasn't altering the Header for responses where Tabular was nil
which lead to mismatched Header columns. Changed it so that we always
update the Header (if it's not nil).