### PR TITLE
minimega: centralize minicli handler registration

### DIFF
--- a/src/minimega/bridge_cli.go
+++ b/src/minimega/bridge_cli.go
@@ -92,10 +92,6 @@ To create a vxlan or GRE tunnel to another bridge, use 'bridge tunnel'. For exam
 	},
 }
 
-func init() {
-	registerHandlers("bridge", bridgeCLIHandlers)
-}
-
 // routines for interfacing bridge mechanisms with the cli
 func cliHostTap(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}

--- a/src/minimega/capture_cli.go
+++ b/src/minimega/capture_cli.go
@@ -80,10 +80,6 @@ Resets state for captures. See "help capture" for more information.`,
 	},
 }
 
-func init() {
-	registerHandlers("capture", captureCLIHandlers)
-}
-
 func cliCapture(c *minicli.Command) *minicli.Response {
 	if c.BoolArgs["netflow"] {
 		// Capture to netflow

--- a/src/minimega/cc_cli.go
+++ b/src/minimega/cc_cli.go
@@ -114,10 +114,6 @@ var ccCliSubHandlers = map[string]func(*minicli.Command) *minicli.Response{
 	"rtunnel":    cliCCTunnel,
 }
 
-func init() {
-	registerHandlers("cc", ccCLIHandlers)
-}
-
 func cliCC(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 	var err error

--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -37,6 +37,31 @@ var (
 	cmdLock sync.Mutex
 )
 
+// cliSetup registers all the minimega handlers
+func cliSetup() {
+	registerHandlers("bridge", bridgeCLIHandlers)
+	registerHandlers("capture", captureCLIHandlers)
+	registerHandlers("cc", ccCLIHandlers)
+	registerHandlers("deploy", deployCLIHandlers)
+	registerHandlers("dnsmasq", dnsmasqCLIHandlers)
+	registerHandlers("dot", dotCLIHandlers)
+	registerHandlers("external", externalCLIHandlers)
+	registerHandlers("history", historyCLIHandlers)
+	registerHandlers("host", hostCLIHandlers)
+	registerHandlers("io", ioCLIHandlers)
+	registerHandlers("log", logCLIHandlers)
+	registerHandlers("meshage", meshageCLIHandlers)
+	registerHandlers("misc", miscCLIHandlers)
+	registerHandlers("nuke", nukeCLIHandlers)
+	registerHandlers("optimize", optimizeCLIHandlers)
+	registerHandlers("qcow", qcowCLIHandlers)
+	registerHandlers("shell", shellCLIHandlers)
+	registerHandlers("vm", vmCLIHandlers)
+	registerHandlers("vnc", vncCLIHandlers)
+	registerHandlers("vyatta", vyattaCLIHandlers)
+	registerHandlers("web", webCLIHandlers)
+}
+
 // Wrapper for minicli.ProcessCommand. Ensures that the command execution lock
 // is acquired before running the command.
 func runCommand(cmd *minicli.Command) chan minicli.Responses {

--- a/src/minimega/command_meshage.go
+++ b/src/minimega/command_meshage.go
@@ -95,10 +95,6 @@ You can use 'all' to send a command to all connected clients.`,
 	},
 }
 
-func init() {
-	registerHandlers("meshage", meshageCLIHandlers)
-}
-
 func meshageHandler() {
 	for {
 		m := <-meshageCommandChan

--- a/src/minimega/deploy.go
+++ b/src/minimega/deploy.go
@@ -61,10 +61,6 @@ flags used when launching minimega.`,
 
 var deployFlags []string
 
-func init() {
-	registerHandlers("deploy", deployCLIHandlers)
-}
-
 func cliDeploy(c *minicli.Command) *minicli.Response {
 	log.Debugln("deploy")
 

--- a/src/minimega/dnsmasq.go
+++ b/src/minimega/dnsmasq.go
@@ -73,8 +73,6 @@ to the file.`,
 }
 
 func init() {
-	registerHandlers("dnsmasq", dnsmasqCLIHandlers)
-
 	dnsmasqServers = make(map[int]*dnsmasqServer)
 }
 

--- a/src/minimega/dot.go
+++ b/src/minimega/dot.go
@@ -38,10 +38,6 @@ Output the current experiment topology as a graphviz readable 'dot' file.`,
 	},
 }
 
-func init() {
-	registerHandlers("dot", dotCLIHandlers)
-}
-
 // dot returns a graphviz 'dotfile' string representing the experiment topology
 // from the perspective of this node.
 func cliDot(c *minicli.Command) *minicli.Response {

--- a/src/minimega/external.go
+++ b/src/minimega/external.go
@@ -66,10 +66,6 @@ versions not met.`,
 	},
 }
 
