### PR TITLE
minimega: fix locking.

### DIFF
--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -113,7 +113,6 @@ func runCommandGlobally(cmd *minicli.Command) chan minicli.Responses {
 	cmd.Record = record
 
 	cmdLock.Lock()
-	defer cmdLock.Unlock()
 
 	var wg sync.WaitGroup
 
@@ -150,10 +149,13 @@ func runCommandGlobally(cmd *minicli.Command) chan minicli.Responses {
 		}(in)
 	}
 
-	// Wait until everything has been read before closing out
+	// Wait until everything has been read before closing the chan and
+	// releasing the lock.
 	go func() {
+		defer cmdLock.Unlock()
+		defer close(out)
+
 		wg.Wait()
-		close(out)
 	}()
 
 	return out


### PR DESCRIPTION
Don't release the cmdLock until we've forwarded responses from the
wrapped commands.