### PR TITLE
minimega: abort after error in read

### DIFF
--- a/src/minimega/misc_cli.go
+++ b/src/minimega/misc_cli.go
@@ -174,15 +174,21 @@ func cliRead(c *minicli.Command, respChan chan<- minicli.Responses) {
 			continue
 		}
 
+		var abort bool
+
 		for resp := range RunCommands(cmd) {
 			respChan <- resp
 
 			// Stop processing if any of the responses have an error.
 			for _, r := range resp {
 				if r.Error != "" {
-					break
+					abort = true
 				}
 			}
+		}
+
+		if abort {
+			break
 		}
 	}
 


### PR DESCRIPTION
Actually stop reading the file if there's an error. Fixes #560.