### PR TITLE
let vms control their destiny

### DIFF
--- a/doc/content/articles/tutorials/cc.article
+++ b/doc/content/articles/tutorials/cc.article
@@ -260,3 +260,13 @@ For example, to tunnel local port 4444 on each client to a web server reachable
 from the minimega host:
 
 	minimega$ cc rtunnel 4444 myserver 80
+
+* Tags
+
+The `miniccc` client can add tags to the info for the VM the client is running
+on. This enables third party tools to upstream information about a VM to
+minimega via miniccc. Tags are key/value pairs, and are added simply by using
+the `-tag` switch on a running `miniccc` instance. 
+
+    ./miniccc -tag foo bar
+

--- a/src/miniccc/main.go
+++ b/src/miniccc/main.go
@@ -28,7 +28,7 @@ var (
 	f_path     = flag.String("path", "/tmp/miniccc", "path to store files in")
 	f_serial   = flag.String("serial", "", "use serial device instead of tcp")
 	f_family   = flag.String("family", "tcp", "[tcp,unix] family to dial on")
-	f_tag      = flag.String("tag", "", "add a key:value tag in minimega for this vm")
+	f_tag      = flag.Bool("tag", false, "add a key value tag in minimega for this vm")
 	c          *ron.Client
 )
 
@@ -55,12 +55,25 @@ func main() {
 
 	logSetup()
 
+	if *f_tag {
+		err := updateTag()
+		if err != nil {
+			log.Errorln(err)
+		}
+		return
+	}
+
 	// signal handling
 	sig := make(chan os.Signal, 1024)
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 
+	// attempt to set up the base path
+	err := os.MkdirAll(*f_path, os.FileMode(0777))
+	if err != nil {
+		log.Fatal("mkdir base path: %v", err)
+	}
+
 	// start a ron client
-	var err error
 	c, err = ron.NewClient(*f_family, *f_port, *f_parent, *f_serial, *f_path)
 	if err != nil {
 		log.Fatal("creating ron node: %v", err)
@@ -113,4 +126,35 @@ func commandSocketHandle(conn net.Conn) {
 
 	log.Debug("adding key/value: %v : %v", k, v)
 	c.Tag(k, v)
+}
+
+func updateTag() error {
+	host := filepath.Join(*f_path, "miniccc")
+
+	args := flag.Args()
+	if len(args) != 2 {
+		return fmt.Errorf("inavlid arguments: %v", args)
+	}
+
+	k := args[0]
+	v := args[1]
+
+	conn, err := net.Dial("unix", host)
+	if err != nil {
+		return err
+	}
+
+	enc := gob.NewEncoder(conn)
+
+	err = enc.Encode(k)
+	if err != nil {
+		return err
+	}
+
+	err = enc.Encode(v)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/src/minimega/cc.go
+++ b/src/minimega/cc.go
@@ -49,12 +49,23 @@ func ccPrefixIDs(prefix string) []int {
 
 func ccStart() {
 	var err error
-	ccNode, err = ron.NewServer(*f_ccPort, *f_iomBase)
+	ccNode, err = ron.NewServer(*f_ccPort, *f_iomBase, ccUpdateTags)
 	if err != nil {
 		log.Fatalln(fmt.Errorf("creating cc node %v", err))
 	}
 
 	log.Debug("created ron node at %v %v", ccPort, *f_base)
+}
+
+// TODO: this is currently global and should filter on the client's namespace,
+// but cc isn't fully namespace aware, so here we are...
+func ccUpdateTags(uuid string, t map[string]string) {
+	vm := vms.FindVMNoNamespace(uuid)
+	if vm != nil {
+		for k, v := range t {
+			vm.SetTag(k, v)
+		}
+	}
 }
 
 func ccClear(what string) (err error) {

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -231,7 +231,7 @@ func (vms VMs) FindKvmVM(s string) (*KvmVM, error) {
 
 // findKvmVm is FindKvmVM without locking vmLock.
 func (vms VMs) findKvmVM(s string) (*KvmVM, error) {
-	vm := vms.findVM(s)
+	vm := vms.findVM(s, true)
 	if vm == nil {
 		return nil, vmNotFound(s)
 	}

--- a/src/minimega/vnc.go
+++ b/src/minimega/vnc.go
@@ -75,7 +75,12 @@ func NewVNCClient(host, idOrName string) (*vncClient, error) {
 		// (can call hostVMs instead of HostVMs). Since we're using not using
 		// the vms global, we don't need to acquire the vmLock (can call findVM
 		// instead of FindVM).
-		vm = hostVMs(host).findVM(idOrName)
+
+		// TODO(fritz): should this be namespace aware? If someone sets
+		// a namespace on the cli and then someone on the web interface
+		// attempts to connect and this is checking namespaces then it
+		// will fail right?
+		vm = hostVMs(host).findVM(idOrName, false)
 	}
 
 	if vm == nil {

--- a/src/ron/client.go
+++ b/src/ron/client.go
@@ -78,6 +78,8 @@ func (c *Client) Tag(k, v string) {
 	c.lock.Lock()
 	c.Tags[k] = v
 	c.lock.Unlock()
+
+	go c.heartbeat()
 }
 
 // commandHandler sorts and filters incoming commands from a ron server.

--- a/src/ron/client.go
+++ b/src/ron/client.go
@@ -67,9 +67,17 @@ func (c *Client) dial(family string, parent string, port int) {
 func (c *Client) Respond(r *Response) {
 	log.Debug("ron Respond: %v", r.ID)
 
-	c.responseLock.Lock()
+	c.lock.Lock()
 	c.Responses = append(c.Responses, r)
-	c.responseLock.Unlock()
+	c.lock.Unlock()
+}
+
+func (c *Client) Tag(k, v string) {
+	log.Debug("ron Tag: %v %v", k, v)
+
+	c.lock.Lock()
+	c.Tags[k] = v
+	c.lock.Unlock()
 }
 
 // commandHandler sorts and filters incoming commands from a ron server.
@@ -166,10 +174,12 @@ func (c *Client) heartbeat() {
 	cin.MAC = macs
 	cin.IP = ips
 
-	c.responseLock.Lock()
+	c.lock.Lock()
 	cin.Responses = c.Responses
 	c.Responses = []*Response{}
-	c.responseLock.Unlock()
+	cin.Tags = c.Tags
+	c.Tags = make(map[string]string)
+	c.lock.Unlock()
 
 	m := &Message{
 		Type:   MESSAGE_CLIENT,
@@ -180,10 +190,11 @@ func (c *Client) heartbeat() {
 	log.Debug("heartbeat %v", cin)
 
 	c.out <- m
+
 	c.lastHeartbeat = time.Now()
 }
 
-// periodically sent the client heartbeat.
+// periodically send the client heartbeat.
 func (c *Client) periodic() {
 	rate := time.Duration(HEARTBEAT_RATE * time.Second)
 	for {

--- a/src/ron/ron.go
+++ b/src/ron/ron.go
@@ -74,8 +74,9 @@ type Client struct {
 
 	Version string
 
-	Responses    []*Response // response queue, consumed and cleared by the heartbeat
-	responseLock sync.Mutex
+	Responses []*Response // response queue, consumed and cleared by the heartbeat
+
+	lock sync.Mutex // lock for ephemeral data to send up (responses, new tags)
 
 	commands      chan map[int]*Command // unordered, unfiltered list of incoming commands from the server
 	lastHeartbeat time.Time             // last heartbeat watchdog time

--- a/src/ron/server.go
+++ b/src/ron/server.go
@@ -445,6 +445,7 @@ func (s *Server) responseHandler() {
 			c.MAC = cin.MAC
 			c.Checkin = time.Now()
 			c.Processes = cin.Processes
+			s.updateTags(cin.UUID, cin.Tags)
 		} else {
 			log.Error("unknown client %v", cin.UUID)
 			s.clientLock.Unlock()


### PR DESCRIPTION
... via updating tags from miniccc

This adds a -tag flag to miniccc which allows adding a tag to that VM's tag map. A few internal changes had to be made to support this. Tags are sent on-demand as well, so this can be used for fast information passing. 

Don't merge until after #564 is fixed and this gets updated against it.

@jcrussell 