### PR TITLE
minimega: fix #469.

### DIFF
--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -145,12 +145,6 @@ func wrapVMTargetCLI(fn func(*minicli.Command) *minicli.Response) minicli.CLIFun
 		// Just invoke the handler if there's no namespace specified or we
 		// received the command via meshage
 		if namespace == "" || !isUserSource(c.Source) {
-			// Ensure that we have finished creating all the vms launched in previous
-			// commands (possibly with noblock) before trying to apply the command.
-			// This prevents a race condition where a vm could be launched with noblock
-			// and then immediately used as the target of a start command.
-			vmLaunch.Wait()
-
 			respChan <- minicli.Responses{fn(c)}
 			return
 		}

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -594,7 +594,6 @@ func NewContainer(name string) *ContainerVM {
 }
 
 func (vm *ContainerVM) Launch() error {
-	vm.lock.Lock()
 	defer vm.lock.Unlock()
 
 	return vm.launch()
@@ -1078,9 +1077,6 @@ func (vm *ContainerVM) launch() error {
 			killAck <- vm.ID
 		}
 	}()
-
-	// No errors.. ready to go!
-	vm.setState(VM_BUILDING)
 
 	return nil
 }

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -119,7 +119,6 @@ func NewKVM(name string) *KvmVM {
 
 // Launch a new KVM VM.
 func (vm *KvmVM) Launch() error {
-	vm.lock.Lock()
 	defer vm.lock.Unlock()
 
 	return vm.launch()
@@ -545,9 +544,6 @@ func (vm *KvmVM) launch() error {
 			killAck <- vm.ID
 		}
 	}()
-
-	// No errors.. ready to go!
-	vm.setState(VM_BUILDING)
 
 	return nil
 }

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -33,8 +33,6 @@ var (
 	vmIDChan chan int   // channel of new VM IDs
 	vmLock   sync.Mutex // lock for synchronizing access to vms
 
-	vmLaunch sync.WaitGroup // waitgroup for noblock vms
-
 	vmConfig VMConfig // current vm config, updated by CLI
 
 	savedInfo = make(map[string]VMConfig) // saved configs, may be reloaded
@@ -186,6 +184,10 @@ func NewVM(name string) *BaseVM {
 	vm.instancePath = filepath.Join(*f_base, strconv.Itoa(vm.ID))
 
 	vm.State = VM_BUILDING
+
+	// New VMs are returned pre-locked. This ensures that the first operation
+	// called on a new VM is Launch.
+	vm.lock.Lock()
 
 	return vm
 }

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -759,12 +759,8 @@ func cliVmLaunch(c *minicli.Command) *minicli.Response {
 		wg.Wait()
 	}()
 
-	vmLaunch.Add(1)
-
 	// Collect all the errors from errChan and turn them into a string
 	collectErrs := func() string {
-		defer vmLaunch.Done()
-
 		errs := []error{}
 		for err := range errChan {
 			errs = append(errs, err)
@@ -788,6 +784,7 @@ func cliVmLaunch(c *minicli.Command) *minicli.Response {
 func cliVmFlush(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 
+	// See VMs.flush for why we don't use LocalVMs
 	vms.flush()
 
 	return resp


### PR DESCRIPTION
Much saner locking so that we can:

 * block on `vm start all` while `vm launch ... noblock` launches things
   in the background
 * block on `vm launch` while the scheduler runs

Removes vmLaunch lock and instead pre-locks the VMs on creation. This
ensures that Launch() is the first operation called on a VM (otherwise
there will be a deadlock).

Updates #472.