### PR TITLE
minimega: rework screenshotting

### DIFF
--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -283,26 +283,32 @@ func (vm *KvmVM) QueryMigrate() (string, float64, error) {
 	return status, completed, nil
 }
 
-func (vm *KvmVM) Screenshot(fpath string, size int) error {
+func (vm *KvmVM) Screenshot(size int) ([]byte, error) {
 	suffix := rand.New(rand.NewSource(time.Now().UnixNano())).Int31()
 	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("minimega_screenshot_%v", suffix))
 
+	// We have to write this out to a file, because QMP
 	err := vm.q.Screendump(tmp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	err = ppmToPng(tmp, fpath, size)
+	ppmFile, err := ioutil.ReadFile(tmp)
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	pngResult, err := ppmToPng(ppmFile, size)
+	if err != nil {
+		return nil, err
 	}
 
 	err = os.Remove(tmp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return pngResult, nil
 
 }
 

--- a/src/minimega/misc.go
+++ b/src/minimega/misc.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"gopacket/macs"
 	_ "gopnm"
@@ -14,7 +15,6 @@ import (
 	"math/rand"
 	"minicli"
 	log "minilog"
-	"os"
 	"os/exec"
 	"regexp"
 	"resize"
@@ -273,16 +273,12 @@ func makeIDChan() chan int {
 
 // convert a src ppm image to a dst png image, resizing to a largest dimension
 // max if max != 0
-func ppmToPng(src, dst string, max int) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
+func ppmToPng(src []byte, max int) ([]byte, error) {
+	in := bytes.NewReader(src)
 
 	img, _, err := image.Decode(in)
-	in.Close()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// resize the image if necessary
@@ -290,17 +286,14 @@ func ppmToPng(src, dst string, max int) error {
 		img = resize.Thumbnail(uint(max), uint(max), img, resize.NearestNeighbor)
 	}
 
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
+	out := new(bytes.Buffer)
 
 	err = png.Encode(out, img)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return out.Bytes(), nil
 }
 
 // hasCommand tests whether cmd or any of it's subcommand has the given prefix.

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -64,9 +64,9 @@ type VM interface {
 	GetTags() map[string]string
 	ClearTags()
 
-	// Screenshot takes a screenshot of the VM and saves it to the fpath. The
+	// Screenshot takes a screenshot of the VM and returns it as a []byte. The
 	// image should be at most size pixels on each edge.
-	Screenshot(fpath string, size int) error
+	Screenshot(size int) ([]byte, error)
 
 	UpdateBW()
 }

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -119,13 +119,13 @@ func (vms VMs) qmp(idOrName, qmp string) (string, error) {
 	}
 }
 
-func (vms VMs) screenshot(idOrName, path string, max int) error {
+func (vms VMs) screenshot(idOrName, path string, max int) ([]byte, error) {
 	vm := vms.findVm(idOrName)
 	if vm == nil {
-		return vmNotFound(idOrName)
+		return nil, vmNotFound(idOrName)
 	}
 
-	return vm.Screenshot(path, max)
+	return vm.Screenshot(max)
 }
 
 func (vms VMs) migrate(idOrName, filename string) error {

--- a/src/minimega/web.go
+++ b/src/minimega/web.go
@@ -193,7 +193,7 @@ func webScreenshot(w http.ResponseWriter, r *http.Request) {
 	host := fields[0]
 	id := strings.TrimSuffix(fields[1], ".png")
 
-	cmdStr := fmt.Sprintf("vm screenshot %s %s", id, size)
+	cmdStr := fmt.Sprintf("vm screenshot %s file /dev/null %s", id, size)
 	if host != hostname {
 		cmdStr = fmt.Sprintf("mesh send %s .record false %s", host, cmdStr)
 	}


### PR DESCRIPTION
This is intended to fix #252. It maintains compatibility with the
old "vm screenshot" command while allowing you to say this:

	vm screenshot 0 file /dev/null
	vm screenshot 0 file /dev/null 100

Instead of writing out the screenshot file at the deepest level, I
pass back a slice of bytes containing the png data, then write
it out in vm_cli's cliVmScreenshot function. Previously, we were
writing to the file, then reading that back out into the response's
Body field, which made it fail when you give /dev/null as a file.