### PR TITLE
igor/minidoc: fixing bad filepath joins.

### DIFF
--- a/src/igor/sub.go
+++ b/src/igor/sub.go
@@ -148,27 +148,30 @@ func runSub(cmd *Command, args []string) {
 	}
 
 	// make kernel copy
-	kdest, err := os.Create(igorConfig.TFTPRoot + "/igor/" + subR + "-kernel")
+	fname := filepath.Join(igorConfig.TFTPRoot, "igor", subR+"-kernel")
+	kdest, err := os.Create(fname)
 	if err != nil {
-		fatalf("%v", err)
+		fatalf("failed to create %v -- %v", fname, err)
 	}
 	io.Copy(kdest, ksource)
 	kdest.Close()
 	ksource.Close()
 
 	// make initrd copy
-	idest, err := os.Create(igorConfig.TFTPRoot + "/igor/" + subR + "-initrd")
+	fname = filepath.Join(igorConfig.TFTPRoot, "igor", subR+"-initrd")
+	idest, err := os.Create(fname)
 	if err != nil {
-		fatalf("%v", err)
+		fatalf("failed to create %v -- %v", fname, err)
 	}
 	io.Copy(idest, isource)
 	idest.Close()
 	isource.Close()
 
 	// create appropriate pxe config file in igorConfig.TFTPRoot+/pxelinux.cfg/igor/
-	masterfile, err := os.Create(igorConfig.TFTPRoot + "/pxelinux.cfg/igor/" + subR)
+	fname = filepath.Join(igorConfig.TFTPRoot, "pxelinux.cfg", "igor", subR)
+	masterfile, err := os.Create(fname)
 	if err != nil {
-		fatalf("failed to create %v: %v", igorConfig.TFTPRoot+"pxelinux.cfg/igor/"+subR, err)
+		fatalf("failed to create %v -- %v", fname, err)
 	}
 	defer masterfile.Close()
 	masterfile.WriteString(fmt.Sprintf("default %s\n\n", subR))
@@ -179,9 +182,10 @@ func runSub(cmd *Command, args []string) {
 	// create individual PXE boot configs i.e. igorConfig.TFTPRoot+/pxelinux.cfg/AC10001B by copying config created above
 	for _, pxename := range pxefiles {
 		masterfile.Seek(0, 0)
-		f, err := os.Create(igorConfig.TFTPRoot + "/pxelinux.cfg/" + pxename)
+		fname := filepath.Join(igorConfig.TFTPRoot, "pxelinux.cfg", pxename)
+		f, err := os.Create(fname)
 		if err != nil {
-			fatalf("%v", err)
+			fatalf("failed to create %v -- %v", fname, err)
 		}
 		io.Copy(f, masterfile)
 		f.Close()

--- a/src/minidoc/dir.go
+++ b/src/minidoc/dir.go
@@ -108,7 +108,7 @@ func renderDoc(w io.Writer, docFile string) error {
 }
 
 func parse(name string, mode present.ParseMode) (*present.Doc, error) {
-	f, err := os.Open(*f_root + name)
+	f, err := os.Open(filepath.Join(*f_root, name))
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func parse(name string, mode present.ParseMode) (*present.Doc, error) {
 // If the given path is not a directory, it returns (isDir == false, err == nil)
 // and writes nothing to w.
 func dirList(w io.Writer, name string) (isDir bool, err error) {
-	f, err := os.Open(*f_root + name)
+	f, err := os.Open(filepath.Join(*f_root, name))
 	if err != nil {
 		return false, err
 	}
@@ -150,7 +150,7 @@ func dirList(w io.Writer, name string) (isDir bool, err error) {
 		}
 		// If there's an index.html, send that back and bail out
 		if fi.Name() == "index.html" {
-			ih, err := os.Open(*f_root + e.Path)
+			ih, err := os.Open(filepath.Join(*f_root, e.Path))
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
Use filepath.Join rather than string concat. Fixes #349.