### PR TITLE
Add Is__() methods to patternItem

### DIFF
--- a/src/minicli/pattern.go
+++ b/src/minicli/pattern.go
@@ -46,11 +46,27 @@ type patternItem struct {
 
 type patternItems []patternItem
 
-func (p patternItem) Optional() bool {
+func (p patternItem) IsOptional() bool {
 	return p.Type&optionalItem != 0
 }
 
-func (p patternItem) List() bool {
+func (p patternItem) IsListeral() bool {
+	return p.Type&literalItem != 0
+}
+
+func (p patternItem) IsCommand() bool {
+	return p.Type&commandItem != 0
+}
+
+func (p patternItem) IsString() bool {
+	return p.Type&stringItem != 0
+}
+
+func (p patternItem) IsChoice() bool {
+	return p.Type&choiceItem != 0
+}
+
+func (p patternItem) IsList() bool {
 	return p.Type&listItem != 0
 }
 

--- a/src/minicli/validate.go
+++ b/src/minicli/validate.go
@@ -43,22 +43,22 @@ func ambiguous(p0, p1 []patternItem) bool {
 	} else if len(p0) == 0 && len(p1) > 0 {
 		// If the next element of p1 is optional, patterns are ambiguous since
 		// optional arguments have to come last.
-		return p1[0].Optional()
+		return p1[0].IsOptional()
 	} else if len(p0) > 0 && len(p1) == 0 {
 		// Same case as above.
-		return p0[0].Optional()
+		return p0[0].IsOptional()
 	}
 
 	// At least one item in each pattern
 	item0, item1 := p0[0], p1[0]
 
 	// Both optional
-	if item0.Optional() && item1.Optional() {
+	if item0.IsOptional() && item1.IsOptional() {
 		return true
 	}
 
 	// A list can always match anything in the other pattern
-	if item0.List() || item1.List() {
+	if item0.IsList() || item1.IsList() {
 		return true
 	}
 
@@ -97,7 +97,7 @@ func allowedValues(item patternItem) []string {
 		vals = append(vals, "*")
 	}
 
-	if item.Optional() {
+	if item.IsOptional() {
 		vals = append(vals, "")
 	}
 


### PR DESCRIPTION
@jcrussell Is there any issue with exporting `itemType`? I have it redefined it in the Python API generator, but this seems like a better option.

Everything still builds for me, and tests are passing.