### PR TITLE
minimega: add ability to skip over the vnc wait period

### DIFF
--- a/src/minimega/vnc.go
+++ b/src/minimega/vnc.go
@@ -32,6 +32,7 @@ type vncClient struct {
 	Rhost string
 
 	done chan bool
+	skip chan bool
 	file *os.File
 
 	err error
@@ -78,6 +79,7 @@ func NewVNCClient(host, vm string) (*vncClient, error) {
 		Name:  vmName,
 		ID:    vmID,
 		done:  make(chan bool),
+		skip:  make(chan bool),
 	}
 
 	return c, nil
@@ -229,6 +231,7 @@ func (v *vncKBPlayback) playFile() {
 		wait := time.After(duration)
 		select {
 		case <-wait:
+		case <-v.skip:
 		case <-v.done:
 			return
 		}

--- a/src/minimega/vnc_cli.go
+++ b/src/minimega/vnc_cli.go
@@ -26,13 +26,18 @@ keyboard actions by the user or of the framebuffer for the VM.
 
 If playback is selected, the specified file (created using vnc record) will be
 read and processed as a sequence of time-stamped mouse/keyboard events to send
-to the specified VM.`,
+to the specified VM.
+
+The skip command causes the specified VM to immediately play the pending VNC 
+action, skipping over any delay period specified in the VNC playback file.
+`,
 		Patterns: []string{
 			"vnc",
 			"vnc <kb,fb> <record,> <host> <vm id or name> <filename>",
 			"vnc <kb,fb> <norecord,> <host> <vm id or name>",
 			"vnc <playback,> <host> <vm id or name> <filename>",
 			"vnc <noplayback,> <host> <vm id or name>",
+			"vnc <skip,> <host> <vm id or name>",
 		},
 		Call: wrapSimpleCLI(cliVNC),
 	},
@@ -102,6 +107,14 @@ func cliVNC(c *minicli.Command) *minicli.Response {
 				log.Error("%v", err)
 			}
 			err = nil
+		}
+	} else if c.BoolArgs["skip"] {
+		for _, v := range vncKBPlaying {
+			if v.Matches(host, vm) {
+				client := v.vncClient
+				client.skip <- true
+				break
+			}
 		}
 	} else if c.BoolArgs["playback"] {
 		// Start keyboard playback


### PR DESCRIPTION
VNC playback files consist of one line per mouse or keyboard event. Each
line is associated with a delay period; minimega waits for the specified
delay, then sends the mouse or keyboard event to the VM. "vnc skip"
allows the user to immediately send the pending event without waiting
for the entire delay period.