### PR TITLE
meshage: fix data races

### DIFF
--- a/src/meshage/message.go
+++ b/src/meshage/message.go
@@ -262,11 +262,9 @@ floodLoop:
 			err := n.clientSend(j, m)
 			if err != nil {
 				// is j still a client?
-				n.clientLock.Lock()
-				if _, ok := n.clients[j]; ok {
+				if n.hasClient(j) {
 					log.Error("flood to client %v: %v", j, err)
 				}
-				n.clientLock.Unlock()
 			}
 		}(k, m)
 	}


### PR DESCRIPTION
Control access to Node.clients via Node.clientLock. Fixes #525.

Going to test this today.