### PR TITLE
minimega: allow scripted multi-file VNC playback

### DIFF
--- a/src/minimega/vnc.go
+++ b/src/minimega/vnc.go
@@ -242,13 +242,12 @@ func (v *vncKBPlayback) playFile() {
 				// Our file is in the same directory as the parent
 				file = filepath.Join(filepath.Dir(v.file.Name()), file)
 			}
-			log.Warn("loading file %v", file)
 			// Save the file we were working from
 			oldfile := v.file
 			// Load the new file
 			v.file, err = os.Open(file)
 			if err != nil {
-				log.Error("oops: %v", err)
+				log.Error("Couldn't load VNC playback file %v: %v", file, err)
 				v.err = err
 			} else {
 				r := &vncKBPlayback{v.vncClient}


### PR DESCRIPTION
In addition to the existing PointerEvent and KeyEvent in VNC playback,
files can now include a LoadFile directive. This will cause the specified
file to be loaded and played. The format follows the usual VNC playback
format, e.g.:

	0:LoadFile,browse_slashdot.vnc
	10000000000:LoadFile,/home/john/recordings/reboot_windows.vnc

The filenames may be relative to the location of the current file,
or they can be absolute. Timestamps are honored as usual.