### PR TITLE
iomeshage: fix #519

### DIFF
--- a/src/iomeshage/handler.go
+++ b/src/iomeshage/handler.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 )
 
 const (
@@ -23,10 +22,6 @@ const (
 
 const (
 	PART_SIZE = 10485760 // 10MB
-)
-
-var (
-	TIDLock sync.Mutex
 )
 
 // IOMessage is the only structure sent between iomeshage nodes (including
@@ -73,20 +68,23 @@ func (iom *IOMeshage) handleMessages() {
 // the receiver gives up. If we try to send on a closed channel, recover and
 // move on.
 func (iom *IOMeshage) handleResponse(m *IOMMessage) {
-	TIDLock.Lock()
-	defer TIDLock.Unlock()
+	iom.tidLock.Lock()
+	c, ok := iom.TIDs[m.TID]
+	iom.tidLock.Unlock()
 
-	if c, ok := iom.TIDs[m.TID]; ok {
-		defer func() {
-			recover()
-			if log.WillLog(log.DEBUG) {
-				log.Debugln("send on closed channel recovered")
-			}
-		}()
-		c <- m
-	} else {
+	if !ok {
 		log.Errorln("dropping message for invalid TID: ", m.TID)
+		return
 	}
+
+	defer func() {
+		recover()
+		if log.WillLog(log.DEBUG) {
+			log.Debugln("send on closed channel recovered")
+		}
+	}()
+
+	c <- m
 }
 
 // Handle incoming "get file info" messages by looking up if we have the file
@@ -200,8 +198,9 @@ func (iom *IOMeshage) fileInfo(filename string) ([]string, int64, error) {
 // Transactions need unique TIDs, and a corresponing channel to return
 // responses along. Register a TID and channel for the mux to respond along.
 func (iom *IOMeshage) registerTID(TID int64, c chan *IOMMessage) error {
-	TIDLock.Lock()
-	defer TIDLock.Unlock()
+	iom.tidLock.Lock()
+	defer iom.tidLock.Unlock()
+
 	if _, ok := iom.TIDs[TID]; ok {
 		return fmt.Errorf("TID already exists, collision?")
 	}
@@ -211,8 +210,9 @@ func (iom *IOMeshage) registerTID(TID int64, c chan *IOMMessage) error {
 
 // Unregister TIDs from the mux.
 func (iom *IOMeshage) unregisterTID(TID int64) {
-	TIDLock.Lock()
-	defer TIDLock.Unlock()
+	iom.tidLock.Lock()
+	defer iom.tidLock.Unlock()
+
 	if _, ok := iom.TIDs[TID]; !ok {
 		log.Errorln("TID does not exist")
 	} else {

--- a/src/iomeshage/iomeshage.go
+++ b/src/iomeshage/iomeshage.go
@@ -36,6 +36,7 @@ type IOMeshage struct {
 	node         *meshage.Node         // meshage node to use
 	Messages     chan *meshage.Message // Incoming messages from meshage
 	TIDs         map[int64]chan *IOMMessage
+	tidLock      sync.Mutex
 	transfers    map[string]*Transfer // current transfers
 	drainLock    sync.RWMutex
 	transferLock sync.RWMutex


### PR DESCRIPTION
Release TIDLock before sending on channel. Move TIDLock into IOMeshage
struct and rename to tidLock so that it is no longer exported.