### PR TITLE
minimega: container tweaks

### DIFF
--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -745,6 +746,13 @@ func (vm *ContainerVM) launch() error {
 
 		if err := os.MkdirAll(vm.instancePath, os.FileMode(0700)); err != nil {
 			teardownf("unable to create VM dir: %v", err)
+		}
+
+		// check that there's a FS configured for this VM
+		if vm.FSPath == "" {
+			err := errors.New("unable to launch container without a configured filesystem")
+			vm.setError(err)
+			return err
 		}
 
 		// Check the disks and network interfaces are sane

--- a/src/minimega/vmconfig.go
+++ b/src/minimega/vmconfig.go
@@ -145,17 +145,9 @@ var containerConfigFns = map[string]VMConfigFns{
 	"hostname": vmConfigString(func(vm interface{}) *string {
 		return &mustContainerConfig(vm).Hostname
 	}, ""),
-	"init": {
-		Update: func(v interface{}, c *minicli.Command) error {
-			vm := mustContainerConfig(v)
-			vm.Init = c.ListArgs["init"]
-			return nil
-		},
-		Clear: func(vm interface{}) {
-			mustContainerConfig(vm).Init = []string{"/init"}
-		},
-		Print: func(vm interface{}) string { return fmt.Sprintf("%v", mustContainerConfig(vm).Init) },
-	},
+	"init": vmConfigSlice(func(vm interface{}) *[]string {
+		return &mustContainerConfig(vm).Init
+	}, "init", []string{"/init"}),
 	"preinit": vmConfigString(func(vm interface{}) *string {
 		return &mustContainerConfig(vm).Preinit
 	}, ""),
@@ -190,10 +182,10 @@ var kvmConfigFns = map[string]VMConfigFns{
 	}, "number", 0),
 	"qemu-append": vmConfigSlice(func(vm interface{}) *[]string {
 		return &mustKVMConfig(vm).QemuAppend
-	}, "qemu-append"),
+	}, "qemu-append", nil),
 	"disk": vmConfigSlice(func(vm interface{}) *[]string {
 		return &mustKVMConfig(vm).DiskPaths
-	}, "disk"),
+	}, "disk", nil),
 	"append": {
 		Update: func(vm interface{}, c *minicli.Command) error {
 			mustKVMConfig(vm).Append = strings.Join(c.ListArgs["arg"], " ")
@@ -281,7 +273,7 @@ func vmConfigInt(fn func(interface{}) *int, arg string, defaultVal int) VMConfig
 	}
 }
 
-func vmConfigSlice(fn func(interface{}) *[]string, name string) VMConfigFns {
+func vmConfigSlice(fn func(interface{}) *[]string, name string, defaultVal []string) VMConfigFns {
 	return VMConfigFns{
 		Update: func(vm interface{}, c *minicli.Command) error {
 			// Reset to empty list
@@ -294,7 +286,14 @@ func vmConfigSlice(fn func(interface{}) *[]string, name string) VMConfigFns {
 
 			return nil
 		},
-		Clear: func(vm interface{}) { *fn(vm) = []string{} },
+		Clear: func(vm interface{}) {
+			*fn(vm) = []string{}
+
+			if defaultVal != nil {
+				// copy values so that we don't change the defaults
+				*fn(vm) = append(*fn(vm), defaultVal...)
+			}
+		},
 		Print: func(vm interface{}) string {
 			if v := *fn(vm); len(v) > 0 {
 				return fmt.Sprintf("%v", v)

--- a/src/minimega/vmconfig_cli.go
+++ b/src/minimega/vmconfig_cli.go
@@ -411,7 +411,9 @@ during runtime because /proc is mounted read-only, add a preinit script:
 		HelpShort: "set the filesystem for containers",
 		HelpLong: `
 Set the filesystem to use for launching a container. This should be a root
-filesystem for a linux distribution (containing /dev, /proc, /sys, etc.)`,
+filesystem for a linux distribution (containing /dev, /proc, /sys, etc.)
+
+This must be specified in order to launch a container.`,
 		Patterns: []string{
 			"vm config filesystem [filesystem]",
 		},


### PR DESCRIPTION
Fixes #507. Return an error if the filesystem is not set for containers.

Tweak `vm config init` so that it uses the `vmConfigSlice` helper (specifically, needed `PrintCLI`). Fixes an issue when trying to launch containers with namespaces.
