### PR TITLE
protonuke: timing & TLS

### DIFF
--- a/src/protonuke/http.go
+++ b/src/protonuke/http.go
@@ -59,7 +59,7 @@ func httpClient(protocol string) {
 		Proxy: http.ProxyFromEnvironment,
 		Dial: func(network, addr string) (net.Conn, error) {
 			dialer := &net.Dialer{
-				Timeout: 30 * time.Second,
+				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}
 			return dialer.Dial(protocol, addr)
@@ -69,7 +69,7 @@ func httpClient(protocol string) {
 	// TODO: max client read timeouts configurable?
 	client := &http.Client{
 		Transport: transport,
-		Timeout: 30 * time.Second,
+		Timeout:   30 * time.Second,
 	}
 
 	for {
@@ -91,7 +91,7 @@ func httpTLSClient(protocol string) {
 		Proxy:           http.ProxyFromEnvironment,
 		Dial: func(network, addr string) (net.Conn, error) {
 			dialer := &net.Dialer{
-				Timeout: 30 * time.Second,
+				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}
 			return dialer.Dial(protocol, addr)
@@ -102,8 +102,6 @@ func httpTLSClient(protocol string) {
 	if *f_tlsVersion != "" {
 		var version uint16
 		switch *f_tlsVersion {
-		case "ssl3":
-			version = tls.VersionSSL30
 		case "tls1.0":
 			version = tls.VersionTLS10
 		case "tls1.1":
@@ -118,7 +116,7 @@ func httpTLSClient(protocol string) {
 	// TODO: max client read timeouts configurable?
 	client := &http.Client{
 		Transport: transport,
-		Timeout: 30 * time.Second,
+		Timeout:   30 * time.Second,
 	}
 
 	for {

--- a/src/protonuke/http.go
+++ b/src/protonuke/http.go
@@ -99,6 +99,22 @@ func httpTLSClient(protocol string) {
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
 
+	if *f_tlsVersion != "" {
+		var version uint16
+		switch *f_tlsVersion {
+		case "ssl3":
+			version = tls.VersionSSL30
+		case "tls1.0":
+			version = tls.VersionTLS10
+		case "tls1.1":
+			version = tls.VersionTLS11
+		case "tls1.2":
+			version = tls.VersionTLS12
+		}
+		transport.TLSClientConfig.MinVersion = tls.VersionSSL30
+		transport.TLSClientConfig.MaxVersion = version
+	}
+
 	// TODO: max client read timeouts configurable?
 	client := &http.Client{
 		Transport: transport,
@@ -241,7 +257,7 @@ func httpGet(url, file string, useTLS bool, client *http.Client) {
 			resp.Body.Close()
 			stop := time.Now().UnixNano()
 			log.Info("https %v %v %vns", client, file, stop-start)
-			httpTLSReportChan <- 1
+			//httpTLSReportChan <- 1
 		}
 	} else {
 		if !strings.HasPrefix(file, "http://") {
@@ -259,7 +275,7 @@ func httpGet(url, file string, useTLS bool, client *http.Client) {
 			resp.Body.Close()
 			stop := time.Now().UnixNano()
 			log.Info("http %v %v %vns", client, file, stop-start)
-			httpReportChan <- 1
+			//httpReportChan <- 1
 		}
 	}
 }
@@ -349,6 +365,8 @@ func httpTLSServer(p string) {
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}
 	}
+	config.MinVersion = tls.VersionTLS10
+	config.MaxVersion = tls.VersionTLS12
 
 	var err error
 	config.Certificates = make([]tls.Certificate, 1)

--- a/src/protonuke/protonuke.go
+++ b/src/protonuke/protonuke.go
@@ -37,7 +37,7 @@ var (
 	f_httpImageSize = flag.Int("httpimagesize", 3, "size of image, in megabytes, to serve in http/https pages")
 	f_httpTLSCert   = flag.String("httptlscert", "", "file containing public certificate for TLS")
 	f_httpTLSKey    = flag.String("httptlskey", "", "file containing private key for TLS")
-	f_tlsVersion		= flag.String("tlsversion", "", "Select an SSL/TLS version for the client: ssl3, tls1.0, tls1.1, tls1.2")
+	f_tlsVersion		= flag.String("tlsversion", "", "Select a TLS version for the client: tls1.0, tls1.1, tls1.2")
 	hosts           map[string]string
 	keys            []string
 )

--- a/src/protonuke/protonuke.go
+++ b/src/protonuke/protonuke.go
@@ -37,7 +37,7 @@ var (
 	f_httpImageSize = flag.Int("httpimagesize", 3, "size of image, in megabytes, to serve in http/https pages")
 	f_httpTLSCert   = flag.String("httptlscert", "", "file containing public certificate for TLS")
 	f_httpTLSKey    = flag.String("httptlskey", "", "file containing private key for TLS")
-	f_tlsVersion		= flag.String("tlsversion", "", "Select a TLS version for the client: tls1.0, tls1.1, tls1.2")
+	f_tlsVersion    = flag.String("tlsversion", "", "Select a TLS version for the client: tls1.0, tls1.1, tls1.2")
 	hosts           map[string]string
 	keys            []string
 )

--- a/src/protonuke/protonuke.go
+++ b/src/protonuke/protonuke.go
@@ -37,6 +37,7 @@ var (
 	f_httpImageSize = flag.Int("httpimagesize", 3, "size of image, in megabytes, to serve in http/https pages")
 	f_httpTLSCert   = flag.String("httptlscert", "", "file containing public certificate for TLS")
 	f_httpTLSKey    = flag.String("httptlskey", "", "file containing private key for TLS")
+	f_tlsVersion		= flag.String("tlsversion", "", "Select an SSL/TLS version for the client: ssl3, tls1.0, tls1.1, tls1.2")
 	hosts           map[string]string
 	keys            []string
 )


### PR DESCRIPTION
Undo some timing changes I'd made; we want to only count http/https "pageloads" rather than individual GETs.

Also added capability to tell the client what TLS version to use.

Sorry these are in the same PR