### PR TITLE
web: fix hide connect button on non-kvm VMs.

### DIFF
--- a/misc/web/js/glue.js
+++ b/misc/web/js/glue.js
@@ -191,7 +191,7 @@ function updateTables () {
         toAppend.find("img").attr("data-url", screenshotURL(vm, 300));
         toAppend.find(".screenshot-state").addClass(COLOR_CLASSES[vm.state]).html(vm.state);
 
-        if (vm.type != "kvm") toAppend.find(".connect-vm-button").attr("visibility", "hidden");
+        if (vm.type != "kvm") toAppend.find(".connect-vm-button").css("visibility", "hidden");
         
         screenshotList.push({
             "name": vm.name,


### PR DESCRIPTION
Set style rather than node attr. Tested on Chrome/Firefox.