### PR TITLE
minimega: fix race in container kill

### DIFF
--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -898,26 +898,6 @@ func (vm *ContainerVM) launch() error {
 
 	go vm.console(parentStdin, parentStdout, parentStderr)
 
-	// Channel to signal when the process has exited
-	var waitChan = make(chan bool)
-
-	// Create goroutine to wait for process to exit
-	go func() {
-		defer close(waitChan)
-		err := cmd.Wait()
-
-		vm.lock.Lock()
-		defer vm.lock.Unlock()
-
-		if err != nil && err.Error() != "signal: killed" { // because we killed it
-			log.Error("kill container: %v", err)
-			vm.setError(err)
-		} else if vm.State != VM_ERROR {
-			// Set to QUIT unless we've already been put into the error state
-			vm.setState(VM_QUIT)
-		}
-	}()
-
 	// TODO: add affinity funcs for containers
 	// vm.CheckAffinity()
 
@@ -996,12 +976,32 @@ func (vm *ContainerVM) launch() error {
 	}
 
 	go func() {
+		var err error
 		cgroupPath := filepath.Join(CGROUP_PATH, fmt.Sprintf("%v", vm.ID))
 		sendKillAck := false
+
+		// Channel to signal when the process has exited
+		var waitChan = make(chan bool)
+
+		// Create goroutine to wait for process to exit
+		go func() {
+			err = cmd.Wait()
+			close(waitChan)
+		}()
 
 		select {
 		case <-waitChan:
 			log.Info("VM %v exited", vm.ID)
+
+			vm.lock.Lock()
+			defer vm.lock.Unlock()
+
+			// we don't need to check the error for a clean kill,
+			// as there's no way to get here if we killed it.
+			if err != nil {
+				log.Error("kill container: %v", err)
+				vm.setError(err)
+			}
 		case <-vm.kill:
 			log.Info("Killing VM %v", vm.ID)
 
@@ -1009,8 +1009,6 @@ func (vm *ContainerVM) launch() error {
 			defer vm.lock.Unlock()
 
 			cmd.Process.Kill()
-
-			vm.setState(VM_QUIT)
 
 			// containers cannot return unless thawed, so thaw the
 			// process if necessary
@@ -1067,6 +1065,11 @@ func (vm *ContainerVM) launch() error {
 		err = os.Remove(cgroupPath)
 		if err != nil {
 			log.Errorln(err)
+		}
+
+		if vm.State != VM_ERROR {
+			// Set to QUIT unless we've already been put into the error state
+			vm.setState(VM_QUIT)
 		}
 
 		if sendKillAck {

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -898,26 +898,6 @@ func (vm *ContainerVM) launch() error {
 
 	go vm.console(parentStdin, parentStdout, parentStderr)
 
-	// Channel to signal when the process has exited
-	var waitChan = make(chan bool)
-
-	// Create goroutine to wait for process to exit
-	go func() {
-		defer close(waitChan)
-		err := cmd.Wait()
-
-		vm.lock.Lock()
-		defer vm.lock.Unlock()
-
-		if err != nil && err.Error() != "signal: killed" { // because we killed it
-			log.Error("kill container: %v", err)
-			vm.setError(err)
-		} else if vm.State != VM_ERROR {
-			// Set to QUIT unless we've already been put into the error state
-			vm.setState(VM_QUIT)
-		}
-	}()
-
 	// TODO: add affinity funcs for containers
 	// vm.CheckAffinity()
 
@@ -999,9 +979,28 @@ func (vm *ContainerVM) launch() error {
 		cgroupPath := filepath.Join(CGROUP_PATH, fmt.Sprintf("%v", vm.ID))
 		sendKillAck := false
 
+		// Channel to signal when the process has exited
+		var waitChan = make(chan error)
+
+		// Create goroutine to wait for process to exit
+		go func() {
+			err := cmd.Wait()
+			waitChan <- err
+		}()
+
 		select {
-		case <-waitChan:
+		case err := <-waitChan:
 			log.Info("VM %v exited", vm.ID)
+
+			vm.lock.Lock()
+			defer vm.lock.Unlock()
+
+			// we don't need to check the error for a clean kill,
+			// as there's no way to get here if we killed it.
+			if err != nil {
+				log.Error("kill container: %v", err)
+				vm.setError(err)
+			}
 		case <-vm.kill:
 			log.Info("Killing VM %v", vm.ID)
 
@@ -1065,6 +1064,11 @@ func (vm *ContainerVM) launch() error {
 		err = os.Remove(cgroupPath)
 		if err != nil {
 			log.Errorln(err)
+		}
+
+		if vm.State != VM_ERROR {
+			// Set to QUIT unless we've already been put into the error state
+			vm.setState(VM_QUIT)
 		}
 
 		if sendKillAck {


### PR DESCRIPTION
A race exists between killing a container, giving up the vm lock, and the goroutine that watches for the container to exit. When the watching goroutine exits, it grabs the vm lock and asserts the new vm state (error, quit...). It's possible that the CLI can issue a kill twice before this goroutine has a chance to set the state. The fix is just to set the state in the kill routine proper.

@jcrussell look at the first commit in this PR. I had a longer solution that actually made more sense for containers, but it didn't mirror the functionality in the kvm implementation (which doesn't have this race fyi). I opted to keep this similar just for maintainability's sake.