### PR TITLE
minirouter: fix interface sorting in findEth()

### DIFF
--- a/src/minirouter/ip.go
+++ b/src/minirouter/ip.go
@@ -178,22 +178,3 @@ func ipAdd(idx int, ip string) error {
 
 	return nil
 }
-
-func findEth(idx int) (string, error) {
-	var ethNames []string
-	dirs, err := ioutil.ReadDir("/sys/class/net")
-	if err != nil {
-		return "", err
-	} else {
-		for _, n := range dirs {
-			if n.Name() == "lo" {
-				continue
-			}
-			ethNames = append(ethNames, n.Name())
-		}
-	}
-	if idx < len(ethNames) {
-		return ethNames[idx], nil
-	}
-	return "", fmt.Errorf("no such network")
-}

--- a/src/minirouter/misc.go
+++ b/src/minirouter/misc.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	log "minilog"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var (
+	trim = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+)
+
+type SortEth []string
+
+func (a SortEth) Len() int      { return len(a) }
+func (a SortEth) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a SortEth) Less(i, j int) bool {
+	// sort on the integer part of an interface name, which we assume will
+	// be in the form of string+int
+	idxI, err := strconv.Atoi(strings.TrimLeft(a[i], trim))
+	if err != nil {
+		log.Errorln(err)
+		return false
+	}
+	idxJ, err := strconv.Atoi(strings.TrimLeft(a[j], trim))
+	if err != nil {
+		log.Errorln(err)
+		return false
+	}
+	return idxI < idxJ
+}
+
+func findEth(idx int) (string, error) {
+	var ethNames SortEth
+	dirs, err := ioutil.ReadDir("/sys/class/net")
+	if err != nil {
+		return "", err
+	} else {
+		for _, n := range dirs {
+			if n.Name() == "lo" {
+				continue
+			}
+			ethNames = append(ethNames, n.Name())
+		}
+	}
+	sort.Sort(ethNames)
+	if idx < len(ethNames) {
+		return ethNames[idx], nil
+	}
+	return "", fmt.Errorf("no such network")
+}


### PR DESCRIPTION
We currently get interface names by an index and allow ioutil.ReadDir to sort names for us. This works with fewer than 10 interfaces (as it was tested). When you get greater than 10, you end up with sorted names like:

eth0
eth1
eth10
eth11
eth2
eth3...

This PR adds a sort interface to sort on the integer part of the string instead.

@jcrussell 