### PR TITLE
minimega: adding `vm config tag`.

### DIFF
--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -94,6 +95,8 @@ type BaseConfig struct {
 	Snapshot bool
 	UUID     string
 	ActiveCC bool // Whether CC is active, updated by calling UpdateCCActive
+
+	Tags map[string]string
 }
 
 // NetConfig contains all the network-related config for an interface. The IP
@@ -127,8 +130,6 @@ type BaseVM struct {
 	Type  VMType
 
 	instancePath string
-
-	Tags map[string]string
 }
 
 // Valid names for output masks for vm info, in preferred output order
@@ -177,7 +178,6 @@ func NewVM(name string) *BaseVM {
 	vm.instancePath = filepath.Join(*f_base, strconv.Itoa(vm.ID))
 
 	vm.State = VM_BUILDING
-	vm.Tags = make(map[string]string)
 
 	return vm
 }
@@ -230,6 +230,12 @@ func (old *BaseConfig) Copy() *BaseConfig {
 	res.Networks = make([]NetConfig, len(old.Networks))
 	copy(res.Networks, old.Networks)
 
+	// Make deep copy of tags
+	res.Tags = map[string]string{}
+	for k, v := range old.Tags {
+		res.Tags[k] = v
+	}
+
 	return res
 }
 
@@ -244,6 +250,7 @@ func (vm *BaseConfig) String() string {
 	fmt.Fprintf(w, "Networks:\t%v\n", vm.NetworkString())
 	fmt.Fprintf(w, "Snapshot:\t%v\n", vm.Snapshot)
 	fmt.Fprintf(w, "UUID:\t%v\n", vm.UUID)
+	fmt.Fprintf(w, "Tags:\t%v\n", vm.TagsString())
 	w.Flush()
 	fmt.Fprintln(&o)
 	return o.String()
@@ -256,6 +263,16 @@ func (vm *BaseConfig) NetworkString() string {
 	}
 
 	return fmt.Sprintf("[%s]", strings.Join(parts, " "))
+}
+
+func (vm *BaseConfig) TagsString() string {
+	res, err := json.Marshal(vm.Tags)
+	if err != nil {
+		log.Error("unable to marshal vm.Tags: %v", err)
+		return ""
+	}
+
+	return string(res)
 }
 
 func (vm *BaseVM) GetID() int {
@@ -466,7 +483,7 @@ func (vm *BaseVM) info(key string) (string, error) {
 			}
 		}
 	case "tags":
-		return fmt.Sprintf("%v", vm.Tags), nil
+		return vm.TagsString(), nil
 	case "cc_active":
 		return fmt.Sprintf("%v", vm.ActiveCC), nil
 	default:

--- a/src/minimega/vmconfig.go
+++ b/src/minimega/vmconfig.go
@@ -25,7 +25,7 @@ type VMConfigFns struct {
 	Update   func(interface{}, *minicli.Command) error
 	Clear    func(interface{})
 	Print    func(interface{}) string
-	PrintCLI func(interface{}) string // If not specified, Print is used
+	PrintCLI func(interface{}) []string // If not specified, Print is used
 }
 
 func (old *VMConfig) Copy() *VMConfig {
@@ -72,6 +72,12 @@ var baseConfigFns = map[string]VMConfigFns{
 	"vcpus": vmConfigString(func(vm interface{}) *string {
 		return &mustBaseConfig(vm).Vcpus
 	}, "1"),
+	"uuid": vmConfigString(func(vm interface{}) *string {
+		return &mustBaseConfig(vm).UUID
+	}, ""),
+	"snapshot": vmConfigBool(func(vm interface{}) *bool {
+		return &mustBaseConfig(vm).Snapshot
+	}, true),
 	"net": {
 		Update: func(v interface{}, c *minicli.Command) error {
 			vm := mustBaseConfig(v)
@@ -95,10 +101,10 @@ var baseConfigFns = map[string]VMConfigFns{
 		Print: func(vm interface{}) string {
 			return mustBaseConfig(vm).NetworkString()
 		},
-		PrintCLI: func(v interface{}) string {
+		PrintCLI: func(v interface{}) []string {
 			vm := mustBaseConfig(v)
 			if len(vm.Networks) == 0 {
-				return ""
+				return nil
 			}
 
 			nics := []string{}
@@ -106,15 +112,27 @@ var baseConfigFns = map[string]VMConfigFns{
 				nic := fmt.Sprintf("%v,%v,%v,%v", net.Bridge, net.VLAN, net.MAC, net.Driver)
 				nics = append(nics, nic)
 			}
-			return "vm config net " + strings.Join(nics, " ")
+			return []string{"vm config net " + strings.Join(nics, " ")}
 		},
 	},
-	"uuid": vmConfigString(func(vm interface{}) *string {
-		return &mustBaseConfig(vm).UUID
-	}, ""),
-	"snapshot": vmConfigBool(func(vm interface{}) *bool {
-		return &mustBaseConfig(vm).Snapshot
-	}, true),
+	"tag": {
+		// see cliVmConfigTag
+		Update: nil,
+		Print:  nil,
+		// see also cliClearVmConfigTag
+		Clear: func(v interface{}) {
+			mustBaseConfig(v).Tags = map[string]string{}
+		},
+		PrintCLI: func(v interface{}) []string {
+			vm := mustBaseConfig(v)
+
+			res := []string{}
+			for k, v := range vm.Tags {
+				res = append(res, fmt.Sprintf("vm config tag %q %q", k, v))
+			}
+			return res
+		},
+	},
 }
 
 // Functions for configuring container-based VMs. Note: if keys overlap with
@@ -206,13 +224,13 @@ var kvmConfigFns = map[string]VMConfigFns{
 		Print: func(_ interface{}) string {
 			return qemuOverrideString()
 		},
-		PrintCLI: func(_ interface{}) string {
-			overrides := []string{}
+		PrintCLI: func(_ interface{}) []string {
+			res := []string{}
 			for _, q := range QemuOverrides {
-				override := fmt.Sprintf("vm kvm config qemu-override add %s %s", q.match, q.repl)
-				overrides = append(overrides, override)
+				res = append(res, fmt.Sprintf("vm kvm config qemu-override add %s %s", q.match, q.repl))
 			}
-			return strings.Join(overrides, "\n")
+
+			return res
 		},
 	},
 }
@@ -277,11 +295,12 @@ func vmConfigSlice(fn func(interface{}) *[]string, name, ns string) VMConfigFns 
 		},
 		Clear: func(vm interface{}) { *fn(vm) = []string{} },
 		Print: func(vm interface{}) string { return fmt.Sprintf("%v", *fn(vm)) },
-		PrintCLI: func(vm interface{}) string {
+		PrintCLI: func(vm interface{}) []string {
 			if v := *fn(vm); len(v) > 0 {
-				return fmt.Sprintf("vm %s config %s %s", ns, name, strings.Join(v, " "))
+				res := fmt.Sprintf("vm %s config %s %s", ns, name, strings.Join(v, " "))
+				return []string{res}
 			}
-			return ""
+			return nil
 		},
 	}
 }

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -33,7 +33,7 @@ func saveConfig(ns string, fns map[string]VMConfigFns, configs interface{}) []st
 	for k, fns := range fns {
 		if fns.PrintCLI != nil {
 			if v := fns.PrintCLI(configs); len(v) > 0 {
-				cmds = append(cmds, v)
+				cmds = append(cmds, v...)
 			}
 		} else if v := fns.Print(configs); len(v) > 0 {
 			cmds = append(cmds, fmt.Sprintf("vm %s config %s %s", ns, k, v))

--- a/tests/vm_tags
+++ b/tests/vm_tags
@@ -1,0 +1,21 @@
+# Set some tags and launch VMs
+vm config tag color red
+vm config tag
+vm launch kvm vm0
+vm config tag shape square
+vm launch kvm vm[1,2]
+.column tags vm info
+
+# Test clearing tags
+clear vm config tag color
+vm launch kvm vm3
+.column tags vm info
+
+# Make sure Tags are truely separate structures
+vm tag vm1 color blue
+.column tags vm info
+
+# Make sure that clear only affects the configured tags
+clear vm config tag
+vm config tag
+.column tags vm info

--- a/tests/vm_tags.want
+++ b/tests/vm_tags.want
@@ -1,0 +1,42 @@
+## # Set some tags and launch VMs
+## vm config tag color red
+## vm config tag
+{"color":"red"}
+## vm launch kvm vm0
+## vm config tag shape square
+## vm launch kvm vm[1,2]
+## .column tags vm info
+tags
+{"color":"red","shape":"square"}
+{"color":"red","shape":"square"}
+{"color":"red"}
+## 
+## # Test clearing tags
+## clear vm config tag color
+## vm launch kvm vm3
+## .column tags vm info
+tags
+{"color":"red","shape":"square"}
+{"color":"red","shape":"square"}
+{"color":"red"}
+{"shape":"square"}
+## 
+## # Make sure Tags are truely separate structures
+## vm tag vm1 color blue
+## .column tags vm info
+tags
+{"color":"blue","shape":"square"}
+{"color":"red","shape":"square"}
+{"color":"red"}
+{"shape":"square"}
+## 
+## # Make sure that clear only affects the configured tags
+## clear vm config tag
+## vm config tag
+{}
+## .column tags vm info
+tags
+{"color":"blue","shape":"square"}
+{"color":"red","shape":"square"}
+{"color":"red"}
+{"shape":"square"}


### PR DESCRIPTION
Allows you to configure tags for all newly launched VMs. Fixes #429.