-func init() {
-	registerHandlers("external", externalCLIHandlers)
-}
-
 // checkExternal checks for the presence of each of the external processes we
 // may call, and error if any aren't in our path.
 func checkExternal() error {

--- a/src/minimega/history.go
+++ b/src/minimega/history.go
@@ -46,10 +46,6 @@ the minimega command line and then saving them for later use.`,
 	},
 }
 
-func init() {
-	registerHandlers("history", historyCLIHandlers)
-}
-
 func cliHistory(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{
 		Host:     hostname,

--- a/src/minimega/iomeshage.go
+++ b/src/minimega/iomeshage.go
@@ -64,10 +64,6 @@ You can also supply globs (wildcards) with the * operator. For example:
 	},
 }
 
-func init() {
-	registerHandlers("io", ioCLIHandlers)
-}
-
 func iomeshageInit(node *meshage.Node) {
 	var err error
 	iom, err = iomeshage.New(*f_iomBase, node)

--- a/src/minimega/log_cli.go
+++ b/src/minimega/log_cli.go
@@ -58,10 +58,6 @@ Resets state for logging. See "help log ..." for more information.`,
 	},
 }
 
-func init() {
-	registerHandlers("log", logCLIHandlers)
-}
-
 func cliLogLevel(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -101,6 +101,7 @@ func main() {
 	}
 
 	logSetup()
+	cliSetup()
 
 	hostname, err = os.Hostname()
 	if err != nil {

--- a/src/minimega/misc_cli.go
+++ b/src/minimega/misc_cli.go
@@ -77,10 +77,6 @@ the file in manually except that it stops after the first error.`,
 	},
 }
 
-func init() {
-	registerHandlers("misc", miscCLIHandlers)
-}
-
 func cliQuit(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 

--- a/src/minimega/nuke.go
+++ b/src/minimega/nuke.go
@@ -32,10 +32,6 @@ Should be run with caution.`,
 	},
 }
 
-func init() {
-	registerHandlers("nuke", nukeCLIHandlers)
-}
-
 // clean up after an especially bad crash, hopefully we don't have to call
 // this one much :)
 // currently this will:

--- a/src/minimega/optimize.go
+++ b/src/minimega/optimize.go
@@ -93,8 +93,6 @@ information.`,
 }
 
 func init() {
-	registerHandlers("optimize", optimizeCLIHandlers)
-
 	affinityClearFilter()
 }
 

--- a/src/minimega/qcow.go
+++ b/src/minimega/qcow.go
@@ -69,10 +69,6 @@ For example:
 	},
 }
 
-func init() {
-	registerHandlers("qcow", qcowCLIHandlers)
-}
-
 //Parse the source-file:destination pairs
 func (inject *injectData) parseInjectPairs(c *minicli.Command) {
 	if inject.err != nil {

--- a/src/minimega/shell.go
+++ b/src/minimega/shell.go
@@ -42,10 +42,6 @@ logged at the "info" level.`,
 	},
 }
 
-func init() {
-	registerHandlers("shell", shellCLIHandlers)
-}
-
 func cliShell(c *minicli.Command, background bool) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 

--- a/src/minimega/stats.go
+++ b/src/minimega/stats.go
@@ -53,7 +53,6 @@ var hostCLIHandlers = []minicli.Handler{
 }
 
 func init() {
-	registerHandlers("host", hostCLIHandlers)
 	go bandwidthCollector()
 }
 

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -780,8 +780,6 @@ Clear all tags from all VMs:
 }
 
 func init() {
-	registerHandlers("vm", vmCLIHandlers)
-
 	// Register these so we can serialize the VMs
 	gob.Register(VMs{})
 	gob.Register(&KvmVM{})

--- a/src/minimega/vnc_cli.go
+++ b/src/minimega/vnc_cli.go
@@ -47,10 +47,6 @@ Resets the state for VNC recordings. See "help vnc" for more information.`,
 	},
 }
 
-func init() {
-	registerHandlers("vnc", vncCLIHandlers)
-}
-
 func cliVNC(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 	var err error

--- a/src/minimega/vyatta.go
+++ b/src/minimega/vyatta.go
@@ -129,8 +129,6 @@ Resets state for vyatta. See "help vyatta" for more information.`,
 }
 
 func init() {
-	registerHandlers("vyatta", vyattaCLIHandlers)
-
 	vyatta.Dhcp = make(map[string]*vyattaDhcp)
 }
 

--- a/src/minimega/web.go
+++ b/src/minimega/web.go
@@ -68,11 +68,6 @@ NOTE: If you start the webserver with an invalid root, you can safely re-run
 	},
 }
 
-func init() {
-	registerHandlers("web", webCLIHandlers)
-
-}
-
 func cliWeb(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 


### PR DESCRIPTION
Move all the minicli handler registration out of init functions and into
a single function. This allows us to use the logging framework which
isn't available until after logSetup.