### PR TITLE
minimega: add vms column to hosts API

### DIFF
--- a/src/minimega/stats.go
+++ b/src/minimega/stats.go
@@ -19,43 +19,64 @@ import (
 var hostCLIHandlers = []minicli.Handler{
 	{ // host
 		HelpShort: "report information about the host",
+		HelpLong: `
+Report information about the host:
+
+- bandwidth : RX/TX bandwidth stats
+- cpus : number of cpus
+- load : system load average
+- memtotal : total memory, in MB
+- memused : memory used, in MB
+- name : hostname
+- vms : number of VMs (in active namespace)
+- vmsall: number of VMs (regardless of namespace)
+		`,
 		Patterns: []string{
 			"host",
-			"host <name,>",
-			"host <memused,>",
-			"host <memtotal,>",
-			"host <load,>",
 			"host <bandwidth,>",
 			"host <cpus,>",
+			"host <load,>",
+			"host <memtotal,>",
+			"host <memused,>",
+			"host <name,>",
+			"host <vms,>",
+			"host <vmsall,>",
 		},
 		Call: wrapBroadcastCLI(cliHost),
 	},
 }
 
 var hostInfoFns = map[string]func() (string, error){
-	"name": func() (string, error) { return hostname, nil },
-	"memused": func() (string, error) {
-		_, used, err := hostStatsMemory()
-		return fmt.Sprintf("%v MB", used), err
-	},
-	"memtotal": func() (string, error) {
-		total, _, err := hostStatsMemory()
-		return fmt.Sprintf("%v MB", total), err
-	},
-	"cpus": func() (string, error) {
-		return fmt.Sprintf("%v", runtime.NumCPU()), nil
-	},
 	"bandwidth": func() (string, error) {
 		rx, tx := bridges.BandwidthStats()
 
 		return fmt.Sprintf("%.1f/%.1f (rx/tx MB/s)", rx, tx), nil
 	},
+	"cpus": func() (string, error) {
+		return strconv.Itoa(runtime.NumCPU()), nil
+	},
 	"load": hostStatsLoad,
+	"memtotal": func() (string, error) {
+		total, _, err := hostStatsMemory()
+		return fmt.Sprintf("%v MB", total), err
+	},
+	"memused": func() (string, error) {
+		_, used, err := hostStatsMemory()
+		return fmt.Sprintf("%v MB", used), err
+	},
+	"name": func() (string, error) { return hostname, nil },
+	"vms": func() (string, error) {
+		return strconv.Itoa(vms.Count()), nil
+	},
+	"vmsall": func() (string, error) {
+		return strconv.Itoa(vms.CountAll()), nil
+	},
 }
 
 // Preferred ordering of host info fields in tabular
 var hostInfoKeys = []string{
 	"name", "cpus", "load", "memused", "memtotal", "bandwidth",
+	"vms", "vmsall",
 }
 
 func cliHost(c *minicli.Command, resp *minicli.Response) error {

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -46,6 +46,30 @@ func (vms VMs) Clone() VMs {
 	return res
 }
 
+// Count of VMs in current namespace.
+func (vms VMs) Count() int {
+	vmLock.Lock()
+	defer vmLock.Unlock()
+
+	i := 0
+
+	for _, vm := range vms {
+		if inNamespace(vm) {
+			i += 1
+		}
+	}
+
+	return i
+}
+
+// CountAll is Count, regardless of namespace.
+func (vms VMs) CountAll() int {
+	vmLock.Lock()
+	defer vmLock.Unlock()
+
+	return len(vms)
+}
+
 // Save the commands to configure the targeted VMs to file.
 func (vms VMs) Save(file *os.File, target string) error {
 	vmLock.Lock()


### PR DESCRIPTION
Report the number of vms in the active namespace and across namespaces
for the host. Fixes #539.