### PR TITLE
minimega: remove link local from VM IPv6 column.

### DIFF
--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -457,9 +457,7 @@ func (vm *KvmVM) launch(ack chan int) (err error) {
 				case update := <-updates:
 					if update.IP4 != "" {
 						net.IP4 = update.IP4
-					} else if net.IP6 != "" && strings.HasPrefix(update.IP6, "fe80") {
-						log.Debugln("ignoring link-local over existing IPv6 address")
-					} else if update.IP6 != "" {
+					} else if update.IP6 != "" && !strings.HasPrefix(update.IP6, "fe80") {
 						net.IP6 = update.IP6
 					}
 				case <-vm.kill:


### PR DESCRIPTION
Filter out the IPv6 link local address for `vm info`.