### PR TITLE
minimega: fixes for disk API.

### DIFF
--- a/tests/disk
+++ b/tests/disk
@@ -1,0 +1,50 @@
+# Create temporary files to inject
+shell touch /tmp/minimega/XXX /tmp/minimega/YYY /tmp/minimega/ZZZ
+
+# Create a disk image with two partitions, each with a FAT filesystem
+disk create qcow2 foo.qcow2 2G
+shell qemu-nbd -c /dev/nbd0 file:foo.qcow2
+shell parted /dev/nbd0 mklabel msdos unit GB mkpart primary fat32 0 1 mkpart primary fat32 1 2
+shell mkfs.fat /dev/nbd0p1
+shell mkfs.fat /dev/nbd0p2
+shell qemu-nbd -d /dev/nbd0
+
+# Inject a file into base image
+disk inject foo.qcow2 files /tmp/minimega/XXX:/tmp/minimega/XXX
+shell qemu-nbd -c /dev/nbd0 file:foo.qcow2
+shell mount /dev/nbd0p1 /mnt
+shell ls -R /mnt
+shell umount /mnt
+shell qemu-nbd -d /dev/nbd0
+
+# Create snapshot, inject a file into first partition of snapshot
+disk snapshot foo.qcow2 bar.qcow2
+disk inject bar.qcow2 files /tmp/minimega/YYY:/tmp/minimega/YYY
+shell qemu-nbd -c /dev/nbd0 file:bar.qcow2
+shell mount /dev/nbd0p1 /mnt
+shell ls -R /mnt
+shell umount /mnt
+shell qemu-nbd -d /dev/nbd0
+
+# Inject a file into second partition of snapshot
+disk inject bar.qcow2:2 files /tmp/minimega/ZZZ:/tmp/minimega/ZZZ
+shell qemu-nbd -c /dev/nbd0 file:bar.qcow2
+shell mount /dev/nbd0p2 /mnt
+shell ls -R /mnt
+shell umount /mnt
+shell qemu-nbd -d /dev/nbd0
+
+# Check that the "snapshot" was actually a snapshot
+shell qemu-nbd -c /dev/nbd0 file:foo.qcow2
+shell mount /dev/nbd0p1 /mnt
+shell ls -R /mnt
+shell umount /mnt
+shell mount /dev/nbd0p2 /mnt
+shell ls -R /mnt
+shell umount /mnt
+shell qemu-nbd -d /dev/nbd0
+
+# Clean up temp files and images
+shell rm /tmp/minimega/XXX /tmp/minimega/YYY /tmp/minimega/ZZZ
+file delete foo.qcow2
+file delete bar.qcow2

--- a/tests/disk.want
+++ b/tests/disk.want
@@ -1,0 +1,96 @@
+## # Create temporary files to inject
+## shell touch /tmp/minimega/XXX /tmp/minimega/YYY /tmp/minimega/ZZZ
+
+## # Create a disk image with two partitions, each with a FAT filesystem
+## disk create qcow2 foo.qcow2 2G
+## shell qemu-nbd -c /dev/nbd0 file:foo.qcow2
+## shell parted /dev/nbd0 mklabel msdos unit GB mkpart primary fat32 0 1 mkpart primary fat32 1 2
+E: Information: You may need to update /etc/fstab.
+
+
+## shell mkfs.fat /dev/nbd0p1
+mkfs.fat 3.0.27 (2014-11-12)
+unable to get drive geometry, using default 255/63
+## shell mkfs.fat /dev/nbd0p2
+mkfs.fat 3.0.27 (2014-11-12)
+unable to get drive geometry, using default 255/63
+## shell qemu-nbd -d /dev/nbd0
+/dev/nbd0 disconnected
+
+## # Inject a file into base image
+## disk inject foo.qcow2 files /tmp/minimega/XXX:/tmp/minimega/XXX
+## shell qemu-nbd -c /dev/nbd0 file:foo.qcow2
+## shell mount /dev/nbd0p1 /mnt
+## shell ls -R /mnt
+/mnt:
+tmp
+
+/mnt/tmp:
+minimega
+
+/mnt/tmp/minimega:
+XXX
+## shell umount /mnt
+## shell qemu-nbd -d /dev/nbd0
+/dev/nbd0 disconnected
+
+## # Create snapshot, inject a file into first partition of snapshot
+## disk snapshot foo.qcow2 bar.qcow2
+## disk inject bar.qcow2 files /tmp/minimega/YYY:/tmp/minimega/YYY
+## shell qemu-nbd -c /dev/nbd0 file:bar.qcow2
+## shell mount /dev/nbd0p1 /mnt
+## shell ls -R /mnt
+/mnt:
+tmp
+
+/mnt/tmp:
+minimega
+
+/mnt/tmp/minimega:
+XXX
+YYY
+## shell umount /mnt
+## shell qemu-nbd -d /dev/nbd0
+/dev/nbd0 disconnected
+
+## # Inject a file into second partition of snapshot
+## disk inject bar.qcow2:2 files /tmp/minimega/ZZZ:/tmp/minimega/ZZZ
+## shell qemu-nbd -c /dev/nbd0 file:bar.qcow2
+## shell mount /dev/nbd0p2 /mnt
+## shell ls -R /mnt
+/mnt:
+tmp
+
+/mnt/tmp:
+minimega
+
+/mnt/tmp/minimega:
+ZZZ
+## shell umount /mnt
+## shell qemu-nbd -d /dev/nbd0
+/dev/nbd0 disconnected
+
+## # Check that the "snapshot" was actually a snapshot
+## shell qemu-nbd -c /dev/nbd0 file:foo.qcow2
+## shell mount /dev/nbd0p1 /mnt
+## shell ls -R /mnt
+/mnt:
+tmp
+
+/mnt/tmp:
+minimega
+
+/mnt/tmp/minimega:
+XXX
+## shell umount /mnt
+## shell mount /dev/nbd0p2 /mnt
+## shell ls -R /mnt
+/mnt:
+## shell umount /mnt
+## shell qemu-nbd -d /dev/nbd0
+/dev/nbd0 disconnected
+
+## # Clean up temp files and images
+## shell rm /tmp/minimega/XXX /tmp/minimega/YYY /tmp/minimega/ZZZ
+## file delete foo.qcow2
+## file delete bar.qcow2


### PR DESCRIPTION
Relative paths should always be relative to /files/, not a mixture of /files/ and CWD. Adding tests to make sure we can create/snapshot/inject images.
