### PR TITLE
docs: add more cgroup setup info to documents

### DIFF
--- a/doc/content/articles/installing.article
+++ b/doc/content/articles/installing.article
@@ -86,6 +86,25 @@ If you plan to launch and maintain VMs, you'll need the following programs:
 - ssh/scp
 - kill
 
+*** Grub note
+
+If you intend to run Linux containers, you need to have the `memory`
+cgroup enabled, but Debian (and some other distros) do not enable it by
+default. If you try to start a container and get an error, you may need
+to enable the memory cgroup.
+
+To enable it, add the following to your kernel boot parameters:
+
+	cgroup_enable=memory
+
+On Debian, you can do this by opening /etc/default/grub and adding that
+parameter to the `GRUB_CMDLINE_LINUX_DEFAULT` line. It should end up
+looking something like this:
+
+	GRUB_CMDLINE_LINUX_DEFAULT="quiet cgroup_enable=memory"
+
+Then run update-grub and reboot for the change to take effect.
+
 ** Network configuration
 
 (This section is primarily relevant for people running minimega on a cluster)

--- a/doc/content/articles/vmtypes.article
+++ b/doc/content/articles/vmtypes.article
@@ -172,5 +172,8 @@ required for minimega to boot `container` type VMs. On debian based linux hosts
 
 	cgroup_enable=memory
 
-to the kernel boot parameters (in grub or otherwise) to enable the `memory`
-cgroup.
+to the kernel boot parameters (in GRUB or otherwise) to enable the `memory`
+cgroup. To enable this in GRUB on Debian, open /etc/default/grub and edit the
+`GRUB_CMDLINE_LINUX_DEFAULT` line to include the cgroup parameter. Then run
+`update-grub` to update the GRUB config. When you reboot, the cgroup will be
+enabled.


### PR DESCRIPTION
Give concrete example of how to turn on the memory cgroup for Debian.