### PR TITLE
minimega: make `file:` work with `cc send`

### DIFF
--- a/src/minimega/cc_cli.go
+++ b/src/minimega/cc_cli.go
@@ -348,14 +348,20 @@ func cliCCFileSend(c *minicli.Command, resp *minicli.Response) error {
 	}
 
 	// Add new files to send, expand globs
-	for _, fglob := range c.ListArgs["file"] {
-		files, err := filepath.Glob(filepath.Join(*f_iomBase, fglob))
+	for _, arg := range c.ListArgs["file"] {
+		arg := filepath.Clean(arg)
+
+		if !strings.HasPrefix(arg, *f_iomBase) {
+			arg = filepath.Join(*f_iomBase, arg)
+		}
+
+		files, err := filepath.Glob(arg)
 		if err != nil {
-			return fmt.Errorf("non-existent files %v", fglob)
+			return fmt.Errorf("non-existent files %v", arg)
 		}
 
 		if len(files) == 0 {
-			return fmt.Errorf("no such file %v", fglob)
+			return fmt.Errorf("no such file %v", arg)
 		}
 
 		for _, f := range files {


### PR DESCRIPTION
Only prepend the files dir to the argument when it is not already in the
files dir. This allows the `file:` prefix to work with `cc send` so you
can push files from any node.