### PR TITLE
minimega: simplify isMac.

### DIFF
--- a/src/minimega/misc.go
+++ b/src/minimega/misc.go
@@ -18,7 +18,6 @@ import (
 	log "minilog"
 	"net"
 	"os/exec"
-	"regexp"
 	"resize"
 	"runtime"
 	"strconv"
@@ -95,11 +94,8 @@ func generateUUID() string {
 }
 
 func isMac(mac string) bool {
-	match, err := regexp.MatchString("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$", mac)
-	if err != nil {
-		return false
-	}
-	return match
+	_, err := net.ParseMAC(mac)
+	return err == nil
 }
 
 func allocatedMac(mac string) bool {


### PR DESCRIPTION
Use net.ParseMAC rather than a regular expression. Cleaner and faster:

BenchmarkIsMac           50000             30745 ns/op
BenchmarkIsMac2        3000000               521 ns/op
BenchmarkIsMacNet     10000000               160 ns/op

Second benchmark uses a pre-compiled regular expression.