### PR TITLE
minimega/tests: enforce UUID uniqueness.

### DIFF
--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -1228,6 +1228,10 @@ func cliVmLaunch(c *minicli.Command) *minicli.Response {
 		err = errors.New("no VMs to launch")
 	}
 
+	if len(names) > 1 && vmConfig.UUID != "" {
+		err = errors.New("cannot launch multiple VMs with a pre-configured UUID")
+	}
+
 	if err != nil {
 		resp.Error = err.Error()
 		return resp

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -182,8 +182,12 @@ func (vms VMs) launch(vm VM) (err error) {
 	vmLock.Lock()
 	defer vmLock.Unlock()
 
-	// Make sure that there isn't an existing VM with the same name
+	// Make sure that there isn't an existing VM with the same name or UUID
 	for _, vm2 := range vms {
+		if vm.GetUUID() == vm2.GetUUID() {
+			return fmt.Errorf("vm launch duplicate UUID: %s", vm.GetUUID())
+		}
+
 		if vm.GetName() == vm2.GetName() {
 			return fmt.Errorf("vm launch duplicate VM name: %s", vm.GetName())
 		}

--- a/tests/vm_uuid
+++ b/tests/vm_uuid
@@ -1,0 +1,10 @@
+# Launch VM with specified UUID
+vm config uuid a5082fed-bc6f-4f77-8c1b-692ce5ef6302
+vm launch kvm 1
+
+# Try to launch another without clearing the UUID
+vm launch kvm 1
+
+# Try to launch two VMs with the same UUID
+vm config uuid f3b8b039-2f26-43d0-908c-b0de030a44ed
+vm launch kvm 2

--- a/tests/vm_uuid.want
+++ b/tests/vm_uuid.want
@@ -1,0 +1,12 @@
+## # Launch VM with specified UUID
+## vm config uuid a5082fed-bc6f-4f77-8c1b-692ce5ef6302
+## vm launch kvm 1
+
+## # Try to launch another without clearing the UUID
+## vm launch kvm 1
+E: vm launch duplicate UUID: a5082fed-bc6f-4f77-8c1b-692ce5ef6302
+
+## # Try to launch two VMs with the same UUID
+## vm config uuid f3b8b039-2f26-43d0-908c-b0de030a44ed
+## vm launch kvm 2
+E: cannot launch multiple VMs with a pre-configured UUID


### PR DESCRIPTION
Enforce that UUIDs are unique, at least on the local node. Add test to
make sure that we don't allow launch VMs with duplicate UUIDs.

Fixes #444.