### PR TITLE
minimega: printVLAN in `vm info`

### DIFF
--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -546,7 +546,7 @@ func (vm *BaseVM) info(key string) (string, error) {
 			if net.VLAN == DisconnectedVLAN {
 				vals = append(vals, "disconnected")
 			} else {
-				vals = append(vals, fmt.Sprintf("%v", net.VLAN))
+				vals = append(vals, printVLAN(net.VLAN))
 			}
 		}
 	case "bridge":


### PR DESCRIPTION
Use printVLAN in `vm info` so that we show the network names.