### PR TITLE
Send over `smtpReportChan` on new mail.

### DIFF
--- a/src/protonuke/smtp.go
+++ b/src/protonuke/smtp.go
@@ -297,6 +297,8 @@ func smtpServer(p string) {
 		client := NewSMTPClientSession(conn)
 
 		go client.Handler()
+
+		smtpReportChan <- 1
 	}
 }
 


### PR DESCRIPTION
Have `smtpServer()` report when it accepts a new connection.

Fixes #579