### PR TITLE
Improved VM net command

### DIFF
--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -212,12 +212,15 @@ func (vms VMs) kill(target string) []error {
 	killedVms := map[int]bool{}
 
 	errs := expandVmTargets(target, false, func(vm VM, _ bool) (bool, error) {
-		if vm.GetState()&(VM_QUIT|VM_ERROR) != 0 {
+		if vm.GetState()&VM_KILLABLE == 0 {
 			return false, nil
 		}
 
-		vm.Kill()
-		killedVms[vm.GetID()] = true
+		if err := vm.Kill(); err != nil {
+			log.Error("unleash the zombie VM: %v", err)
+		} else {
+			killedVms[vm.GetID()] = true
+		}
 		return true, nil
 	})
 

--- a/src/minimega/vmstate.go
+++ b/src/minimega/vmstate.go
@@ -22,6 +22,9 @@ const (
 // All VM states in one variable for masking any state
 var VM_ANY_STATE VMState = ^0
 
+// VM states that can be killed
+var VM_KILLABLE = VM_BUILDING | VM_RUNNING | VM_PAUSED
+
 func (s VMState) String() string {
 	switch s {
 	case VM_BUILDING:

--- a/tests/vm_netmod
+++ b/tests/vm_netmod
@@ -1,0 +1,14 @@
+.annotate false
+vm config net 0
+vm launch kvm vm0
+.columns name,vlan,bridge vm info
+vm net disconnect vm0 0
+.columns name,vlan,bridge vm info
+vm net connect vm0 0 foo 1
+.columns name,vlan,bridge vm info
+vm net connect vm0 0 bar 0
+.columns name,vlan,bridge vm info
+vm net disconnect vm0 0
+.columns name,vlan,bridge vm info
+vm kill all
+vm flush

--- a/tests/vm_netmod.want
+++ b/tests/vm_netmod.want
@@ -1,0 +1,24 @@
+## .annotate false
+## vm config net 0
+## vm launch kvm vm0
+## .columns name,vlan,bridge vm info
+name | vlan | bridge
+vm0  | [0]  | [mega_bridge]
+## vm net disconnect vm0 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+vm0  | [disconnected] | []
+## vm net connect vm0 0 foo 1
+## .columns name,vlan,bridge vm info
+name | vlan | bridge
+vm0  | [1]  | [foo]
+## vm net connect vm0 0 bar 0
+## .columns name,vlan,bridge vm info
+name | vlan | bridge
+vm0  | [0]  | [bar]
+## vm net disconnect vm0 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+vm0  | [disconnected] | []
+## vm kill all
+## vm flush


### PR DESCRIPTION
When a network is disconnected, clear the name of the bridge. Split network connect/disconnect into VM code so that we can lock properly.

Closes #184.