### PR TITLE
minimega: add profiling to `debug` API

### DIFF
--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -17,6 +17,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"syscall"
@@ -261,6 +262,10 @@ func teardown() {
 	err = os.Remove(filepath.Join(*f_base, "minimega.pid"))
 	if err != nil {
 		log.Fatalln(err)
+	}
+	if cpuProfileOut != nil {
+		pprof.StopCPUProfile()
+		cpuProfileOut.Close()
 	}
 	os.Exit(0)
 }


### PR DESCRIPTION
Add `debug memory` and `debug cpu` APIs to dump profiling information
about minimega.

Updates #478