### PR TITLE
minidoc: cut miniclient into minidoc without syscall code (that minid…

### DIFF
--- a/src/minidoc/client.go
+++ b/src/minidoc/client.go
@@ -1,0 +1,101 @@
+// Copyright (2015) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+// cut from miniclient/client.go to not include syscall, which isn't allowed in
+// appengine builds
+
+import (
+	"encoding/json"
+	"io"
+	"minicli"
+	log "minilog"
+	"net"
+	"path"
+)
+
+type Response struct {
+	Resp     minicli.Responses
+	Rendered string
+	More     bool // whether there are more responses coming
+}
+
+type Conn struct {
+	url string
+
+	conn net.Conn
+
+	enc *json.Encoder
+	dec *json.Decoder
+}
+
+func Dial(base string) (*Conn, error) {
+	var mm = &Conn{
+		url: path.Join(base, "minimega"),
+	}
+	var err error
+
+	// try to connect to the local minimega
+	mm.conn, err = net.Dial("unix", mm.url)
+	if err != nil {
+		return nil, err
+	}
+
+	mm.enc = json.NewEncoder(mm.conn)
+	mm.dec = json.NewDecoder(mm.conn)
+
+	return mm, nil
+}
+
+func (mm *Conn) Close() error {
+	return mm.conn.Close()
+}
+
+// Run a command through a JSON pipe, hand back channel for responses.
+func (mm *Conn) Run(cmd *minicli.Command) chan *Response {
+	if cmd == nil {
+		// Language spec: "Receiving from a nil channel blocks forever."
+		// Instead, make and immediately close the channel so that range
+		// doesn't block and receives no values.
+		out := make(chan *Response)
+		close(out)
+
+		return out
+	}
+
+	err := mm.enc.Encode(*cmd)
+	if err != nil {
+		log.Fatal("local command gob encode: %v", err)
+	}
+	log.Debugln("encoded command:", cmd)
+
+	respChan := make(chan *Response)
+
+	go func() {
+		defer close(respChan)
+
+		for {
+			var r Response
+			err = mm.dec.Decode(&r)
+			if err != nil {
+				if err == io.EOF {
+					log.Fatal("server disconnected")
+				}
+
+				log.Fatal("local command gob decode: %v", err)
+			}
+
+			respChan <- &r
+			if !r.More {
+				log.Debugln("got last message")
+				break
+			} else {
+				log.Debugln("expecting more data")
+			}
+		}
+	}()
+
+	return respChan
+}

--- a/src/minidoc/minimega.go
+++ b/src/minidoc/minimega.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"minicli"
-	"miniclient"
 	log "minilog"
 	"strings"
 )
@@ -14,7 +13,7 @@ func sendCommand(s string) string {
 
 	log.Debug("sendCommand: %v", s)
 
-	mm, err := miniclient.Dial(*f_minimega)
+	mm, err := Dial(*f_minimega)
 	if err != nil {
 		log.Errorln(err)
 		return err.Error()


### PR DESCRIPTION
…oc isn't using) so it will build in appengine