### PR TITLE
Fixes issue that would fail to launch containers

### DIFF
--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -267,7 +267,7 @@ func (_ ContainerIniter) init() error {
 		return fmt.Errorf("cgroup mkdir: %v", err)
 	}
 
-	err = syscall.Mount("minicgroup", CGROUP_ROOT, "cgroup", 0, "")
+	err = syscall.Mount("minicgroup", CGROUP_ROOT, "tmpfs", 0, "")
 	if err != nil {
 		return fmt.Errorf("cgroup mount: %v", err)
 	}


### PR DESCRIPTION
On latest debian, minimega would fail to mount minicgroup:
```
$ vm config filesystem /root/containerfs
$ vm launch container foo
2016/03/01 18:39:12 ERROR container.go:253: cgroup mount: device or resource busy
2016/03/01 18:39:12 ERROR container.go:721: cannot launch container VMs -- cgroups failed to initialize
2016/03/01 18:39:12 ERROR vm.go:487: write instance state file: open /tmp/minimega/0/state: no such file or directory
Error (debian): cannot launch container VMs -- cgroups failed to initialize
```

I was unable to mount as well:
```
# mount -t cgroup minicgroup foo/
mount: minicgroup is already mounted or /tmp/foo busy
```

I'm not too familiar with cgroups, but after some research and testing, I found that cgroup is mounted with tmpfs, but systemd is still mounted with cgroup.

I ended up using tmpfs instead of cgroup for the mount call in [container.go](https://github.com/sandia-minimega/minimega/blob/master/src/minimega/container.go), and minimega containers  would then load without any errors.

I'm not sure if this necessarily fixes the issue, but it seemed to be a possible solution. 

Any input regarding this?