### PR TITLE
Add /tilevnc to web interface

### DIFF
--- a/misc/web/js/glue.js
+++ b/misc/web/js/glue.js
@@ -216,7 +216,7 @@ function updateTables () {
                 { "sTitle": "Name", "mDataProp": "name", "visible": false },
                 { "sTitle": "Model", "mDataProp": "model", "searchable": false },
             ],
-            "lengthMenu": [6, 12, 30],
+            "lengthMenu": [[6, 12, 30, -1], [6, 12, 30, "All"]],
             "fnRowCallback": loadOrRestoreImage
         });
         setInterval((function (closureTable) {

--- a/misc/web/tilevnc.html
+++ b/misc/web/tilevnc.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>minimega</title>
+
+		<link rel="stylesheet" type="text/css" href="./css/bootstrap.css">
+		<link rel="stylesheet" type="text/css" href="./css/font-awesome.css">
+
+		<link rel="stylesheet" type="text/css" href="./libs/dataTables/dataTables.bootstrap.css">
+
+		<link rel="stylesheet" type="text/css" href="./css/minimega.css">
+	</head>
+	<body>
+		<div id="nav navbar-default" style="background: #22313F">
+			<div class="container-fluid">
+			<img id="logo" src="./images/minimega.svg" alt="">
+			
+			<div id="global-search">
+				<div class="input-group">
+					<input type="text" class="form-control" placeholder="Search for...">
+					<span class="input-group-btn">
+						<button class="btn btn-default" type="button"><i class="fa fa-search"></i></button>
+					</span>
+				</div>
+			</div>
+			
+			<ul class="nav navbar-nav">
+				<li>
+				<a class="nav-blue" href="#vms">
+					<i class="fa fa-desktop fa-2x"></i>
+					<span>VMs</span>
+				</a>
+				</li>
+				<li>
+				<a class="nav-green" href="#hosts">
+					<i class="fa fa-server fa-2x"></i>
+					<span>Hosts</span>
+				</a>
+				</li>
+				<li>
+				<a class="nav-yellow" href="#config">
+					<i class="fa fa-cogs fa-2x"></i>
+					<span>Config</span>
+				</a>
+				</li>
+			</ul>
+			</div>
+		</div>
+
+		<div id="content">
+			<div id="vms">
+
+
+
+				<div id="vms-screenshots" class="box">
+					<h1 class="box-header">VM Screenshots</h1>
+					<div class="box-content">
+						<table id="screenshots-list">
+							<thead>
+								<tr>
+									<th>Name</th>
+									<th>Box</th>
+								</tr>
+							</thead>
+							<tbody>
+
+							</tbody>
+						</table>
+					</div>
+				</div>
+
+				<!-- if I don't leave this in, the screenshots don't show up. Go figure. -->
+				<div id="vms-network" class="box" style="display: none;">
+						<div id="chart">
+						</div>
+				</div>
+			</div>
+
+			<div id="hosts">
+				<div id="hosts-table" class="box">
+					<h1 class="box-header">Host List</h1>
+					<div class="box-content">
+						<table id="hosts-dataTable" class="table table-striped table-bordered dataTable no-footer"></table>
+					</div>
+				</div>
+			</div>
+
+			<div id="config">
+				<div id="config-box" class="box">
+					<h1 class="box-header">Configuration</h1>
+					<div class="box-content">
+						<div style="text-align:center;font-style:italic;opacity:0.5;font-size:1.5em">Nothing here... yet.</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<script type="text/javascript" src="./libs/jquery-1.11.1.min.js"></script>
+		<script type="text/javascript" src="./libs/d3.min.js"></script>
+
+		<script type="text/javascript" src="./libs/grapher/grapher.js"></script>
+		<script type="text/javascript" src="./libs/grapher/center.js"></script>
+		<script type="text/javascript" src="./libs/grapher/palette.js"></script>
+		<script type="text/javascript" src="./libs/grapher/target.js"></script>
+		<script type="text/javascript" src="./libs/grapher/zoom.js"></script>
+
+		<script type="text/javascript" src="./libs/dataTables/jquery.dataTables.js"></script>
+		<script type="text/javascript" src="./libs/dataTables/dataTables.bootstrap.js"></script>
+
+		<script type="text/javascript" src="./js/graph.js"></script>
+		<script type="text/javascript" src="./js/glue.js"></script>
+	</body>
+</html>

--- a/src/minimega/web.go
+++ b/src/minimega/web.go
@@ -104,6 +104,7 @@ func webStart(port int, root string) {
 	}
 
 	mux.HandleFunc("/", webIndex)
+	mux.HandleFunc("/tilevnc", webTileVNC)
 	mux.HandleFunc("/hosts", webHosts)
 	mux.HandleFunc("/vms", webVMs)
 	mux.HandleFunc("/vnc/", webVNC)
@@ -198,6 +199,10 @@ func webIndex(w http.ResponseWriter, r *http.Request) {
 	} else {
 		http.ServeFile(w, r, filepath.Join(web.Root, "index.html"))
 	}
+}
+
+func webTileVNC(w http.ResponseWriter, r *http.Request) {
+	http.ServeFile(w, r, filepath.Join(web.Root, "tilevnc.html"))
 }
 
 func webVNC(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
If you go to /tilevnc on the web interface, you can view all the VNC screens at once with no additional information. Works best on Chrome, Firefox uses a lot of CPU.