### PR TITLE
minimega: screenshots are now integral to vms

### DIFF
--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -739,7 +739,7 @@ func (vm *ContainerVM) ConflictsContainer(vm2 *ContainerVM) error {
 }
 
 func (vm *ContainerVM) Screenshot(size int) ([]byte, error) {
-	return nil, errors.New("Cannot take screenshot of container")
+	return nil, errors.New("cannot take screenshot of container")
 }
 
 func (vm *ContainerConfig) String() string {

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -738,6 +738,10 @@ func (vm *ContainerVM) ConflictsContainer(vm2 *ContainerVM) error {
 	return vm.BaseVM.conflicts(vm2.BaseVM)
 }
 
+func (vm *ContainerVM) Screenshot(size int) ([]byte, error) {
+	return nil, errors.New("Cannot take screenshot of container")
+}
+
 func (vm *ContainerConfig) String() string {
 	// create output
 	var o bytes.Buffer

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -64,6 +64,8 @@ type VM interface {
 	String() string
 	Info(string) (string, error)
 
+	Screenshot(int) ([]byte, error)
+
 	Tag(string) string          // Tag gets the value of the given tag
 	SetTag(string, string)      // SetTag updates the given tag
 	GetTags() map[string]string // GetTags returns a copy of the tags

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -725,7 +725,7 @@ func cliVmScreenshot(c *minicli.Command, resp *minicli.Response) error {
 
 	vm := vms.FindVM(c.StringArgs["vm"])
 	if vm == nil {
-		return errors.New("no such vm")
+		return vmNotFound(c.StringArgs["vm"])
 	}
 
 	data, err := vm.Screenshot(max)

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -723,10 +723,7 @@ func cliVmScreenshot(c *minicli.Command, resp *minicli.Response) error {
 		max = v
 	}
 
-	vm, err := vms.FindKvmVM(c.StringArgs["vm"])
-	if err != nil {
-		return err
-	}
+	vm := vms.FindVM(c.StringArgs["vm"])
 
 	data, err := vm.Screenshot(max)
 	if err != nil {

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -724,6 +724,9 @@ func cliVmScreenshot(c *minicli.Command, resp *minicli.Response) error {
 	}
 
 	vm := vms.FindVM(c.StringArgs["vm"])
+	if vm == nil {
+		return errors.New("no such vm")
+	}
 
 	data, err := vm.Screenshot(max)
 	if err != nil {


### PR DESCRIPTION
KVM VMs aren't the only type that may be able to do screenshots. Instead,
we can make Screenshot part of all VM types, and just have containers
return an error if you call it.

@djfritz @jcrussell 