### PR TITLE
minimega: add -ltermcap to goreadline LDFLAGS

### DIFF
--- a/src/goreadline/goreadline.go
+++ b/src/goreadline/goreadline.go
@@ -5,7 +5,7 @@
 // Very simple libreadline binding.
 package goreadline
 
-// #cgo LDFLAGS: -lreadline
+// #cgo LDFLAGS: -lreadline -ltermcap
 // #include <stdio.h>
 // #include <stdlib.h>
 // #include <readline/readline.h>


### PR DESCRIPTION
Although it's not needed on Debian, some distros (e.g. Slackware) appear to
need this. Tested that it still compiles on Debian.