### PR TITLE
minidoc: make exec flag false by default

### DIFF
--- a/src/minidoc/minidoc.go
+++ b/src/minidoc/minidoc.go
@@ -18,7 +18,7 @@ var (
 	f_port     = flag.Int("port", 9003, "HTTP port")
 	f_root     = flag.String("root", "doc/content/", "HTTP root directory")
 	f_base     = flag.String("base", "doc/template/", "base path for static content and templates")
-	f_exec     = flag.Bool("exec", true, "allow minimega commands")
+	f_exec     = flag.Bool("exec", false, "allow minimega commands")
 	f_loglevel = flag.String("level", "debug", "log level: [debug, info, warn, error, fatal]")
 	f_log      = flag.Bool("v", true, "log on stderr")
 	f_logfile  = flag.String("logfile", "", "log to file")


### PR DESCRIPTION
fixes #361

@jcrussell I don't actually know why this fixes this issue, but it does. This flag shouldn't even exist in the appengine build...

Doesn't really matter though, as this flag should be false by default anyway.