### PR TITLE
minitunnel: fix race.

### DIFF
--- a/src/minitunnel/minitunnel.go
+++ b/src/minitunnel/minitunnel.go
@@ -169,9 +169,9 @@ func (t *Tunnel) mux() error {
 
 		// create new session if necessary
 		if m.Type == CONNECT {
-			go t.handleRemote(&m)
+			t.handleRemote(&m)
 		} else if m.Type == FORWARD {
-			go t.handleReverse(&m)
+			t.handleReverse(&m)
 		} else if c, ok := t.tids[m.TID]; ok {
 			// route the message to the handler by TID
 			c <- &m
@@ -289,7 +289,7 @@ func (t *Tunnel) handleRemote(m *tunnelMessage) {
 		return
 	}
 
-	t.handle(in, conn, TID)
+	go t.handle(in, conn, TID)
 }
 
 func (t *Tunnel) handleTunnel(conn net.Conn, host string, dest int) {


### PR DESCRIPTION
There was a race in minitunnel -- if you forwarded a port and used it
immediately, before the TID was registered, then some of the data would get
lost causing the tests to hang. Moved spawning goroutine to after registering
the TID to fix. Ran tests for ten minutes with no issues.

Also, rewrote tests so that we don't call T.FailNow from separate goroutines as
per the [documentation](https://golang.org/pkg/testing/#T.FailNow).