### PR TITLE
ron/minimega: cc++

### DIFF
--- a/src/minimega/cc.go
+++ b/src/minimega/cc.go
@@ -105,6 +105,18 @@ func ccClients() map[string]bool {
 	return nil
 }
 
+// ccGetFilter returns a filter for cc clients, adding the implicit namespace
+// filter, if a namespace is active.
+func ccGetFilter() *ron.Client {
+	filter := ron.Client{}
+	if ccFilter != nil {
+		filter = *ccFilter
+	}
+
+	filter.Namespace = namespace
+	return &filter
+}
+
 func filterString(f *ron.Client) string {
 	if f == nil {
 		return ""

--- a/src/minimega/cc.go
+++ b/src/minimega/cc.go
@@ -66,6 +66,11 @@ func ccClear(what string) (err error) {
 	case "commands":
 		errs := []string{}
 		for _, v := range ccNode.GetCommands() {
+			// only delete commands for the active namespace
+			if !ccMatchNamespace(v) {
+				continue
+			}
+
 			err := ccNode.DeleteCommand(v.ID)
 			if err != nil {
 				errMsg := fmt.Sprintf("cc delete command %v : %v", v.ID, err)
@@ -77,6 +82,7 @@ func ccClear(what string) (err error) {
 			err = errors.New(strings.Join(errs, "\n"))
 		}
 	case "responses": // delete everything in miniccc_responses
+		// TODO: limit to the active namespace
 		path := filepath.Join(*f_iomBase, ron.RESPONSE_PATH)
 		err := os.RemoveAll(path)
 		if err != nil {
@@ -115,6 +121,12 @@ func ccGetFilter() *ron.Client {
 
 	filter.Namespace = namespace
 	return &filter
+}
+
+// ccMatchNamespace tests whether a command is relavant to the active
+// namespace.
+func ccMatchNamespace(c *ron.Command) bool {
+	return namespace == "" || c.Filter == nil || c.Filter.Namespace == namespace
 }
 
 func filterString(f *ron.Client) string {

--- a/src/minimega/cc_cli.go
+++ b/src/minimega/cc_cli.go
@@ -190,7 +190,7 @@ func cliCCTunnel(c *minicli.Command) *minicli.Response {
 	}
 
 	if c.BoolArgs["rtunnel"] {
-		err := ccNode.Reverse(ccFilter, src, host, dst)
+		err := ccNode.Reverse(ccGetFilter(), src, host, dst)
 		if err != nil {
 			resp.Error = err.Error()
 		}
@@ -379,11 +379,8 @@ func cliCCFilter(c *minicli.Command) *minicli.Response {
 func cliCCFileSend(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 
-	// Set implicit filter
-	ccFilter.Namespace = namespace
-
 	cmd := &ron.Command{
-		Filter: ccFilter,
+		Filter: ccGetFilter(),
 	}
 
 	// Add new files to send, expand globs
@@ -430,11 +427,8 @@ func cliCCFileSend(c *minicli.Command) *minicli.Response {
 func cliCCFileRecv(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 
-	// Set implicit filter
-	ccFilter.Namespace = namespace
-
 	cmd := &ron.Command{
-		Filter: ccFilter,
+		Filter: ccGetFilter(),
 	}
 
 	// Add new files to receive
@@ -456,13 +450,10 @@ func cliCCFileRecv(c *minicli.Command) *minicli.Response {
 func cliCCBackground(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 
-	// Set implicit filter
-	ccFilter.Namespace = namespace
-
 	cmd := &ron.Command{
 		Background: true,
 		Command:    c.ListArgs["command"],
-		Filter:     ccFilter,
+		Filter:     ccGetFilter(),
 	}
 
 	id := ccNode.NewCommand(cmd)
@@ -486,7 +477,7 @@ func cliCCProcess(c *minicli.Command) *minicli.Response {
 
 		cmd := &ron.Command{
 			PID:    pid,
-			Filter: ccFilter,
+			Filter: ccGetFilter(),
 		}
 
 		id := ccNode.NewCommand(cmd)
@@ -548,12 +539,9 @@ func cliCCProcess(c *minicli.Command) *minicli.Response {
 func cliCCExec(c *minicli.Command) *minicli.Response {
 	resp := &minicli.Response{Host: hostname}
 
-	// Set implicit filter
-	ccFilter.Namespace = namespace
-
 	cmd := &ron.Command{
 		Command: c.ListArgs["command"],
-		Filter:  ccFilter,
+		Filter:  ccGetFilter(),
 	}
 
 	id := ccNode.NewCommand(cmd)

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -741,7 +741,7 @@ func (vm *ContainerVM) launch() error {
 
 	// don't repeat the preamble if we're just in the quit state
 	if s != VM_QUIT {
-		ccNode.RegisterClient(vm.UUID, vm.Namespace)
+		ccNode.RegisterVM(vm.UUID, vm)
 
 		if err := os.MkdirAll(vm.instancePath, os.FileMode(0700)); err != nil {
 			teardownf("unable to create VM dir: %v", err)

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -405,7 +405,7 @@ func (vm *KvmVM) launch() error {
 	// If this is the first time launching the VM, do the final configuration
 	// check and create a directory for it.
 	if vm.State != VM_QUIT {
-		ccNode.RegisterClient(vm.UUID, vm.Namespace)
+		ccNode.RegisterVM(vm.UUID, vm)
 
 		if err := os.MkdirAll(vm.instancePath, os.FileMode(0700)); err != nil {
 			teardownf("unable to create VM dir: %v", err)

--- a/src/minimega/misc.go
+++ b/src/minimega/misc.go
@@ -70,18 +70,6 @@ func (m *loggingMutex) Unlock() {
 	log.Info("unlocked: %v:%v", file, line)
 }
 
-// generate a random mac address and return as a string
-func randomMac() string {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	//
-	prefix := validMACPrefix[r.Intn(len(validMACPrefix))]
-
-	mac := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", prefix[0], prefix[1], prefix[2], r.Intn(256), r.Intn(256), r.Intn(256))
-	log.Info("generated mac: %v", mac)
-	return mac
-}
-
 func generateUUID() string {
 	log.Debugln("generateUUID")
 	uuid, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
@@ -92,6 +80,41 @@ func generateUUID() string {
 	uuid = uuid[:len(uuid)-1]
 	log.Debug("generated UUID: %v", string(uuid))
 	return string(uuid)
+}
+
+func isUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+
+	parts := strings.Split(s, "-")
+	if len(parts) != 5 {
+		return false
+	}
+
+	for i, v := range []int{8, 4, 4, 4, 12} {
+		if len(parts[i]) != v {
+			return false
+		}
+
+		if _, err := strconv.ParseInt(parts[i], 16, 64); err != nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+// generate a random mac address and return as a string
+func randomMac() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	//
+	prefix := validMACPrefix[r.Intn(len(validMACPrefix))]
+
+	mac := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", prefix[0], prefix[1], prefix[2], r.Intn(256), r.Intn(256), r.Intn(256))
+	log.Info("generated mac: %v", mac)
+	return mac
 }
 
 func isMac(mac string) bool {

--- a/src/minimega/misc_test.go
+++ b/src/minimega/misc_test.go
@@ -38,3 +38,25 @@ func TestHasCommand(t *testing.T) {
 		}
 	}
 }
+
+func TestIsUUID(t *testing.T) {
+	var data = []struct {
+		v    string
+		want bool
+	}{
+		{"", false},
+		{"false", false},
+		{"-----", false},
+		{"0-0-0-0-0-0", false},
+		{"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", false},
+		{"00000x00-0000-0000-0000-0000x0000000", false},
+		{"00000000-0000-0000-0000-000000000000", true},
+		{"deadbeef-cafe-dead-beef-cafeeeeeeeee", true},
+	}
+
+	for i := range data {
+		if got := isUUID(data[i].v); got != data[i].want {
+			t.Errorf("expected isUUID(%v) = %t", data[i].v, data[i].want)
+		}
+	}
+}

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -69,6 +69,7 @@ type VM interface {
 	Info(string) (string, error)
 
 	Tag(tag string) string
+	SetTag(k, v string)
 	GetTags() map[string]string
 	ClearTags()
 
@@ -355,14 +356,35 @@ func (vm *BaseVM) Flush() error {
 }
 
 func (vm *BaseVM) Tag(tag string) string {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
 	return vm.Tags[tag]
 }
 
+func (vm *BaseVM) SetTag(k, v string) {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	vm.Tags[k] = v
+}
+
 func (vm *BaseVM) GetTags() map[string]string {
-	return vm.Tags
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	res := map[string]string{}
+	for k, v := range vm.Tags {
+		res[k] = v
+	}
+
+	return res
 }
 
 func (vm *BaseVM) ClearTags() {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
 	vm.Tags = make(map[string]string)
 }
 

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -349,7 +349,7 @@ func (vm *BaseVM) Kill() error {
 }
 
 func (vm *BaseVM) Flush() error {
-	ccNode.UnregisterClient(vm.UUID)
+	ccNode.UnregisterVM(vm.UUID)
 
 	return os.RemoveAll(vm.instancePath)
 }

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -608,7 +608,7 @@ func cliVmTag(c *minicli.Command) *minicli.Response {
 	// in parallel since it updates resp.Tabular.
 	applyFunc := func(vm VM, wild bool) (bool, error) {
 		if setOp {
-			vm.GetTags()[key] = value
+			vm.SetTag(key, value)
 		} else if key == Wildcard {
 			for k, v := range vm.GetTags() {
 				resp.Tabular = append(resp.Tabular, []string{
@@ -620,7 +620,7 @@ func cliVmTag(c *minicli.Command) *minicli.Response {
 			// TODO: return false if tag not set?
 			resp.Tabular = append(resp.Tabular, []string{
 				strconv.Itoa(vm.GetID()),
-				vm.GetTags()[key],
+				vm.Tag(key),
 			})
 		}
 

--- a/src/ron/command.go
+++ b/src/ron/command.go
@@ -56,3 +56,17 @@ type Response struct {
 	Stdout string
 	Stderr string
 }
+
+// Creates a copy of c
+func (c *Command) Copy() *Command {
+	return &Command{
+		ID:         c.ID,
+		Background: c.Background,
+		Command:    c.Command,
+		FilesSend:  c.FilesSend,
+		FilesRecv:  c.FilesRecv,
+		CheckedIn:  c.CheckedIn,
+		Filter:     c.Filter,
+		PID:        c.PID,
+	}
+}

--- a/src/ron/ron.go
+++ b/src/ron/ron.go
@@ -40,11 +40,11 @@ type Server struct {
 	commandCounterLock sync.Mutex
 	clients            map[string]*Client // map of active clients, each of which have a running handler
 	clientLock         sync.Mutex
-	namespaces         map[string]string // map of uuid -> namespace
-	in                 chan *Message     // incoming message queue, consumed by the mux
-	path               string            // path for serving files
-	lastBroadcast      time.Time         // watchdog time of last command list broadcast
-	responses          chan *Client      // queue of incoming responses, consumed by the response processor
+	vms                map[string]VM // map of uuid -> VM
+	in                 chan *Message // incoming message queue, consumed by the mux
+	path               string        // path for serving files
+	lastBroadcast      time.Time     // watchdog time of last command list broadcast
+	responses          chan *Client  // queue of incoming responses, consumed by the response processor
 }
 
 type Client struct {
@@ -59,13 +59,15 @@ type Client struct {
 	tunnel         *minitunnel.Tunnel
 
 	// client parameters
-	UUID      string
-	Hostname  string
-	Arch      string
-	OS        string
-	IP        []string
-	MAC       []string
+	UUID     string
+	Hostname string
+	Arch     string
+	OS       string
+	IP       []string
+	MAC      []string
+
 	Namespace string
+	Tags      map[string]string
 
 	Processes   map[int]*Process // list of processes backgrounded (cc background in minimega)
 	processLock sync.Mutex
@@ -87,6 +89,11 @@ type Process struct {
 	process *os.Process
 }
 
+type VM interface {
+	GetNamespace() string
+	GetTags() map[string]string
+}
+
 type Message struct {
 	Type     int
 	UUID     string
@@ -105,7 +112,7 @@ func NewServer(port int, path string) (*Server, error) {
 		udsConns:      make(map[string]net.Listener),
 		commands:      make(map[int]*Command),
 		clients:       make(map[string]*Client),
-		namespaces:    make(map[string]string),
+		vms:           make(map[string]VM),
 		path:          path,
 		in:            make(chan *Message, 1024),
 		lastBroadcast: time.Now(),

--- a/src/ron/server.go
+++ b/src/ron/server.go
@@ -20,6 +20,20 @@ import (
 	"version"
 )
 
+// GetCommand returns copy of a command by ID or nil if it doesn't exist
+func (s *Server) GetCommand(id int) *Command {
+	s.commandLock.Lock()
+	defer s.commandLock.Unlock()
+
+	log.Debug("ron GetCommand: %v", id)
+
+	if v, ok := s.commands[id]; ok {
+		return v.Copy()
+	}
+
+	return nil
+}
+
 // GetCommands returns a copy of the current command list
 func (s *Server) GetCommands() map[int]*Command {
 	// return a deep copy of the command list
@@ -28,16 +42,7 @@ func (s *Server) GetCommands() map[int]*Command {
 	defer s.commandLock.Unlock()
 
 	for k, v := range s.commands {
-		ret[k] = &Command{
-			ID:         v.ID,
-			Background: v.Background,
-			Command:    v.Command,
-			FilesSend:  v.FilesSend,
-			FilesRecv:  v.FilesRecv,
-			CheckedIn:  v.CheckedIn,
-			Filter:     v.Filter,
-			PID:        v.PID,
-		}
+		ret[k] = v.Copy()
 	}
 
 	log.Debug("ron GetCommands: %v", ret)

--- a/src/ron/server.go
+++ b/src/ron/server.go
@@ -367,8 +367,11 @@ func (s *Server) route(m *Message) {
 
 		cmdLoop:
 			for k, cmd := range m.Commands {
+				want := cmd.Filter.Namespace
+				got := vm.GetNamespace()
+
 				// filter commands by namespace
-				if v := vm.GetNamespace(); v != "" && v != cmd.Filter.Namespace {
+				if want != "" && want != got {
 					continue
 				}
 

--- a/tests/cc_filter
+++ b/tests/cc_filter
@@ -1,0 +1,31 @@
+# Try setting individual fields
+cc filter uuid=99d2c66f-7e8f-4a26-af92-3876284d33f5
+cc filter
+cc filter hostname=foo
+cc filter
+cc filter arch=amd64
+cc filter
+cc filter os=linux
+cc filter
+cc filter ip=10.0.0.1
+cc filter
+cc filter ip=10.0.0.0/24
+cc filter
+cc filter mac=13:37:13:37:00:00
+cc filter
+
+# Fun with tags
+cc filter tag=foo
+cc filter
+cc filter tag=foo=bar
+cc filter
+cc filter foo=bar
+cc filter
+cc filter foo=
+cc filter
+cc filter tag=foo:bar
+cc filter
+cc filter tag=foo tag=bar:car
+cc filter
+cc filter tag=foo tag=bar:car a=b
+cc filter

--- a/tests/cc_filter.want
+++ b/tests/cc_filter.want
@@ -1,0 +1,59 @@
+## # Try setting individual fields
+## cc filter uuid=99d2c66f-7e8f-4a26-af92-3876284d33f5
+## cc filter
+UUID                                 | hostname | arch | OS | IP | MAC | Tags
+99d2c66f-7e8f-4a26-af92-3876284d33f5 |          |      |    | [] | []  | {}
+## cc filter hostname=foo
+## cc filter
+UUID | hostname | arch | OS | IP | MAC | Tags
+     | foo      |      |    | [] | []  | {}
+## cc filter arch=amd64
+## cc filter
+UUID | hostname | arch  | OS | IP | MAC | Tags
+     |          | amd64 |    | [] | []  | {}
+## cc filter os=linux
+## cc filter
+UUID | hostname | arch | OS    | IP | MAC | Tags
+     |          |      | linux | [] | []  | {}
+## cc filter ip=10.0.0.1
+## cc filter
+UUID | hostname | arch | OS | IP         | MAC | Tags
+     |          |      |    | [10.0.0.1] | []  | {}
+## cc filter ip=10.0.0.0/24
+## cc filter
+UUID | hostname | arch | OS | IP            | MAC | Tags
+     |          |      |    | [10.0.0.0/24] | []  | {}
+## cc filter mac=13:37:13:37:00:00
+## cc filter
+UUID | hostname | arch | OS | IP | MAC                 | Tags
+     |          |      |    | [] | [13:37:13:37:00:00] | {}
+
+## # Fun with tags
+## cc filter tag=foo
+## cc filter
+UUID | hostname | arch | OS | IP | MAC | Tags
+     |          |      |    | [] | []  | {"foo":""}
+## cc filter tag=foo=bar
+## cc filter
+UUID | hostname | arch | OS | IP | MAC | Tags
+     |          |      |    | [] | []  | {"foo":"bar"}
+## cc filter foo=bar
+## cc filter
+UUID | hostname | arch | OS | IP | MAC | Tags
+     |          |      |    | [] | []  | {"foo":"bar"}
+## cc filter foo=
+## cc filter
+UUID | hostname | arch | OS | IP | MAC | Tags
+     |          |      |    | [] | []  | {"foo":""}
+## cc filter tag=foo:bar
+## cc filter
+UUID | hostname | arch | OS | IP | MAC | Tags
+     |          |      |    | [] | []  | {"foo":"bar"}
+## cc filter tag=foo tag=bar:car
+## cc filter
+UUID | hostname | arch | OS | IP | MAC | Tags
+     |          |      |    | [] | []  | {"bar":"car","foo":""}
+## cc filter tag=foo tag=bar:car a=b
+## cc filter
+UUID | hostname | arch | OS | IP | MAC | Tags
+     |          |      |    | [] | []  | {"a":"b","bar":"car","foo":""}


### PR DESCRIPTION
Summary:

 * Add `cc filter tag=`
 * Fix crash caused by implicit filtering
 * Fix race with VM tags
 * Add better filtering for namespace-specific cc commands/responses.

Closes #488.