### PR TITLE
minimega/miniclient: move Attach to minimega.

### DIFF
--- a/src/miniclient/client.go
+++ b/src/miniclient/client.go
@@ -7,16 +7,13 @@ package miniclient
 import (
 	"encoding/json"
 	"fmt"
-	"goreadline"
 	"io"
 	"minicli"
 	log "minilog"
 	"minipager"
 	"net"
 	"os"
-	"os/signal"
 	"path"
-	"syscall"
 )
 
 type Response struct {
@@ -26,7 +23,7 @@ type Response struct {
 }
 
 type Conn struct {
-	url string
+	URL string // URL for minimega, changing doesn't cause a redial
 
 	conn net.Conn
 
@@ -39,12 +36,12 @@ type Conn struct {
 
 func Dial(base string) (*Conn, error) {
 	var mm = &Conn{
-		url: path.Join(base, "minimega"),
+		URL: path.Join(base, "minimega"),
 	}
 	var err error
 
 	// try to connect to the local minimega
-	mm.conn, err = net.Dial("unix", mm.url)
+	mm.conn, err = net.Dial("unix", mm.URL)
 	if err != nil {
 		return nil, err
 	}
@@ -118,70 +115,6 @@ func (mm *Conn) RunAndPrint(cmd *minicli.Command, page bool) {
 		errs := resp.Resp.Error()
 		if errs != "" {
 			fmt.Fprintln(os.Stderr, errs)
-		}
-	}
-}
-
-// Attach creates a CLI interface to the dialed minimega instance
-func (mm *Conn) Attach() {
-	// set up signal handling
-	sig := make(chan os.Signal, 1024)
-	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-sig
-		log.Debug("caught signal, disconnecting")
-		goreadline.Rlcleanup()
-		os.Exit(0)
-	}()
-
-	// start our own rlwrap
-	fmt.Println("CAUTION: calling 'quit' will cause the minimega daemon to exit")
-	fmt.Println("use 'disconnect' or ^d to exit just the minimega command line")
-	fmt.Println()
-	defer goreadline.Rlcleanup()
-
-	var exitNext bool
-	for {
-		prompt := fmt.Sprintf("minimega:%v$ ", mm.url)
-		line, err := goreadline.Rlwrap(prompt, true)
-		if err != nil {
-			return
-		}
-		command := string(line)
-		log.Debug("got from stdin: `%s`", line)
-
-		// HAX: Shortcut some commands without using minicli
-		if command == "disconnect" {
-			log.Debugln("disconnecting")
-			return
-		} else if command == "quit" {
-			if !exitNext {
-				fmt.Println("CAUTION: calling 'quit' will cause the minimega daemon to exit")
-				fmt.Println("If you really want to stop the minimega daemon, enter 'quit' again")
-				exitNext = true
-				continue
-			}
-		}
-
-		exitNext = false
-
-		cmd, err := minicli.Compile(command)
-		if err != nil {
-			log.Error("%v", err)
-			//fmt.Println("closest match: TODO")
-			continue
-		}
-
-		// No command was returned, must have been a blank line or a comment
-		// line. Either way, don't try to run a nil command.
-		if cmd == nil {
-			continue
-		}
-
-		mm.RunAndPrint(cmd, true)
-
-		if command == "quit" {
-			return
 		}
 	}
 }


### PR DESCRIPTION
Too many dependencies for app engine. Moving code to minimega so that we
can still import miniclient in app engine for minidoc.

Should fix #455.