### PR TITLE
minicli: add .alias and .unalias builtins

### DIFF
--- a/tests/builtins
+++ b/tests/builtins
@@ -8,6 +8,15 @@ vm launch kvm foo[1-3],bar
 .filter name~foo .column name vm info
 .filter name!~foo .column name vm info
 
+# Test aliases
+vm start foo2
+.alias
+.alias vmr=.column name .filter state=running vm info
+.alias
+vmr
+.unalias vmr
+.alias
+
 # Test disable headers
 .headers false .column name vm info
 .headers false
@@ -27,3 +36,4 @@ vm launch kvm foo[1-3],bar
 #.json true
 #.column name,state vm info
 #.json false
+

--- a/tests/builtins.want
+++ b/tests/builtins.want
@@ -20,6 +20,19 @@ foo3
 name
 bar
 
+## # Test aliases
+## vm start foo2
+## .alias
+## .alias vmr=.column name .filter state=running vm info
+## .alias
+alias | expansion
+vmr   | .column name .filter state=running vm info
+## vmr
+name
+foo2
+## .unalias vmr
+## .alias
+
 ## # Test disable headers
 ## .headers false .column name vm info
 bar
@@ -39,14 +52,14 @@ foo3
 name,state
 bar,BUILDING
 foo1,BUILDING
-foo2,BUILDING
+foo2,RUNNING
 foo3,BUILDING
 ## .csv true
 ## .column name,state vm info
 name,state
 bar,BUILDING
 foo1,BUILDING
-foo2,BUILDING
+foo2,RUNNING
 foo3,BUILDING
 ## .csv false
 
@@ -57,3 +70,4 @@ foo3,BUILDING
 ## #.json true
 ## #.column name,state vm info
 ## #.json false
+


### PR DESCRIPTION
Works similar to bash aliases. Updated minitests. Fixes #528.