### PR TITLE
minicli: fix compile error in test

### DIFF
--- a/src/minicli/minicli_test.go
+++ b/src/minicli/minicli_test.go
@@ -98,7 +98,7 @@ var testPrefixes = []struct {
 
 var testHandler = &Handler{
 	Patterns: []string{"test"},
-	Call: func(c *Command, out chan Responses) {
+	Call: func(c *Command, out chan<- Responses) {
 		// Do nothing
 	},
 }


### PR DESCRIPTION
Update function type to match update minicli.CLIFunc type.

Fixes #516.