### PR TITLE
minimega: fix noblock issues.

### DIFF
--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -33,6 +33,8 @@ var (
 	vmIDChan chan int   // channel of new VM IDs
 	vmLock   sync.Mutex // lock for synchronizing access to vms
 
+	vmLaunch sync.WaitGroup // waitgroup for noblock vms
+
 	vmConfig VMConfig // current vm config, updated by CLI
 
 	savedInfo = make(map[string]VMConfig) // saved configs, may be reloaded

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -1198,10 +1198,20 @@ func cliVmLaunch(c *minicli.Command) *minicli.Response {
 	for _, name := range names {
 		wg.Add(1)
 
+		var vm VM
+		switch vmType {
+		case KVM:
+			vm = NewKVM(name)
+		case CONTAINER:
+			vm = NewContainer(name)
+		default:
+			// TODO
+		}
+
 		go func(name string) {
 			defer wg.Done()
 
-			errChan <- vms.launch(name, vmType)
+			errChan <- vms.launch(vm)
 		}(name)
 	}
 

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -165,26 +165,14 @@ func (vms VMs) findVm(idOrName string) VM {
 }
 
 // launch one VM of a given type.
-func (vms VMs) launch(name string, vmType VMType) error {
+func (vms VMs) launch(vm VM) error {
 	vmLock.Lock()
 
 	// Make sure that there isn't an existing VM with the same name
-	if name != "" {
-		for _, vm := range vms {
-			if vm.GetName() == name {
-				return fmt.Errorf("vm launch duplicate VM name: %s", name)
-			}
+	for _, vm2 := range vms {
+		if vm.GetName() == vm2.GetName() {
+			return fmt.Errorf("vm launch duplicate VM name: %s", vm.GetName())
 		}
-	}
-
-	var vm VM
-	switch vmType {
-	case KVM:
-		vm = NewKVM(name)
-	case CONTAINER:
-		vm = NewContainer(name)
-	default:
-		// TODO
 	}
 
 	vms[vm.GetID()] = vm


### PR DESCRIPTION
Remove two races caused by `vm launch ... noblock`:

1. Need to create copy of `vmConfig` before running the next command (in case the next command changes `vmConfig`).
2. Need to block on `vm start all` (and other vm target commands) until all outstanding `vm launch ... noblock` commands have finished creating vms.

Note: this is a cleaner fix than the one that was pushed to @djfritz's fork.