### PR TITLE
minidoc: copy miniclient code into minidoc for local connections

### DIFF
--- a/src/minidoc/minimega.go
+++ b/src/minidoc/minimega.go
@@ -1,9 +1,15 @@
 package main
 
+// everything after sendCommand is forked from miniclient and trimmed to build
+// in appengine
+
 import (
+	"encoding/json"
+	"io"
 	"minicli"
-	"miniclient"
 	log "minilog"
+	"net"
+	"path"
 	"strings"
 )
 
@@ -14,7 +20,7 @@ func sendCommand(s string) string {
 
 	log.Debug("sendCommand: %v", s)
 
-	mm, err := miniclient.Dial(*f_minimega)
+	mm, err := dial(*f_minimega)
 	if err != nil {
 		log.Errorln(err)
 		return err.Error()
@@ -33,4 +39,88 @@ func sendCommand(s string) string {
 		}
 	}
 	return responses
+}
+
+type Response struct {
+	Resp     minicli.Responses
+	Rendered string
+	More     bool // whether there are more responses coming
+}
+
+type Conn struct {
+	url string
+
+	conn net.Conn
+
+	enc *json.Encoder
+	dec *json.Decoder
+}
+
+func dial(base string) (*Conn, error) {
+	var mm = &Conn{
+		url: path.Join(base, "minimega"),
+	}
+	var err error
+
+	// try to connect to the local minimega
+	mm.conn, err = net.Dial("unix", mm.url)
+	if err != nil {
+		return nil, err
+	}
+
+	mm.enc = json.NewEncoder(mm.conn)
+	mm.dec = json.NewDecoder(mm.conn)
+
+	return mm, nil
+}
+
+func (mm *Conn) Close() error {
+	return mm.conn.Close()
+}
+
+// Run a command through a JSON pipe, hand back channel for responses.
+func (mm *Conn) Run(cmd *minicli.Command) chan *Response {
+	if cmd == nil {
+		// Language spec: "Receiving from a nil channel blocks forever."
+		// Instead, make and immediately close the channel so that range
+		// doesn't block and receives no values.
+		out := make(chan *Response)
+		close(out)
+
+		return out
+	}
+
+	err := mm.enc.Encode(*cmd)
+	if err != nil {
+		log.Fatal("local command gob encode: %v", err)
+	}
+	log.Debugln("encoded command:", cmd)
+
+	respChan := make(chan *Response)
+
+	go func() {
+		defer close(respChan)
+
+		for {
+			var r Response
+			err = mm.dec.Decode(&r)
+			if err != nil {
+				if err == io.EOF {
+					log.Fatal("server disconnected")
+				}
+
+				log.Fatal("local command gob decode: %v", err)
+			}
+
+			respChan <- &r
+			if !r.More {
+				log.Debugln("got last message")
+				break
+			} else {
+				log.Debugln("expecting more data")
+			}
+		}
+	}()
+
+	return respChan
 }


### PR DESCRIPTION
strip components that cannot built in appengine.

fixes #455

@jcrussell 