### PR TITLE
add file: prefix to invoke iomeshage anywhere

### DIFF
--- a/doc/content/articles/file.article
+++ b/doc/content/articles/file.article
@@ -1,0 +1,55 @@
+File transfer with minimega
+
+David Fritz
+01 Oct 2015
+
+* Introduction
+
+This tutorial illustrates iomeshage, the meshage-based file transfer layer provided by minimega. iomeshage is a distributed file transfer layer that provides a means to very quickly copy files between minimega nodes. By leveraging minimega's meshage message passing protocol, iomeshage can exceed transfer speeds obtained with one-to-one copying. 
+
+* Overview
+
+There are two ways to use iomeshage - through the `file` API and via an inline `file:` prefix available anywhere on the command line. In order for iomeshage to locate files on remote nodes, the files must be located in the `filepath` directory provided to minimega (by default `/tmp/minimega/files`). 
+
+iomeshage supports transferring single files, globs (wildcard files such as foo*), and entire directories. Permissions on transferred files are preserved.
+
+*CAUTION*: iomeshage uses filenames (including the path) as the unique identifier for that file. For example, if two nodes have a file "foo", which is different on each node, iomeshage will have undefined behavior when transferring the file.
+
+** `file` API
+
+iomeshage can be invoked using the `file` API on any node. It doesn't matter which remote node the file is on, so long as it exists on at least one node. For example, to find and transfer a file 'foo' to the requesting node's filepath directory:
+
+	file get foo
+
+If the file exists, the command will return with no error. The `file` API is non-blocking - it will return immediately and enqueue the file transfer. To see the status of existing file transfers, use the `file`status` API:
+
+	minimega$ file get bigfile
+	minimega$ file status
+	host  | Filename | Temporary directory                    | Completed parts | Queued
+	foo   | bigfile  | /tmp/minimega/files/transfer_442933642 | 65/103          | false
+
+You can also list and delete files using the `file` API:
+
+	minimega$ file list
+	host  | dir | name    | size
+	foo   |     | bigfile | 1073741824
+	minimega$ file delete bigfile
+	minimega$ file list
+	minimega$ 
+
+File transfers are always done by 'pulling' the file to the requesting node. There is no way to transfer a file to a remote node directly. In such cases, you will need to tell the remote node to pull the file using the `mesh` API. For example, to have remote node `foo` pull a file `bar` from the mesh:
+
+	mesh send foo file get bar
+
+** file: prefix
+
+iomeshage can also be invoked anywhere on the command line by prefixing the file you want to transfer to the local node with `file:`. For example, if a remote node has a file `foo.qcow2`, and you want to use it locally as a disk image:
+
+	vm config disk file:foo.qcow2
+
+This will transfer the file foo.qcow2 to the local node, and block until the file transfer is complete. Once complete, the path will be replaced with local reference to the file:
+
+	minimega$ vm config disk file:foo.qcow2
+	minimega$ vm config disk
+	[/tmp/minimega/files/foo.qcow2]
+	minimega$ 

--- a/src/iomeshage/iomeshage.go
+++ b/src/iomeshage/iomeshage.go
@@ -226,6 +226,8 @@ func (iom *IOMeshage) Get(file string) error {
 // parts to maximize the distributed transfer behavior of iomeshage when used
 // at scale.
 func (iom *IOMeshage) getParts(filename string, numParts int64, perm os.FileMode) {
+	defer iom.destroyTempTransfer(filename)
+
 	// corner case - empty file
 	if numParts == 0 {
 		log.Debug("file %v has 0 parts, creating empty file", filename)
@@ -267,8 +269,6 @@ func (iom *IOMeshage) getParts(filename string, numParts int64, perm os.FileMode
 		parts[j] = parts[i]
 		parts[i] = t
 	}
-
-	defer iom.destroyTempTransfer(filename)
 
 	// get in line
 	iom.queue <- true

--- a/src/meshage/message.go
+++ b/src/meshage/message.go
@@ -51,7 +51,7 @@ func (m *Message) String() string {
 	case MESSAGE:
 		fmt.Fprintf(w, "\tCommand:\tmessage\n")
 	}
-	fmt.Fprintf(w, "\tBody:\t%v", m.Body)
+	//fmt.Fprintf(w, "\tBody:\t%v", m.Body)
 	w.Flush()
 	return o.String()
 }

--- a/src/minimega/misc_cli.go
+++ b/src/minimega/misc_cli.go
@@ -146,6 +146,18 @@ func cliRead(c *minicli.Command, respChan chan minicli.Responses) {
 			break
 		}
 
+		cmd, err := cliPreprocessor(cmd)
+		if err != nil {
+			log.Errorln(err)
+			respChan <- minicli.Responses{
+				&minicli.Response{
+					Host:  hostname,
+					Error: err.Error(),
+				},
+			}
+			return
+		}
+
 		for resp := range minicli.ProcessCommand(cmd) {
 			respChan <- resp
 


### PR DESCRIPTION
Also added a file transfer article.

This feature allows using "file:" anywhere on the command line to transfer files to the local node. file: blocks until the file is transferred. This makes it possible to do things like:

    # foo.qcow2 is on some remote node, grab it and have minimega automatically update the path
    vm config disk file:foo.qcow2
    vm config disk
    [/tmp/minimega/files/foo.qcow2]

@floren @jcrussell @mkunz7 @bjwrigh 
