### PR TITLE
minimega: add VNC shim

### DIFF
--- a/misc/web/js/glue.js
+++ b/misc/web/js/glue.js
@@ -55,7 +55,7 @@ function screenshotURL (vm, size) {
 
 // Generate the appropriate URL for requesting a VNC connection
 function vncURL (vm) {
-    return "./vnc#" + vm.host + ":" + (5900 + vm.id) + ":" + vm.name
+    return "./vnc#" + vm.host + ":" + (vm.vnc_port) + ":" + vm.name
 }
 
 // Get the screenshot for the requested row, or restore it from the cache of screenshots if available
@@ -192,7 +192,7 @@ function updateTables () {
         toAppend.find(".screenshot-state").addClass(COLOR_CLASSES[vm.state]).html(vm.state);
 
         if (vm.type != "kvm") toAppend.find(".connect-vm-button").css("visibility", "hidden");
-        
+
         screenshotList.push({
             "name": vm.name,
             "model": toAppend.get(0).outerHTML

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -792,8 +792,8 @@ func (vm *ContainerVM) launch() error {
 
 	// write the config for this vm
 	config := vm.BaseConfig.String() + vm.ContainerConfig.String()
-	writeOrDie(filepath.Join(vm.instancePath, "config"), config)
-	writeOrDie(filepath.Join(vm.instancePath, "name"), vm.Name)
+	writeOrDie(vm.path("config"), config)
+	writeOrDie(vm.path("name"), vm.Name)
 
 	// the child process will communicate with a fake console using pipes
 	// to mimic stdio, and a fourth pipe for logging before the child execs
@@ -839,12 +839,12 @@ func (vm *ContainerVM) launch() error {
 
 	// create the uuid path that will bind mount into sysfs in the
 	// container
-	uuidPath := filepath.Join(vm.instancePath, "uuid")
+	uuidPath := vm.path("uuid")
 	ioutil.WriteFile(uuidPath, []byte(vm.UUID+"\n"), 0400)
 
 	// create fifos
 	for i := 0; i < vm.Fifos; i++ {
-		p := filepath.Join(vm.instancePath, fmt.Sprintf("fifo%v", i))
+		p := vm.path(fmt.Sprintf("fifo%v", i))
 		if err = syscall.Mkfifo(p, 0660); err != nil {
 			log.Error("fifo: %v", err)
 			vm.setError(err)
@@ -1127,8 +1127,8 @@ func (vm *ContainerVM) unlinkNetns() error {
 // create an overlay mount (linux 3.18 or greater) is snapshot mode is
 // being used.
 func (vm *ContainerVM) overlayMount() error {
-	vm.effectivePath = filepath.Join(vm.instancePath, "fs")
-	workPath := filepath.Join(vm.instancePath, "fs_work")
+	vm.effectivePath = vm.path("fs")
+	workPath := vm.path("fs_work")
 
 	err := os.MkdirAll(vm.effectivePath, 0755)
 	if err != nil {
@@ -1169,7 +1169,7 @@ func (vm *ContainerVM) overlayUnmount() error {
 }
 
 func (vm *ContainerVM) console(stdin, stdout, stderr *os.File) {
-	socketPath := filepath.Join(vm.instancePath, "console")
+	socketPath := vm.path("console")
 	l, err := net.Listen("unix", socketPath)
 	if err != nil {
 		log.Error("could not start unix domain socket console on vm %v: %v", vm.ID, err)

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -62,7 +62,7 @@ type KvmVM struct {
 	q   qmp.Conn // qmp connection for this vm
 
 	vncShim net.Listener // shim for VNC connections
-	vncPort int
+	VNCPort int
 }
 
 // Ensure that KvmVM implements the VM interface
@@ -254,7 +254,7 @@ func (vm *KvmVM) Info(mask string) (string, error) {
 
 	switch mask {
 	case "vnc_port":
-		return strconv.Itoa(vm.vncPort), nil
+		return strconv.Itoa(vm.VNCPort), nil
 	}
 
 	return "", fmt.Errorf("invalid mask: %s", mask)
@@ -446,7 +446,7 @@ func (vm *KvmVM) connectVNC() error {
 
 	// Keep track of shim so that we can close it later
 	vm.vncShim = l
-	vm.vncPort = l.Addr().(*net.TCPAddr).Port
+	vm.VNCPort = l.Addr().(*net.TCPAddr).Port
 
 	go func() {
 		defer l.Close()

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -416,7 +416,7 @@ func (vm *KvmVM) connectQMP() (err error) {
 	delay := QMP_CONNECT_DELAY * time.Millisecond
 
 	for count := 0; count < QMP_CONNECT_RETRY; count++ {
-		vm.q, err = qmp.Dial(vm.qmpPath())
+		vm.q, err = qmp.Dial(vm.path("qmp"))
 		if err == nil {
 			log.Debug("qmp dial to %v successful", vm.ID)
 			return
@@ -445,8 +445,8 @@ func (vm *KvmVM) launch() error {
 
 	// write the config for this vm
 	config := vm.BaseConfig.String() + vm.KVMConfig.String()
-	writeOrDie(filepath.Join(vm.instancePath, "config"), config)
-	writeOrDie(filepath.Join(vm.instancePath, "name"), vm.Name)
+	writeOrDie(vm.path("config"), config)
+	writeOrDie(vm.path("name"), vm.Name)
 
 	// create and add taps if we are associated with any networks
 	for i := range vm.Networks {
@@ -542,7 +542,7 @@ func (vm *KvmVM) launch() error {
 	go qmpLogger(vm.ID, vm.q)
 
 	// connect cc
-	ccPath := filepath.Join(vm.instancePath, "cc")
+	ccPath := vm.path("cc")
 	if err := ccNode.DialSerial(ccPath); err != nil {
 		log.Warn("unable to connect to cc for vm %v: %v", vm.ID, err)
 	}
@@ -561,11 +561,6 @@ func (vm *KvmVM) launch() error {
 	}()
 
 	return nil
-}
-
-// return the path to the qmp socket
-func (vm *KvmVM) qmpPath() string {
-	return filepath.Join(vm.instancePath, "qmp")
 }
 
 // build the horribly long qemu argument string

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -721,7 +721,7 @@ func (vm *BaseVM) setState(s VMState) {
 	log.Debug("updating vm %v state: %v -> %v", vm.ID, vm.State, s)
 	vm.State = s
 
-	err := ioutil.WriteFile(filepath.Join(vm.instancePath, "state"), []byte(s.String()), 0666)
+	err := ioutil.WriteFile(vm.path("state"), []byte(s.String()), 0666)
 	if err != nil {
 		log.Error("write instance state file: %v", err)
 	}
@@ -754,7 +754,7 @@ func (vm *BaseVM) writeTaps() error {
 		taps = append(taps, net.Tap)
 	}
 
-	f := filepath.Join(vm.instancePath, "taps")
+	f := vm.path("taps")
 	if err := ioutil.WriteFile(f, []byte(strings.Join(taps, "\n")), 0666); err != nil {
 		return fmt.Errorf("write instance taps file: %v", err)
 	}
@@ -784,6 +784,11 @@ func (vm *BaseVM) conflicts(vm2 BaseVM) error {
 	}
 
 	return nil
+}
+
+// path joins instancePath with provided path
+func (vm *BaseVM) path(s string) string {
+	return filepath.Join(vm.instancePath, s)
 }
 
 // inNamespace tests whether vm is part of active namespace, if there is one.

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -154,12 +154,13 @@ var vmInfo = []string{
 	"id", "name", "state", "namespace", "memory", "vcpus", "type", "vlan",
 	"bridge", "tap", "mac", "ip", "ip6", "bandwidth", "migrate", "disk",
 	"snapshot", "initrd", "kernel", "cdrom", "append", "uuid", "cc_active",
-	"tags", "qos",
+	"vnc_port", "tags", "qos",
 }
 
 // Valid names for output masks for `vm summary`, in preferred output order
 var vmInfoLite = []string{
 	"id", "name", "state", "namespace", "type", "vlan", "uuid", "cc_active",
+	"vnc_port",
 }
 
 func init() {

--- a/src/minimega/vnc.go
+++ b/src/minimega/vnc.go
@@ -67,9 +67,9 @@ func NewVNCClient(host, idOrName string) (*vncClient, error) {
 		host = hostname
 	}
 
-	var vm VM
+	var vm *KvmVM
 	if host == hostname {
-		vm = vms.FindVM(idOrName)
+		vm, _ = vms.FindKvmVM(idOrName)
 	} else {
 		// LOCK: This is only invoked via the CLI so we already hold cmdLock
 		// (can call hostVMs instead of HostVMs). Since we're using not using
@@ -80,14 +80,14 @@ func NewVNCClient(host, idOrName string) (*vncClient, error) {
 		// a namespace on the cli and then someone on the web interface
 		// attempts to connect and this is checking namespaces then it
 		// will fail right?
-		vm = hostVMs(host).findVM(idOrName, false)
+		vm, _ = hostVMs(host).findKvmVM(idOrName)
 	}
 
 	if vm == nil {
 		return nil, vmNotFound(host + ":" + idOrName)
 	}
 
-	rhost := fmt.Sprintf("%v:%v", host, 5900+vm.GetID())
+	rhost := fmt.Sprintf("%v:%v", host, vm.VNCPort)
 
 	c := &vncClient{
 		Rhost: rhost,

--- a/src/minimega/web.go
+++ b/src/minimega/web.go
@@ -272,6 +272,10 @@ func webVMs(w http.ResponseWriter, r *http.Request) {
 			"memory": config.Memory,
 		}
 
+		if vm, ok := vm.(*KvmVM); ok {
+			vmMap["vnc_port"] = vm.VNCPort
+		}
+
 		if config.Networks == nil {
 			vmMap["network"] = make([]int, 0)
 		} else {


### PR DESCRIPTION
qemu now creates a domain socket for VNC connections to the VM. minimega creates a TCP<->domain socket shim that proxies all traffic using a random port for TCP. Updated new field in `vm info` and `vm summary` to lookup the port. Updated web to connect noVNC to the non-5900 based ports.