### PR TITLE
protonuke: timeouts and ipv6

### DIFF
--- a/src/protonuke/hosts.go
+++ b/src/protonuke/hosts.go
@@ -132,7 +132,7 @@ func isIPv6(ip string) bool {
 		if len(d) <= 6 && i == len(d)-1 && isIPv4(v) {
 			return true
 		}
-		octet, err := strconv.Atoi(v)
+		octet, err := strconv.ParseInt(v, 16, 64)
 		if err != nil {
 			return false
 		}

--- a/src/protonuke/http.go
+++ b/src/protonuke/http.go
@@ -66,10 +66,10 @@ func httpClient(protocol string) {
 		},
 	}
 
-	// TODO: max client read timeouts configurable?
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   30 * time.Second,
+		// TODO: max client read timeouts configurable?
+		//Timeout:   30 * time.Second,
 	}
 
 	for {
@@ -113,10 +113,10 @@ func httpTLSClient(protocol string) {
 		transport.TLSClientConfig.MaxVersion = version
 	}
 
-	// TODO: max client read timeouts configurable?
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   30 * time.Second,
+		// TODO: max client read timeouts configurable?
+		//Timeout:   30 * time.Second,
 	}
 
 	for {


### PR DESCRIPTION
You can't do an Atoi on a hex address.

If you set an HTTP timeout of 30 seconds, it'll give up on a transfer after 30 seconds. I fixed that.