### PR TITLE
minimega: fix VM nits

### DIFF
--- a/src/minimega/capture.go
+++ b/src/minimega/capture.go
@@ -102,7 +102,7 @@ func startCapturePcap(vm string, iface int, filename string) error {
 		return vmNotFound(vm)
 	}
 
-	config := v.Config()
+	config := getConfig(v)
 
 	if len(config.Networks) <= iface {
 		return fmt.Errorf("no such interface %v", iface)

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -580,7 +580,7 @@ func (vm *ContainerVM) Config() *BaseConfig {
 	return &vm.BaseConfig
 }
 
-func NewContainer(name string) *ContainerVM {
+func NewContainer(name string) (*ContainerVM, error) {
 	vm := new(ContainerVM)
 
 	vm.BaseVM = *NewBaseVM(name)
@@ -588,7 +588,11 @@ func NewContainer(name string) *ContainerVM {
 
 	vm.ContainerConfig = vmConfig.ContainerConfig.Copy() // deep-copy configured fields
 
-	return vm
+	if vm.FSPath == "" {
+		return nil, errors.New("unable to create container without a configured filesystem")
+	}
+
+	return vm, nil
 }
 
 func (vm *ContainerVM) Launch() error {

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -680,7 +680,14 @@ func (vm *ContainerVM) SaveConfig(w io.Writer) error {
 	cmds := []string{"clear vm config"}
 	cmds = append(cmds, saveConfig(baseConfigFns, &vm.BaseConfig)...)
 	cmds = append(cmds, saveConfig(containerConfigFns, &vm.ContainerConfig)...)
-	cmds = append(cmds, fmt.Sprintf("vm launch %s %s", vm.Type, vm.Name))
+
+	// Build launch string, make sure to preserve namespace if set
+	format := "vm launch %v %v"
+	if vm.Namespace != "" {
+		format = fmt.Sprintf("namespace %q %v", vm.Namespace, format)
+	}
+	cmds = append(cmds, fmt.Sprintf(format, vm.Type, vm.Name))
+	cmds = append(cmds, "", "") // add a blank line
 
 	_, err := io.WriteString(w, strings.Join(cmds, "\n"))
 	return err

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -683,6 +684,31 @@ func (vm *ContainerVM) SaveConfig(w io.Writer) error {
 
 	_, err := io.WriteString(w, strings.Join(cmds, "\n"))
 	return err
+}
+
+func (vm *ContainerVM) Conflicts(vm2 VM) error {
+	switch vm2 := vm2.(type) {
+	case *ContainerVM:
+		return vm.ConflictsContainer(vm2)
+	case *KvmVM:
+		return vm.BaseVM.conflicts(vm2.BaseVM)
+	}
+
+	return errors.New("unknown VM type")
+}
+
+// ConflictsContainer tests whether vm and vm2 share a filesystem and
+// returns an error if one of them is not running in snapshot mode. Also
+// checks whether the BaseVMs conflict.
+func (vm *ContainerVM) ConflictsContainer(vm2 *ContainerVM) error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	if vm.FSPath == vm2.FSPath && (!vm.Snapshot || !vm2.Snapshot) {
+		return fmt.Errorf("filesystem conflict with vm %v: %v", vm.Name, vm.FSPath)
+	}
+
+	return vm.BaseVM.conflicts(vm2.BaseVM)
 }
 
 func (vm *ContainerConfig) String() string {

--- a/src/minimega/dot.go
+++ b/src/minimega/dot.go
@@ -72,7 +72,7 @@ func cliDot(c *minicli.Command, resp *minicli.Response) error {
 
 		fmt.Fprintf(writer, "%v [style=filled, color=%v];\n", text, color)
 
-		for _, net := range vm.Config().Networks {
+		for _, net := range getConfig(vm).Networks {
 			fmt.Fprintf(writer, "%v -- %v\n", text, net.VLAN)
 			vlans[net.VLAN] = true
 		}

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -104,7 +104,7 @@ func (old KVMConfig) Copy() KVMConfig {
 	return res
 }
 
-func NewKVM(name string) *KvmVM {
+func NewKVM(name string) (*KvmVM, error) {
 	vm := new(KvmVM)
 
 	vm.BaseVM = *NewBaseVM(name)
@@ -114,7 +114,7 @@ func NewKVM(name string) *KvmVM {
 
 	vm.hotplug = make(map[int]string)
 
-	return vm
+	return vm, nil
 }
 
 // Launch a new KVM VM.

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -238,7 +238,14 @@ func (vm *KvmVM) SaveConfig(w io.Writer) error {
 	cmds := []string{"clear vm config"}
 	cmds = append(cmds, saveConfig(baseConfigFns, &vm.BaseConfig)...)
 	cmds = append(cmds, saveConfig(kvmConfigFns, &vm.KVMConfig)...)
-	cmds = append(cmds, fmt.Sprintf("vm launch %s %s", vm.Type, vm.Name))
+
+	// Build launch string, make sure to preserve namespace if set
+	format := "vm launch %v %v"
+	if vm.Namespace != "" {
+		format = fmt.Sprintf("namespace %q %v", vm.Namespace, format)
+	}
+	cmds = append(cmds, fmt.Sprintf(format, vm.Type, vm.Name))
+	cmds = append(cmds, "", "") // add a blank line
 
 	_, err := io.WriteString(w, strings.Join(cmds, "\n"))
 	return err

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -633,7 +633,7 @@ func (vm *BaseVM) writeTaps() error {
 }
 
 func (vm *BaseVM) conflicts(vm2 BaseVM) error {
-	// TODO: || vm.Namespace == ""????
+	// Return error if two VMs have same name or UUID
 	if vm.Namespace == vm2.Namespace {
 		if vm.Name == vm2.Name {
 			return fmt.Errorf("duplicate VM name: %s", vm.Name)
@@ -644,7 +644,15 @@ func (vm *BaseVM) conflicts(vm2 BaseVM) error {
 		}
 	}
 
-	// TODO: check for MAC address conflicts?
+	// Warn if we see two VMs that share a MAC on the same VLAN
+	for _, n := range vm.Networks {
+		for _, n2 := range vm2.Networks {
+			if n.MAC == n2.MAC && n.VLAN == n2.VLAN {
+				log.Warn("duplicate MAC/VLAN: %v/%v for %v and %v", vm.ID, vm2.ID)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -163,7 +163,7 @@ func init() {
 	gob.Register(&ContainerVM{})
 }
 
-func NewVM(name string, vmType VMType) VM {
+func NewVM(name string, vmType VMType) (VM, error) {
 	switch vmType {
 	case KVM:
 		return NewKVM(name)
@@ -171,7 +171,7 @@ func NewVM(name string, vmType VMType) VM {
 		return NewContainer(name)
 	}
 
-	return nil
+	return nil, errors.New("unknown VM type")
 }
 
 // NewBaseVM creates a new VM, copying the currently set configs. After a VM is

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -71,6 +71,10 @@ type VM interface {
 	// config to the io.Writer.
 	SaveConfig(io.Writer) error
 
+	// Conflicts checks whether the VMs have conflicting configs. Called
+	// when we create a VM but before adding it to the list of VMs.
+	Conflicts(VM) error
+
 	SetCCActive(bool)
 	UpdateBW()
 
@@ -193,6 +197,15 @@ func NewBaseVM(name string) *BaseVM {
 	// generate a UUID if we don't have one
 	if vm.UUID == "" {
 		vm.UUID = generateUUID()
+	}
+
+	// generate MAC addresses if any are unassigned. Don't bother checking
+	// for collisions -- based on the birthday paradox, there's only a
+	// 0.016% chance of collisions when running 10K VMs (one interface/VM).
+	for i := range vm.Networks {
+		if vm.Networks[i].MAC == "" {
+			vm.Networks[i].MAC = randomMac()
+		}
 	}
 
 	vm.kill = make(chan bool)
@@ -616,6 +629,22 @@ func (vm *BaseVM) writeTaps() error {
 		return fmt.Errorf("write instance taps file: %v", err)
 	}
 
+	return nil
+}
+
+func (vm *BaseVM) conflicts(vm2 BaseVM) error {
+	// TODO: || vm.Namespace == ""????
+	if vm.Namespace == vm2.Namespace {
+		if vm.Name == vm2.Name {
+			return fmt.Errorf("duplicate VM name: %s", vm.Name)
+		}
+
+		if vm.UUID == vm2.UUID {
+			return fmt.Errorf("duplicate VM UUID: %s", vm.UUID)
+		}
+	}
+
+	// TODO: check for MAC address conflicts?
 	return nil
 }
 

--- a/src/minimega/vmconfig_cli.go
+++ b/src/minimega/vmconfig_cli.go
@@ -526,11 +526,12 @@ func cliVmConfig(c *minicli.Command, resp *minicli.Response) error {
 			return vmNotFound(c.StringArgs["vm"])
 		}
 
-		vmConfig.BaseConfig = vm.Config().Copy()
 		switch vm := vm.(type) {
 		case *KvmVM:
+			vmConfig.BaseConfig = vm.BaseConfig.Copy()
 			vmConfig.KVMConfig = vm.KVMConfig.Copy()
 		case *ContainerVM:
+			vmConfig.BaseConfig = vm.BaseConfig.Copy()
 			vmConfig.ContainerConfig = vm.ContainerConfig.Copy()
 		}
 

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -30,22 +30,6 @@ type Tag struct {
 
 var vmLock sync.Mutex // lock for synchronizing access to vms
 
-// Clone creates a snapshot of the currently running VMs. It should be safe to
-// range over the returned value without holding the vmLock to perform
-// read-only operations. Does *not* filter the returned VMs to just those in
-// the active namespace.
-func (vms VMs) Clone() VMs {
-	vmLock.Lock()
-	defer vmLock.Unlock()
-
-	res := VMs{}
-	for k, v := range res {
-		res[k] = v
-	}
-
-	return res
-}
-
 // Save the commands to configure the targeted VMs to file.
 func (vms VMs) Save(file *os.File, target string) error {
 	vmLock.Lock()

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -88,6 +88,10 @@ func (vms VMs) Info(masks []string, resp *minicli.Response) {
 	res := VMs{} // for res.Data
 
 	for _, vm := range vms {
+		if !inNamespace(vm) {
+			continue
+		}
+
 		// Update dynamic fields before querying info
 		vm.UpdateBW()
 

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -254,9 +254,16 @@ func (vms VMs) Launch(names []string, vmType VMType) <-chan error {
 		// This uses the global vmConfigs so we have to create the VMs in the
 		// CLI thread (before the next command gets processed which could
 		// change the vmConfigs).
-		vm := NewVM(name, vmType)
+		vm, err := NewVM(name, vmType)
+		if err == nil {
+			for _, vm2 := range vms {
+				if err = vm2.Conflicts(vm); err != nil {
+					break
+				}
+			}
+		}
 
-		if err := vms.check(vm); err != nil {
+		if err != nil {
 			// Send from new goroutine to prevent deadlock since we haven't
 			// even returned the output channel yet... hopefully we won't spawn
 			// too many goroutines.
@@ -295,41 +302,6 @@ func (vms VMs) Launch(names []string, vmType VMType) <-chan error {
 	}()
 
 	return out
-}
-
-// check VM doesn't have any conflicts with the existing VMs
-func (vms VMs) check(vm VM) error {
-	// Make sure that there isn't an existing VM with the same name or UUID
-	for _, vm2 := range vms {
-		// We only care about name collisions if the VMs are running in the
-		// same namespace or if the collision is a non-namespaced VM with an
-		// already running namespaced VM.
-		namesEq := vm.GetName() == vm2.GetName()
-		uuidEq := vm.GetUUID() == vm2.GetUUID()
-		namespaceEq := (vm.GetNamespace() == vm2.GetNamespace())
-
-		if uuidEq && (namespaceEq || vm.GetNamespace() == "") {
-			return fmt.Errorf("vm launch duplicate UUID: %s", vm.GetUUID())
-		}
-
-		if namesEq && (namespaceEq || vm.GetNamespace() == "") {
-			return fmt.Errorf("vm launch duplicate VM name: %s", vm.GetName())
-		}
-	}
-
-	// Check the interfaces/disks/filesystem is sane
-	if err := vms.checkInterfaces(vm); err != nil {
-		return err
-	}
-
-	switch vm := vm.(type) {
-	case *KvmVM:
-		return vms.checkDisks(vm)
-	case *ContainerVM:
-		return vms.checkFilesystem(vm)
-	}
-
-	return errors.New("unknown VM type")
 }
 
 // Start VMs matching target.
@@ -571,149 +543,6 @@ func (vms VMs) apply(target string, concurrent bool, fn vmApplyFunc) []error {
 	}
 
 	return errs
-}
-
-// checkInterfaces checks to make sure that a VM's MAC addresses are unique.
-// Only returns an error if the MAC addresses are not unique for the interfaces
-// on the same VM. If multiple VMs share the same MAC address, logs a warning.
-// If a VM's MAC address is empty for a given interface, it randomly assigns a
-// valid, unique, MAC to that interface.
-func (vms VMs) checkInterfaces(vm VM) error {
-	macs := map[string]bool{}
-
-	for _, net := range getConfig(vm).Networks {
-		// Skip unassigned MACs
-		if net.MAC == "" {
-			continue
-		}
-
-		// Check if the VM already has this MAC for one of its interfaces
-		if _, ok := macs[net.MAC]; ok {
-			return fmt.Errorf("VM has same MAC for more than one interface -- %s", net.MAC)
-		}
-
-		macs[net.MAC] = true
-	}
-
-	for _, vm2 := range vms {
-		// Skip ourself
-		if vm.GetID() == vm2.GetID() {
-			continue
-		}
-
-		for _, net := range getConfig(vm2).Networks {
-			// VM must still be in the pre-building stage so it hasn't been
-			// assigned a MAC yet. We skip this case in order to supress
-			// duplicate MAC errors on an empty string.
-			if net.MAC == "" {
-				continue
-			}
-
-			// Warn if we see a conflict
-			if _, ok := macs[net.MAC]; ok {
-				log.Warn("VMs share MAC (%v) -- %v %v", net.MAC, vm.GetID(), vm2.GetID())
-			}
-
-			macs[net.MAC] = true
-		}
-	}
-
-	// Get a handle to the VM's actual Networks so that we can update them
-	var networks []NetConfig
-	switch vm := vm.(type) {
-	case *KvmVM:
-		networks = vm.Networks
-	case *ContainerVM:
-		networks = vm.Networks
-	default:
-		return errors.New("unable to CheckInterfaces for unknown VM type")
-	}
-
-	// Find any unassigned MACs and randomly generate a MAC for them
-	for i := range networks {
-		n := &networks[i]
-
-		if n.MAC != "" {
-			continue
-		}
-
-		// Loop until we don't have a conflict
-		for exists := true; exists; _, exists = macs[n.MAC] {
-			n.MAC = randomMac()
-		}
-
-		macs[n.MAC] = true
-	}
-
-	return nil
-}
-
-// checkDisks looks for Kvm VMs that share the same disk image and don't have
-// Snapshot set to true.
-func (vms VMs) checkDisks(vm *KvmVM) error {
-	// Disk path to whether it is a snapshot or not
-	disks := map[string]bool{}
-
-	// Record which disks are in use and whether they are being used as a
-	// snapshot or not by other VMs. If the same disk happens to be in use by
-	// different VMs and they have mismatched snapshot flags, assume that the
-	// disk is not being used in snapshot mode.
-	for _, vm2 := range vms {
-		// Skip ourself
-		if vm == vm2 {
-			continue
-		}
-
-		if vm2, ok := vm2.(*KvmVM); ok {
-			for _, disk := range vm2.DiskPaths {
-				disks[disk] = vm2.Snapshot || disks[disk]
-			}
-		}
-	}
-
-	// Check our disks to see if we're trying to use a disk that is in use by
-	// another VM (unless both are being used in snapshot mode).
-	for _, disk := range vm.DiskPaths {
-		if snapshot, ok := disks[disk]; ok && (snapshot != vm.Snapshot) {
-			return fmt.Errorf("disk path %v is already in use by another vm", disk)
-		}
-	}
-
-	return nil
-}
-
-// checkFilesystem looks for Container VMs that share the same filesystem
-// directory and don't have Snapshot set to true.
-func (vms VMs) checkFilesystem(vm *ContainerVM) error {
-	if vm.FSPath == "" {
-		return errors.New("unable to launch container without a configured filesystem")
-	}
-
-	// Disk path to whether it is a snapshot or not
-	disks := map[string]bool{}
-
-	// Record which disks are in use and whether they are being used as a
-	// snapshot or not by other VMs. If the same disk happens to be in use by
-	// different VMs and they have mismatched snapshot flags, assume that the
-	// disk is not being used in snapshot mode.
-	for _, vm2 := range vms {
-		// Skip ourself
-		if vm == vm2 { // ignore this vm
-			continue
-		}
-
-		if vm2, ok := vm2.(*ContainerVM); ok {
-			disks[vm2.FSPath] = vm2.Snapshot
-		}
-	}
-
-	// Check our disk to see if we're trying to use a disk that is in use by
-	// another VM (unless both are being used in snapshot mode).
-	if snapshot, ok := disks[vm.FSPath]; ok && (snapshot != vm.Snapshot) {
-		return fmt.Errorf("disk path %v is already in use by another vm", vm.FSPath)
-	}
-
-	return nil
 }
 
 // HostVMs gets all the VMs running on the specified remote host, filtered to

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -62,38 +62,8 @@ func (vms VMs) Save(file *os.File, target string) error {
 			return true, err
 		}
 
-		// build up the command list to re-launch this vm, first clear all
-		// previous configuration.
-		cmds := []string{"clear vm config"}
-
-		cmds = append(cmds, saveConfig(baseConfigFns, vm.Config())...)
-
-		switch vm := vm.(type) {
-		case *KvmVM:
-			cmds = append(cmds, saveConfig(kvmConfigFns, &vm.KVMConfig)...)
-		case *ContainerVM:
-			cmds = append(cmds, saveConfig(containerConfigFns, &vm.ContainerConfig)...)
-		default:
-		}
-
-		// build the string to actually launch the VM
-		arg := vm.GetName()
-		if arg == "" {
-			arg = "1"
-		}
-		cmds = append(cmds, fmt.Sprintf("vm launch %s %s", vm.GetType(), arg))
-
-		// and a blank line
-		cmds = append(cmds, "")
-
-		// write commands to file
-		for _, cmd := range cmds {
-			if _, err = file.WriteString(cmd + "\n"); err != nil {
-				return true, err
-			}
-		}
-
-		return true, nil
+		err = vm.SaveConfig(file)
+		return true, err
 	}
 
 	vms.apply(target, false, applyFunc)
@@ -611,7 +581,7 @@ func (vms VMs) apply(target string, concurrent bool, fn vmApplyFunc) []error {
 func (vms VMs) checkInterfaces(vm VM) error {
 	macs := map[string]bool{}
 
-	for _, net := range vm.Config().Networks {
+	for _, net := range getConfig(vm).Networks {
 		// Skip unassigned MACs
 		if net.MAC == "" {
 			continue
@@ -631,7 +601,7 @@ func (vms VMs) checkInterfaces(vm VM) error {
 			continue
 		}
 
-		for _, net := range vm2.Config().Networks {
+		for _, net := range getConfig(vm2).Networks {
 			// VM must still be in the pre-building stage so it hasn't been
 			// assigned a MAC yet. We skip this case in order to supress
 			// duplicate MAC errors on an empty string.

--- a/src/minimega/web.go
+++ b/src/minimega/web.go
@@ -260,7 +260,7 @@ func webVMs(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		config := vm.Config()
+		config := getConfig(vm)
 
 		vmMap := map[string]interface{}{
 			"host":   vm.GetHost(),

--- a/tests/vm_uuid.want
+++ b/tests/vm_uuid.want
@@ -4,7 +4,7 @@
 
 ## # Try to launch another without clearing the UUID
 ## vm launch kvm 1
-E: vm launch duplicate UUID: a5082fed-bc6f-4f77-8c1b-692ce5ef6302
+E: duplicate VM UUID: a5082fed-bc6f-4f77-8c1b-692ce5ef6302
 
 ## # Try to launch two VMs with the same UUID
 ## vm config uuid f3b8b039-2f26-43d0-908c-b0de030a44ed


### PR DESCRIPTION
Fix a bunch of smaller things that I didn't like about the VM interface.

Questions:
 * Do we want to warn if two VMs share the same MAC or return an error?
 * Can VMs share the same name if one is in the global namespace?
 * Should `vm save` record the namespace of the VM? (I think we want this)

@djfritz: thoughts?