### PR TITLE
Fixes #222.

### DIFF
--- a/src/minicli/builtins.go
+++ b/src/minicli/builtins.go
@@ -154,6 +154,24 @@ Note: the annotate flag controls the presence of the host column.`,
 		},
 		Call: cliColumns,
 	},
+	{ // record
+		HelpShort: "enable or disable history recording",
+		HelpLong: `
+Enable or disable the recording of a given command in the command history.`,
+		Patterns: []string{
+			".record [true,false]",
+			".record <true,false> (command)",
+		},
+		Call: func(c *Command, out chan Responses) {
+			if c.Subcommand != nil {
+				c.Record = c.BoolArgs["true"]
+			} else if !c.BoolArgs["true"] {
+				// Don't record `.record false` in history
+				c.Record = false
+			}
+			cliFlagHelper(c, out, func(f *Flags) *bool { return &f.Record })
+		},
+	},
 }
 
 var hostname string

--- a/src/minicli/command.go
+++ b/src/minicli/command.go
@@ -21,6 +21,8 @@ type Command struct {
 
 	Call CLIFunc `json:"-"`
 
+	Record bool // record command in history (or not), default is true
+
 	// Set when the command is intentionally a NoOp (the original string
 	// contains just a comment). This was added to ensure that lines containing
 	// only a comment are recorded in the history.
@@ -97,7 +99,7 @@ outer:
 			return &cmd, i, exact
 		case item.Type == commandItem:
 			// Parse the subcommand
-			subCmd, err := CompileCommand(input.items[i:].String())
+			subCmd, err := Compile(input.items[i:].String())
 			if err != nil {
 				return nil, i, exact
 			}

--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -71,11 +71,11 @@ var (
 
 // Wrapper for minicli.ProcessCommand. Ensures that the command execution lock
 // is acquired before running the command.
-func runCommand(cmd *minicli.Command, record bool) chan minicli.Responses {
+func runCommand(cmd *minicli.Command) chan minicli.Responses {
 	cmdLock.Lock()
 	defer cmdLock.Unlock()
 
-	return minicli.ProcessCommand(cmd, record)
+	return minicli.ProcessCommand(cmd)
 }
 
 // Wrapper for minicli.ProcessCommand for commands that use meshage.
@@ -85,8 +85,7 @@ func runCommand(cmd *minicli.Command, record bool) chan minicli.Responses {
 // nodes in the cluster without having to run a command locally and over
 // meshage.
 func runCommandGlobally(cmd *minicli.Command, record bool) chan minicli.Responses {
-	cmdStr := fmt.Sprintf("mesh send %s %s", Wildcard, cmd.Original)
-	cmd, err := minicli.CompileCommand(cmdStr)
+	cmd, err := minicli.Compilef("mesh send .record %t %s %s", record, Wildcard, cmd.Original)
 	if err != nil {
 		log.Fatal("cannot run `%v` globally -- %v", cmd.Original, err)
 	}
@@ -101,8 +100,8 @@ func runCommandGlobally(cmd *minicli.Command, record bool) chan minicli.Response
 	// Run the command (should be `mesh send all ...` and the subcommand which
 	// should run locally).
 	ins := []chan minicli.Responses{
-		minicli.ProcessCommand(cmd, record),
-		minicli.ProcessCommand(cmd.Subcommand, record),
+		minicli.ProcessCommand(cmd),
+		minicli.ProcessCommand(cmd.Subcommand),
 	}
 
 	// De-mux ins into out
@@ -137,7 +136,7 @@ func cliLocal() {
 		command := string(line)
 		log.Debug("got from stdin:", command)
 
-		cmd, err := minicli.CompileCommand(command)
+		cmd, err := minicli.Compile(command)
 		if err != nil {
 			log.Error("%v", err)
 			//fmt.Printf("closest match: TODO\n")
@@ -151,9 +150,11 @@ func cliLocal() {
 		}
 
 		// HAX: Don't record the read command
-		record := !hasCommand(cmd, "read")
+		if hasCommand(cmd, "read") {
+			cmd.Record = false
+		}
 
-		for resp := range runCommand(cmd, record) {
+		for resp := range runCommand(cmd) {
 			// print the responses
 			pageOutput(resp.String())
 
@@ -216,7 +217,7 @@ func cliAttach() {
 
 		exitNext = false
 
-		cmd, err := minicli.CompileCommand(command)
+		cmd, err := minicli.Compile(command)
 		if err != nil {
 			log.Error("%v", err)
 			//fmt.Println("closest match: TODO")
@@ -252,7 +253,7 @@ func localCommand() {
 	command := strings.Join(a, " ")
 
 	// TODO: Need to escape?
-	cmd, err := minicli.CompileCommand(command)
+	cmd, err := minicli.Compile(command)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/src/minimega/command_meshage.go
+++ b/src/minimega/command_meshage.go
@@ -105,14 +105,14 @@ func meshageHandler() {
 		go func() {
 			mCmd := m.Body.(meshageCommand)
 
-			cmd, err := minicli.CompileCommand(mCmd.Original)
+			cmd, err := minicli.Compile(mCmd.Original)
 			if err != nil {
 				log.Error("invalid command from mesh: `%s`", mCmd.Original)
 				return
 			}
 
 			resps := []minicli.Responses{}
-			for resp := range runCommand(cmd, true) {
+			for resp := range runCommand(cmd) {
 				resps = append(resps, resp)
 			}
 

--- a/src/minimega/command_socket.go
+++ b/src/minimega/command_socket.go
@@ -62,10 +62,12 @@ outer:
 
 		if cmd != nil {
 			// HAX: Don't record the read command
-			record := !hasCommand(cmd, "read")
+			if hasCommand(cmd, "read") {
+				cmd.Record = false
+			}
 
 			// HAX: Work around so that we can add the more boolean
-			for resp := range runCommand(cmd, record) {
+			for resp := range runCommand(cmd) {
 				if prevResp != nil {
 					err = sendLocalResp(enc, prevResp, true)
 					if err != nil {
@@ -101,7 +103,7 @@ func readLocalCommand(dec *json.Decoder) (*minicli.Command, error) {
 
 	// HAX: Reprocess the original command since the Call target cannot be
 	// serialized... is there a cleaner way to do this?
-	return minicli.CompileCommand(cmd.Original)
+	return minicli.Compile(cmd.Original)
 }
 
 func sendLocalResp(enc *json.Encoder, resp minicli.Responses, more bool) error {

--- a/src/minimega/dot.go
+++ b/src/minimega/dot.go
@@ -56,7 +56,7 @@ func cliDot(c *minicli.Command) *minicli.Response {
 	defer fout.Close()
 
 	// TODO: Rewrite to use runCommandGlobally
-	cmd := minicli.MustCompile(".columns host,name,id,ip,ip6,state,vlan vm info")
+	cmd := minicli.MustCompile(".record false .columns host,name,id,ip,ip6,state,vlan vm info")
 
 	writer := bufio.NewWriter(fout)
 
@@ -68,7 +68,7 @@ func cliDot(c *minicli.Command) *minicli.Response {
 	var expVms []*dotVM
 
 	// Get info from local hosts by invoking command directly
-	for resp := range minicli.ProcessCommand(cmd, false) {
+	for resp := range minicli.ProcessCommand(cmd) {
 		expVms = append(expVms, dotProcessInfo(resp)...)
 	}
 

--- a/src/minimega/misc_cli.go
+++ b/src/minimega/misc_cli.go
@@ -133,7 +133,7 @@ func cliRead(c *minicli.Command, respChan chan minicli.Responses) {
 		command := scanner.Text()
 		log.Debug("read command: %v", command) // commands don't have their newlines removed
 
-		cmd, err = minicli.CompileCommand(command)
+		cmd, err = minicli.Compile(command)
 		if err != nil {
 			break
 		}
@@ -150,7 +150,7 @@ func cliRead(c *minicli.Command, respChan chan minicli.Responses) {
 			break
 		}
 
-		for resp := range minicli.ProcessCommand(cmd, true) {
+		for resp := range minicli.ProcessCommand(cmd) {
 			respChan <- resp
 
 			// Stop processing at the first error if there is one response.

--- a/src/minimega/web.go
+++ b/src/minimega/web.go
@@ -188,10 +188,11 @@ func webScreenshot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cmd := minicli.MustCompile(cmdStr)
+	cmd.Record = false
 
 	var screenshot []byte
 
-	for resps := range runCommand(cmd, false) {
+	for resps := range runCommand(cmd) {
 		for _, resp := range resps {
 			if resp.Error != "" {
 				log.Errorln(resp.Error)
@@ -348,7 +349,7 @@ func webHosts(w http.ResponseWriter, r *http.Request) {
 		Class:   "hover",
 	}
 
-	cmd, err := minicli.CompileCommand("host")
+	cmd, err := minicli.Compile("host")
 	if err != nil {
 		// Should never happen
 		log.Fatalln(err)


### PR DESCRIPTION
Added new built-ins: `.record` that controls whether subcommands get
recorded in the history. This allows us to `mesh send` commands and omit
them from the local history, as needed for things like web.