### PR TITLE
doc/misc/minimega: s/namespace/context for meshage.

### DIFF
--- a/doc/content/articles/usage.article
+++ b/doc/content/articles/usage.article
@@ -1,6 +1,6 @@
 Using minimega
 
-* Launching, Namespaces, and the Base Directory
+* Launching, Contexts, and the Base Directory
 
 minimega is designed to be simple to deploy, and is configured at runtime by
 running minimega scripts (more on that later). A few optional startup options
@@ -56,17 +56,17 @@ minimega will attempt to maintain several connections to the mesh of minimega
 nodes, the number of which is defined by the `degree` flag. `degree` is by
 default 0, which means that when you launch minimega, it will not solicit
 connections to any other nodes. Additionally, minimega supports partitioning
-meshage-based groups of nodes by specifying a namespace at launch using the
-`namespace` flag. This allows you to have two minimega clusters on the same
+meshage-based groups of nodes by specifying a context at launch using the
+`context` flag. This allows you to have two minimega clusters on the same
 network co-exist without connecting to each other.
 
 For example, if you want to launch minimega on a number of nodes and put
-minimega in the background on each node with a namespace of `foo` and a degree
-of 2 - run the following on each node:
+minimega in the background on each node with a context of `foo` and a degree of
+2 - run the following on each node:
 
-	$ sudo bin/minimega -nostdin -degree 2 -namespace foo &
+	$ sudo bin/minimega -nostdin -degree 2 -context foo &
 
-Each node will then auto-discover at least two other nodes with the namespace
+Each node will then auto-discover at least two other nodes with the context
 `foo` and connect to them. If the number of connections to any given node drops
 below 2, it will attempt to discover additional nodes.
 
@@ -81,7 +81,7 @@ on the whole cluster, `ccc1` through `ccc14`, we can use deploy to push it out
 and launch it:
 
     # Launch minimga on ccc1
-    ccc1$ sudo bin/minimega -degree 2 -namespace foo
+    ccc1$ sudo bin/minimega -degree 2 -context foo
     # Now, tell deploy to launch it on the other nodes
     minimega$ deploy launch ccc[2-14]
 
@@ -679,7 +679,7 @@ into the cluster nodes which may not be directly routable from outside the
 cluster.
 
 In order to run the web interface, minimega must have access to included static
-content. This is provided in the distribution under `misc/web`. 
+content. This is provided in the distribution under `misc/web`.
 
 To change the path minimega should use for static content, use the `web`
 command:
@@ -718,7 +718,7 @@ operational goal of meshage is to support running a cluster of minimega
 instances that significantly oversubscribe resources. In such an environment,
 participating nodes can regularly fail, leave the network, and later rejoin.
 Meshage is also designed to support multiple sessions running on the same
-network simultaneously via namespaces that partitions meshage networks.
+network simultaneously via contexts that partitions meshage networks.
 
 *** Node connections
 
@@ -726,8 +726,8 @@ minimega connects to other minimega instances (which are communicated to via
 the `mesh`send` command) using the meshage package. When a minimega instance
 connects to another instance (either through auto-discovery or the `mesh`dial`
 command), a simple handshake occurs to verify connection prerequisites and to
-check the connection namespace. If using auto-discovery and the namespaces are
-not the same, the connection is dropped. If using `mesh`dial`, namespaces are
+check the connection context. If using auto-discovery and the contexts are not
+the same, the connection is dropped. If using `mesh`dial`, contexts are
 ignored. This allows two minimega networks to be forcibly joined.
 
 *** Auto-discovery

--- a/misc/daemon/minimega.init
+++ b/misc/daemon/minimega.init
@@ -82,9 +82,9 @@ start() {
     return 1
   fi
   mkdir -p $MM_RUN_PATH
-	pushd $MINIMEGA_DIR &>/dev/null
-  $MINIMEGA_DIR/bin/minimega -base=$MM_RUN_PATH -degree=$MM_MESH_DEGREE -nostdin=$MM_DAEMON -namespace=$MM_NAMESPACE -port=$MM_PORT -level=$MM_LOG_LEVEL -logfile=$MM_LOG_FILE ${@:1} &> /dev/null &
-	popd &>/dev/null
+  pushd $MINIMEGA_DIR &>/dev/null
+  $MINIMEGA_DIR/bin/minimega -base=$MM_RUN_PATH -degree=$MM_MESH_DEGREE -nostdin=$MM_DAEMON -context=$MM_CONTEXT -port=$MM_PORT -level=$MM_LOG_LEVEL -logfile=$MM_LOG_FILE ${@:1} &> /dev/null &
+  popd &>/dev/null
   sleep 1
   new_pid=`cat $MM_RUN_PATH/minimega.pid 2> /dev/null`
   if [ "$?" != "0" ]; then # if the process has already died

--- a/src/minimega/command_meshage.go
+++ b/src/minimega/command_meshage.go
@@ -223,7 +223,7 @@ func cliMeshageStatus(c *minicli.Command) *minicli.Response {
 	degree := meshageNode.GetDegree()
 	nodes := len(mesh)
 
-	resp.Header = []string{"mesh size", "degree", "peers", "namespace", "port"}
+	resp.Header = []string{"mesh size", "degree", "peers", "context", "port"}
 	resp.Tabular = [][]string{
 		[]string{
 			strconv.Itoa(nodes),


### PR DESCRIPTION
Update docs with renaming of `namespace` flag to `context`. Updated
daemon script with new flag.

Users should update their envs to rename $MM_NAMESPACE to $MM_CONTEXT.

Closes #497.