### PR TITLE
bridge/minimega: fix #540

### DIFF
--- a/src/bridge/container.go
+++ b/src/bridge/container.go
@@ -30,7 +30,7 @@ func (b *Bridge) CreateContainerTap(t string, ns, mac string, vlan, index int) (
 	// Clean up the tap we just created, if it didn't already exist.
 	defer func() {
 		if err != nil {
-			if err := destroyVeth(tap); err != nil {
+			if err := destroyTap(tap); err != nil {
 				// Welp, we're boned
 				log.Error("zombie tap -- %v %v", tap, err)
 			}

--- a/src/bridge/ip.go
+++ b/src/bridge/ip.go
@@ -119,37 +119,9 @@ func DestroyTap(name string) error {
 func destroyTap(name string) error {
 	log.Info("destroying tuntap: %v", name)
 
-	out, err := processWrapper("ip", "tuntap", "del", "mode", "tap", name)
+	out, err := processWrapper("ip", "link", "del", name)
 	if err != nil {
 		return fmt.Errorf("destroy tap failed: %v: %v", err, out)
-	}
-
-	return nil
-}
-
-// destroyVeth destroys a veth device.
-func destroyVeth(name string) error {
-	// TODO: Needed?
-	if err := downInterface(name); err != nil {
-		return err
-	}
-
-	log.Info("destroying veth: %v", name)
-
-	args := []string{
-		"ip",
-		"link",
-		"del",
-		name,
-		"type",
-		"veth",
-		"peer",
-		"eth0",
-	}
-
-	out, err := processWrapper(args...)
-	if err != nil {
-		return fmt.Errorf("destroy veth failed: %v: %v", err, out)
 	}
 
 	return nil

--- a/src/bridge/tap.go
+++ b/src/bridge/tap.go
@@ -152,7 +152,7 @@ func (b *Bridge) RemoveTap(tap string) error {
 }
 
 // startIML starts the MAC listener for this bridge.
-func (b *Bridge) startIML() {
+func (b *Bridge) startIML() error {
 	// use openflow to redirect arp and icmp6 traffic to the local tap
 	filters := []string{
 		"dl_type=0x0806,actions=local,normal",
@@ -161,18 +161,17 @@ func (b *Bridge) startIML() {
 
 	for _, filter := range filters {
 		if err := b.addOpenflow(filter); err != nil {
-			log.Error("cannot start ip learner on bridge: %v", err)
-			return
+			return fmt.Errorf("start ip learner failed: %v", err)
 		}
 	}
 
 	iml, err := ipmac.NewLearner(b.Name)
 	if err != nil {
-		log.Error("cannot start ip learner on bridge: %v", err)
-		return
+		return fmt.Errorf("start ip learner failed: %v", err)
 	}
 
 	b.IPMacLearner = iml
+	return nil
 }
 
 // addOpenflow adds an openflow rule to the bridge using `ovs-ofctl`.

--- a/src/bridge/tap.go
+++ b/src/bridge/tap.go
@@ -128,10 +128,6 @@ func (b *Bridge) destroyTap(t string) error {
 
 	tap.Defunct = true
 
-	if tap.Container {
-		return destroyVeth(tap.Name)
-	}
-
 	return destroyTap(tap.Name)
 }
 


### PR DESCRIPTION
Created a local err in `Container.launch` when calling `bridges.Get`. If
this failed, we wouldn't register a MAC with the bridge so when we tried
to unregister it, minimega panicked. Move networking code to a separate
function so it's easier to return an error if there's a problem rather
than break out of the loop. Fixed some potential issues in the bridge
code when creating and destroying a bridge.