### PR TITLE
miniccc/ron: two updates for windows clients

### DIFF
--- a/src/miniccc/main.go
+++ b/src/miniccc/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"ron"
+	"runtime"
 	"syscall"
 	"version"
 )
@@ -56,6 +57,10 @@ func main() {
 	logSetup()
 
 	if *f_tag {
+		if runtime.GOOS == "windows" {
+			log.Fatalln("tag updates are not available on windows miniccc clients")
+		}
+
 		err := updateTag()
 		if err != nil {
 			log.Errorln(err)
@@ -82,7 +87,9 @@ func main() {
 	log.Debug("starting ron client with UUID: %v", c.UUID)
 
 	// create a listening domain socket for tag updates
-	go commandSocketStart()
+	if runtime.GOOS != "windows" {
+		go commandSocketStart()
+	}
 
 	<-sig
 	// terminate

--- a/src/ron/server.go
+++ b/src/ron/server.go
@@ -450,7 +450,7 @@ func (s *Server) responseHandler() {
 					vm.SetTag(k, v)
 				}
 			} else {
-				log.Errorln("no registered vm %v", cin.UUID)
+				log.Error("no registered vm %v", cin.UUID)
 			}
 		} else {
 			log.Error("unknown client %v", cin.UUID)

--- a/src/ron/uuid_windows.go
+++ b/src/ron/uuid_windows.go
@@ -44,8 +44,7 @@ func getUUID() (string, error) {
 		return "", fmt.Errorf("wmic run: %v", err)
 	}
 
-	uuid := strings.TrimSpace(sOut.String())
-	uuid = unmangleUUID(uuid)
+	uuid := unmangleUUID(strings.TrimSpace(sOut.String()))
 	if sErr.String() != "" {
 		return "", fmt.Errorf("wmic failed: %v %v", sOut.String(), sErr.String())
 	}
@@ -59,12 +58,17 @@ func unmangleUUID(uuid string) string {
 	//	XXXXXXXX-XXXX-XXXX-YYYY-YYYYYYYYYYYY
 	// the X characters are reversed at 2 byte intervals (big/little endian for a uuid?)
 	var ret string
-	uuid = strings.ToLower(uuid)
 	re := regexp.MustCompile("[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}")
 
-	u := re.FindString(uuid)
+	u := re.FindString(strings.ToLower(uuid))
 	if uuid == "" {
 		log.Fatal("uuid failed to match uuid format: %v", uuid)
+	}
+
+	log.Debug("found uuid: %v", u)
+
+	if getOSVer() != "Windows XP" {
+		return u
 	}
 
 	ret += u[6:8]
@@ -81,4 +85,171 @@ func unmangleUUID(uuid string) string {
 
 	log.Debug("mangled/unmangled uuid: %v %v", u, ret)
 	return ret
+}
+
+func getOSVer() string {
+	var fullVersion string
+
+	//Get CurrentVersion
+	cmd := exec.Command("reg", "query",
+		"HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+		"/v", "CurrentVersion")
+	cvBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Warnln("failed reg query: CurrentVersion")
+	}
+	cvStr := strings.Split(string(cvBytes), "    ")
+	currentVersion := strings.TrimSpace(cvStr[len(cvStr)-1])
+
+	//Get CurrentBuild
+	cmd = exec.Command("reg", "query",
+		"HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+		"/v", "CurrentBuild")
+
+	cbBytes, err := cmd.CombinedOutput()
+
+	if err != nil {
+		log.Warnln("failed reg query: CurrentBuild")
+		fullVersion = currentVersion
+	} else {
+		cbStr := strings.Split(string(cbBytes), "    ")
+		currentBuild := strings.TrimSpace(cbStr[len(cbStr)-1])
+
+		fullVersion = currentVersion + "." + currentBuild
+	}
+
+	switch fullVersion {
+	case "1.04":
+		return "Windows 1.0"
+	case "2.11":
+		return "Windows 2.0"
+	case "3":
+		return "Windows 3.0"
+	case "3.11":
+		return "Windows for Workgroups 3.11"
+	case "2250":
+		return "Whistler Server"
+	case "2257":
+		return "Whistler Server"
+	case "2267":
+		return "Whistler Server"
+	case "2410":
+		return "Whistler Server"
+	case "3.10.528":
+		return "Windows NT 3.1"
+	case "3.5.807":
+		return "Windows NT Workstation 3.5"
+	case "3.51.1057":
+		return "Windows NT Workstation 3.51"
+	case "4.0.1381":
+		return "Windows Workstation 4.0"
+	case "4.0.950":
+		return "Windows 95"
+	case "4.00.950":
+		return "Windows 95"
+	case "4.00.1111":
+		return "Windows 95"
+	case "4.03.1212-1214":
+		return "Windows 95"
+	case "4.03.1214":
+		return "Windows 95"
+	case "4.1.1998":
+		return "Windows 98"
+	case "4.1.2222":
+		return "Windows 98"
+	case "4.90.2476":
+		return "Windows Millenium"
+	case "4.90.3000":
+		return "Windows Me"
+	case "5.00.1515":
+		return "Windows NT 5.00"
+	case "5.00.2031":
+		return "Windows 2000"
+	case "5.00.2128":
+		return "Windows 2000"
+	case "5.00.2183":
+		return "Windows 2000"
+	case "5.00.2195":
+		return "Windows 2000"
+	case "5.0.2195":
+		return "Windows 2000"
+	case "5.1.2505":
+		return "Windows XP"
+	case "5.1.2600":
+		return "Windows XP"
+	case "5.2.3790":
+		return "Windows XP"
+		//      Conflicts with Windows XP.
+		//	case "5.2.3790": return "Windows Home Server"
+		//	case "5.2.3790": return "Windows Server 2003"
+	case "5.2.3541":
+		return "Windows .NET Server"
+	case "5.2.3590":
+		return "Windows .NET Server"
+	case "5.2.3660":
+		return "Windows .NET Server"
+	case "5.2.3718":
+		return "Windows .NET Server 2003"
+	case "5.2.3763":
+		return "Windows Server 2003"
+	case "6.0.5048":
+		return "Windows Longhorn"
+	case "6.0.5112":
+		return "Windows Vista"
+	case "6.0.5219":
+		return "Windows Vista"
+	case "6.0.5259":
+		return "Windows Vista"
+	case "6.0.5270":
+		return "Windows Vista"
+	case "6.0.5308":
+		return "Windows Vista"
+	case "6.0.5342":
+		return "Windows Vista"
+	case "6.0.5381":
+		return "Windows Vista"
+	case "6.0.5384":
+		return "Windows Vista"
+	case "6.0.5456":
+		return "Windows Vista"
+	case "6.0.5472":
+		return "Windows Vista"
+	case "6.0.5536":
+		return "Windows Vista"
+	case "6.0.5600":
+		return "Windows Vista"
+	case "6.0.5700":
+		return "Windows Vista"
+	case "6.0.5728":
+		return "Windows Vista"
+	case "6.0.5744":
+		return "Windows Vista"
+	case "6.0.5808":
+		return "Windows Vista"
+	case "6.0.5824":
+		return "Windows Vista"
+	case "6.0.5840":
+		return "Windows Vista"
+	case "6.0.6000":
+		return "Windows Vista"
+	case "6.0.6001":
+		return "Windows Server 2008"
+	case "6.0.6002":
+		return "Windows Vista"
+	case "6.1.7600":
+		return "Windows 7"
+		//      Conflicts with Windows 7.  Need more granularity (.16385)
+		//	case "6.1.7600": return "Windows Server 2008 R2, RTM (Release to Manufacturing)"
+	case "6.1.7601":
+		return "Windows 7"
+	case "6.2.9200":
+		return "Windows 8"
+		//	Conflicts with Windows 8.  Not sure how to tell these apart
+		//	case "6.2.9200": return "Windows Server 2012"
+	case "6.2.8102":
+		return "Windows Server 2012"
+	case "6.3.9600":
+		return "Windows 8.1"
+	}
+	return "unknown"
 }


### PR DESCRIPTION
- Don't create the domain socket on windows clients... because we can't
- Don't unmangle the UUID on non-windows xp clients

@jcrussell @floren @mwisely 