### PR TITLE
multiple: remove "ln" on log calls where printf vararg is used. "ln" …

### DIFF
--- a/src/minidoc/minimega.go
+++ b/src/minidoc/minimega.go
@@ -86,7 +86,7 @@ func runCommand(cmd Command) chan *localResponse {
 
 	err = enc.Encode(cmd)
 	if err != nil {
-		log.Errorln("local command json encode: %v", err)
+		log.Error("local command json encode: %v", err)
 		return nil
 	}
 
@@ -106,7 +106,7 @@ func runCommand(cmd Command) chan *localResponse {
 					return
 				}
 
-				log.Errorln("local command json decode: %v", err)
+				log.Error("local command json decode: %v", err)
 				return
 			}
 

--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -303,7 +303,7 @@ func DialMinimega() (*MinimegaConn, error) {
 func (mm *MinimegaConn) runCommand(cmd *minicli.Command) chan *localResponse {
 	err := mm.enc.Encode(*cmd)
 	if err != nil {
-		log.Errorln("local command gob encode: %v", err)
+		log.Error("local command gob encode: %v", err)
 		return nil
 	}
 	log.Debugln("encoded command:", cmd)
@@ -322,7 +322,7 @@ func (mm *MinimegaConn) runCommand(cmd *minicli.Command) chan *localResponse {
 					return
 				}
 
-				log.Errorln("local command gob decode: %v", err)
+				log.Error("local command gob decode: %v", err)
 				return
 			}
 

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -78,7 +78,7 @@ func main() {
 	if *f_cli {
 		doc, err := minicli.Doc()
 		if err != nil {
-			log.Fatalln("failed to generate docs: %v", err)
+			log.Fatal("failed to generate docs: %v", err)
 		}
 		fmt.Println(doc)
 		os.Exit(0)

--- a/src/minimega/stats.go
+++ b/src/minimega/stats.go
@@ -168,28 +168,28 @@ func hostStatsMemory() (int, int, error) {
 				return 0, 0, fmt.Errorf("cannot parse meminfo MemTotal: %v", err)
 			}
 			memTotal = m
-			log.Debugln("got memTotal %v", memTotal)
+			log.Debug("got memTotal %v", memTotal)
 		case "MemFree:":
 			m, err := strconv.Atoi(d[1])
 			if err != nil {
 				return 0, 0, fmt.Errorf("cannot parse meminfo MemFree: %v", err)
 			}
 			memFree = m
-			log.Debugln("got memFree %v", memFree)
+			log.Debug("got memFree %v", memFree)
 		case "Buffers:":
 			m, err := strconv.Atoi(d[1])
 			if err != nil {
 				return 0, 0, fmt.Errorf("cannot parse meminfo Buffers: %v", err)
 			}
 			memBuffers = m
-			log.Debugln("got memBuffers %v", memBuffers)
+			log.Debug("got memBuffers %v", memBuffers)
 		case "Cached:":
 			m, err := strconv.Atoi(d[1])
 			if err != nil {
 				return 0, 0, fmt.Errorf("cannot parse meminfo Cached: %v", err)
 			}
 			memCached = m
-			log.Debugln("got memCached %v", memCached)
+			log.Debug("got memCached %v", memCached)
 		}
 	}
 

--- a/src/minimega/vminfo.go
+++ b/src/minimega/vminfo.go
@@ -66,7 +66,7 @@ func (vm *vmInfo) start() error {
 		log.Info("restarting VM: %v", vm.ID)
 		ack := make(chan int)
 		go vm.launchOne(ack)
-		log.Debugln("ack restarted VM %v", <-ack)
+		log.Debug("ack restarted VM %v", <-ack)
 	}
 
 	log.Info("starting VM: %v", vm.ID)

--- a/src/minitunnel/minitunnel.go
+++ b/src/minitunnel/minitunnel.go
@@ -256,7 +256,7 @@ func (t *Tunnel) forward(ln net.Listener, source int, host string, dest int) {
 // register a transaction ID, adding a return channel to the mux
 func (t *Tunnel) registerTID(TID int32) chan *tunnelMessage {
 	if _, ok := t.tids[TID]; ok {
-		log.Fatalln(fmt.Sprintf("tid %v already exists!", TID))
+		log.Fatal("tid %v already exists!", TID)
 	}
 	c := make(chan *tunnelMessage, 1024)
 	t.tids[TID] = c

--- a/src/ron/server.go
+++ b/src/ron/server.go
@@ -272,7 +272,7 @@ func (s *Server) routeTunnel(m *Message) {
 			return
 		}
 	}
-	log.Errorln("routeTunnel invalid UUID: %v", m.UUID)
+	log.Error("routeTunnel invalid UUID: %v", m.UUID)
 }
 
 // return a file to a client requesting it via the clients GetFile() call

--- a/src/ron/tunnel.go
+++ b/src/ron/tunnel.go
@@ -69,7 +69,7 @@ func (c *Client) handleTunnel(server bool, stop chan bool) {
 			var err error
 			c.tunnel, err = minitunnel.Dial(a)
 			if err != nil {
-				log.Errorln("Dial: %v", err)
+				log.Error("Dial: %v", err)
 				a.Close()
 				b.Close()
 			}
@@ -77,7 +77,7 @@ func (c *Client) handleTunnel(server bool, stop chan bool) {
 			go func() {
 				err := minitunnel.ListenAndServe(a)
 				if err != nil {
-					log.Fatalln("ListenAndServe: %v", err)
+					log.Fatal("ListenAndServe: %v", err)
 				}
 			}()
 		}

--- a/src/vmbetter/overlays.go
+++ b/src/vmbetter/overlays.go
@@ -25,7 +25,7 @@ func Overlays(buildPath string, c vmconfig.Config) error {
 		// check if overlay exists as absolute path or relative to cwd
 		if _, err := os.Stat(o); os.IsNotExist(err) {
 			// it doesn't, so we'll check relative to config file
-			log.Debugln("overlay directory '%v' does not exist as an absolute path or relative to the current working directory.", o)
+			log.Debug("overlay directory '%v' does not exist as an absolute path or relative to the current working directory.", o)
 			var path string
 			base := filepath.Base(o)    // get base path of overlay directory
 			if i == len(c.Overlays)-1 { // if this is the last overlay, we'll check relative to c.Path
@@ -35,7 +35,7 @@ func Overlays(buildPath string, c vmconfig.Config) error {
 				log.Debugln("parent overlay")
 				path = filepath.Join(filepath.Dir(c.Parents[i]), base)
 			}
-			log.Debugln("checking path relative to config location: '%v'", path)
+			log.Debug("checking path relative to config location: '%v'", path)
 			if _, err := os.Stat(path); os.IsNotExist(err) { // check if we can find overlay relative to config file
 				return err // nope
 			} else { // yep


### PR DESCRIPTION
…calls (Debugln, Errorln...) are used for simple, space delimited strings in vararg, in the same way golang's Println and friends are.