### PR TITLE
minimega/tests: fix tap tests.

### DIFF
--- a/src/minimega/bridge.go
+++ b/src/minimega/bridge.go
@@ -42,7 +42,7 @@ type Bridge struct {
 	Tunnel   []string
 
 	Taps        map[string]Tap
-	defunctTaps []string
+	defunctTaps map[string]bool
 
 	// Embedded mutex
 	sync.Mutex
@@ -102,8 +102,9 @@ func init() {
 func NewBridge(name string) (*Bridge, error) {
 	log.Debug("creating new bridge -- %v", name)
 	b := &Bridge{
-		Name: name,
-		Taps: make(map[string]Tap),
+		Name:        name,
+		Taps:        make(map[string]Tap),
+		defunctTaps: make(map[string]bool),
 	}
 
 	// Create the bridge
@@ -642,8 +643,10 @@ func bridgeInfo() string {
 	fmt.Fprintf(w, "Bridge\tExisted before minimega\tActive VLANS\n")
 	for _, v := range bridges {
 		vlans := map[int]bool{}
-		for _, tap := range v.Taps {
-			vlans[tap.lan] = true
+		for name, tap := range v.Taps {
+			if !v.defunctTaps[name] {
+				vlans[tap.lan] = true
+			}
 		}
 
 		vlans2 := []int{}
@@ -719,7 +722,7 @@ func hostTapList(resp *minicli.Response) {
 	// find all the host taps first
 	for k, b := range bridges {
 		for name, tap := range b.Taps {
-			if tap.host {
+			if tap.host && !b.defunctTaps[name] {
 				resp.Tabular = append(resp.Tabular, []string{
 					k, name, strconv.Itoa(tap.lan),
 				})
@@ -933,7 +936,7 @@ func (b *Bridge) queueRemove(tap string) error {
 		return fmt.Errorf("no such tap %v", tap)
 	}
 
-	b.defunctTaps = append(b.defunctTaps, tap)
+	b.defunctTaps[tap] = true
 	return nil
 }
 
@@ -975,11 +978,11 @@ func reapTaps() {
 			defer b.Unlock()
 
 			// just build up the arg string directly
-			for _, t := range b.defunctTaps {
+			for t := range b.defunctTaps {
 				args = append(args, "--", "del-port", b.Name, t)
 				delete(b.Taps, t)
 			}
-			b.defunctTaps = []string{}
+			b.defunctTaps = map[string]bool{}
 		}
 	}
 

--- a/tests/taps_lifecycle
+++ b/tests/taps_lifecycle
@@ -1,11 +1,13 @@
-.columns bridge,tap,vlan tap
-tap create 10 t0
-.columns bridge,tap,vlan tap
-tap create 10 bridge mega_test0 t1
-.columns bridge,tap,vlan tap
-tap create 10 ip 192.168.123.100 t2
-.columns bridge,tap,vlan tap
-tap create 10 bridge mega_test0 ip 192.168.123.101 t3
-.columns bridge,tap,vlan tap
+# Create a tap, second time should fail
+.filter bridge=minitest tap
+tap create 10 bridge minitest name minitest_tap0
+.filter bridge=minitest tap
+tap create 10 bridge minitest name minitest_tap0
+
+# Create another tap with a static IP
+tap create 10 bridge minitest ip 192.168.100.1 minitest_tap1
+.filter bridge=minitest tap
+
+# Clean up taps
 tap delete all
-.columns bridge,tap,vlan tap
+.filter bridge=minitest tap

--- a/tests/taps_lifecycle.want
+++ b/tests/taps_lifecycle.want
@@ -1,29 +1,21 @@
-## .columns bridge,tap,vlan tap
-## tap create 10 t0
-t0
-## .columns bridge,tap,vlan tap
-bridge      | tap | vlan
-mega_bridge | t0  | 10
-## tap create 10 bridge mega_test0 t1
-t1
-## .columns bridge,tap,vlan tap
-bridge      | tap | vlan
-mega_bridge | t0  | 10
-mega_test0  | t1  | 10
-## tap create 10 ip 192.168.123.100 t2
-t2
-## .columns bridge,tap,vlan tap
-bridge      | tap | vlan
-mega_bridge | t0  | 10
-mega_bridge | t2  | 10
-mega_test0  | t1  | 10
-## tap create 10 bridge mega_test0 ip 192.168.123.101 t3
-t3
-## .columns bridge,tap,vlan tap
-bridge      | tap | vlan
-mega_bridge | t0  | 10
-mega_bridge | t2  | 10
-mega_test0  | t1  | 10
-mega_test0  | t3  | 10
+## # Create a tap, second time should fail
+## .filter bridge=minitest tap
+## tap create 10 bridge minitest name minitest_tap0
+minitest_tap0
+## .filter bridge=minitest tap
+bridge   | tap           | vlan
+minitest | minitest_tap0 | 10
+## tap create 10 bridge minitest name minitest_tap0
+E: tap is already connected to bridge: minitest minitest_tap0
+
+## # Create another tap with a static IP
+## tap create 10 bridge minitest ip 192.168.100.1 minitest_tap1
+minitest_tap1
+## .filter bridge=minitest tap
+bridge   | tap           | vlan
+minitest | minitest_tap0 | 10
+minitest | minitest_tap1 | 10
+
+## # Clean up taps
 ## tap delete all
-## .columns bridge,tap,vlan tap
+## .filter bridge=minitest tap


### PR DESCRIPTION
Changed defunctTaps from a slice to a map so that we can omit printing
of defunctTaps. This removes a race if we call `tap delete all` and then
immediately call `tap`.

Updated simple lifecycle test for taps.