### PR TITLE
minimega/minicli: fix unit tests.

### DIFF
--- a/src/minicli/minicli_test.go
+++ b/src/minicli/minicli_test.go
@@ -117,7 +117,7 @@ func TestParse(t *testing.T) {
 		for _, i := range v.inputs {
 			t.Logf("Testing input: `%s`", i)
 
-			cmd, err := CompileCommand(i)
+			cmd, err := Compile(i)
 			if err != nil {
 				t.Errorf("unable to compile command, %s", err.Error())
 			} else if cmd.Pattern != v.pattern {

--- a/src/minimega/qcow_test.go
+++ b/src/minimega/qcow_test.go
@@ -19,7 +19,7 @@ var validInjectCommands = []string{
 
 func TestParseInject(t *testing.T) {
 	for _, cmdStr := range validInjectCommands {
-		cmd, err := minicli.CompileCommand(cmdStr)
+		cmd, err := minicli.Compile(cmdStr)
 		if err != nil {
 			t.Fatalf("invalid command: %s", cmdStr)
 		}


### PR DESCRIPTION
Renamed CompileCommand -> Compile. Fixes #227.