### PR TITLE
minimega: remove kill timeout a.k.a. I'll never let go

### DIFF
--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -530,7 +530,6 @@ func (vm *KvmVM) launch() error {
 
 	// Create goroutine to wait to kill the VM
 	go func() {
-		sendKillAck := false
 		select {
 		case <-waitChan:
 			log.Info("VM %v exited", vm.ID)
@@ -538,10 +537,6 @@ func (vm *KvmVM) launch() error {
 			log.Info("Killing VM %v", vm.ID)
 			cmd.Process.Kill()
 			<-waitChan
-			sendKillAck = true // wait to ack until we've cleaned up
-		}
-
-		if sendKillAck {
 			killAck <- vm.ID
 		}
 	}()

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -393,14 +393,9 @@ func (vms VMs) Kill(target string) []error {
 
 outer:
 	for len(killedVms) > 0 {
-		select {
-		case id := <-killAck:
-			log.Info("VM %v killed", id)
-			delete(killedVms, id)
-		case <-time.After(COMMAND_TIMEOUT * time.Second):
-			log.Error("vm kill timeout")
-			break outer
-		}
+		id := <-killAck
+		log.Info("VM %v killed", id)
+		delete(killedVms, id)
 	}
 
 	for id := range killedVms {


### PR DESCRIPTION
If we have lots of containers and call `vm kill all` then we will likely
timeout when receiving the ACKs. Removed the timeout so that we'll
always wait until everything has ACK'ed.

There's probably a race condition if the VM quits while we are trying to
kill it.