### PR TITLE
Meshage fix

### DIFF
--- a/src/meshage/node.go
+++ b/src/meshage/node.go
@@ -117,7 +117,7 @@ func NewNode(name string, namespace string, degree uint, port int, version strin
 		log.Fatal("NewNode: %v", err)
 	}
 	for _, iface := range ifaces {
-		// Check if this is one of the broadcast interfaces
+		// Check if this is one of the allowed broadcast interfaces
 		if len(broadcastInterfaces) > 0 {
 			found := false
 			for _, bc := range broadcastInterfaces {
@@ -127,9 +127,11 @@ func NewNode(name string, namespace string, degree uint, port int, version strin
 				}
 			}
 			if !found {
-				break
+				// we specified interfaces, but this is not one of them.
+				continue
 			}
 		}
+
 		addrs, err := iface.Addrs()
 		if err != nil {
 			log.Error("NewNode: %v", err)

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -219,7 +219,10 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	interfaces := strings.Split(*f_interfaces, ",")
+	var interfaces []string
+	if *f_interfaces != "" {
+		interfaces = strings.Split(*f_interfaces, ",")
+	}
 	meshageInit(host, *f_context, *f_degree, *f_msaTimeout, *f_port, interfaces)
 
 	// start the cc service

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -40,6 +40,7 @@ var (
 	f_degree     = flag.Uint("degree", 0, "meshage starting degree")
 	f_msaTimeout = flag.Uint("msa", 10, "meshage MSA timeout")
 	f_port       = flag.Int("port", 9000, "meshage port to listen on")
+	f_interfaces = flag.String("interfaces", "", "comma-separated list of interfaces on which to broadcast meshage. default all.")
 	f_ccPort     = flag.Int("ccport", 9002, "cc port to listen on")
 	f_force      = flag.Bool("force", false, "force minimega to run even if it appears to already be running")
 	f_nostdin    = flag.Bool("nostdin", false, "disable reading from stdin, useful for putting minimega in the background")
@@ -214,7 +215,8 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	meshageInit(host, *f_context, *f_degree, *f_msaTimeout, *f_port)
+	interfaces := strings.Split(*f_interfaces, ",")
+	meshageInit(host, *f_context, *f_degree, *f_msaTimeout, *f_port, interfaces)
 
 	// start the cc service
 	ccStart()

--- a/src/minimega/meshage.go
+++ b/src/minimega/meshage.go
@@ -43,8 +43,8 @@ func init() {
 	gob.Register(iomeshage.IOMMessage{})
 }
 
-func meshageInit(host string, namespace string, degree, msaTimeout uint, port int) {
-	meshageNode, meshageMessages = meshage.NewNode(host, namespace, degree, port, version.Revision)
+func meshageInit(host string, namespace string, degree, msaTimeout uint, port int, interfaces []string) {
+	meshageNode, meshageMessages = meshage.NewNode(host, namespace, degree, port, version.Revision, interfaces)
 
 	meshageCommandChan = make(chan *meshage.Message, 1024)
 	meshageResponseChan = make(chan *meshage.Message, 1024)

--- a/src/minimega/meshage.go
+++ b/src/minimega/meshage.go
@@ -43,7 +43,7 @@ func init() {
 	gob.Register(iomeshage.IOMMessage{})
 }
 
-func meshageInit(host string, namespace string, degree, msaTimeout uint, port int, interfaces []string) {
+func meshageInit(host string, namespace string, degree, msaTimeout uint, port int, broadcastInterfaces []string) {
 	meshageNode, meshageMessages = meshage.NewNode(host, namespace, degree, port, version.Revision, interfaces)
 
 	meshageCommandChan = make(chan *meshage.Message, 1024)


### PR DESCRIPTION
Minimega used to only broadcast on one interface. Now, by default, it broadcasts on all ipv4 interfaces. If you specify "-interfaces eth0,eth1" it will only broadcast on eth0 and eth1.

@djfritz @jcrussell 
