### PR TITLE
qos info now prints network indexes

### DIFF
--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -322,7 +322,7 @@ func (vm *BaseConfig) NetworkString() string {
 	return fmt.Sprintf("[%s]", strings.Join(parts, " "))
 }
 
-func (vm *BaseConfig) QosString(b, t string) string {
+func (vm *BaseConfig) QosString(b, t, i string) string {
 	var val string
 	br, err := getBridge(b)
 	if err != nil {
@@ -334,7 +334,7 @@ func (vm *BaseConfig) QosString(b, t string) string {
 		return ""
 	}
 
-	val += fmt.Sprintf("%s: ", t)
+	val += fmt.Sprintf("%s: ", i)
 	for _, op := range ops {
 		if op.Type == bridge.Delay {
 			val += fmt.Sprintf("delay %s ", op.Value)
@@ -695,8 +695,8 @@ func (vm *BaseVM) info(key string) (string, error) {
 			vals = append(vals, s)
 		}
 	case "qos":
-		for _, v := range vm.Networks {
-			s := vm.QosString(v.Bridge, v.Tap)
+		for idx, v := range vm.Networks {
+			s := vm.QosString(v.Bridge, v.Tap, strconv.Itoa(idx))
 			if s != "" {
 				vals = append(vals, s)
 			}

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -40,6 +40,7 @@ info include:
 - ip         : IPv4 address
 - ip6        : IPv6 address
 - bandwidth  : stats regarding bandwidth usage
+- qos        : quality-of-service contraints on network interfaces
 - tags       : any additional information attached to the VM
 - uuid       : QEMU system uuid
 - cc_active  : whether cc is active

--- a/tests/vm_qos.want
+++ b/tests/vm_qos.want
@@ -6,32 +6,32 @@
 ## qos add vm0 0 loss 5
 ## .columns qos vm info
 qos
-[mega_tap1: loss 5]
+[0: loss 5]
 
 ## qos add vm0 0 delay 100ms
 ## .columns qos vm info
 qos
-[mega_tap1: loss 5 delay 100ms]
+[0: loss 5 delay 100ms]
 
 ## qos add vm0 0 rate 1 mbit
 ## .columns qos vm info
 qos
-[mega_tap1: rate 1mbit loss 5 delay 100ms]
+[0: rate 1mbit loss 5 delay 100ms]
 
 ## qos add vm0 0 delay 200ms
 ## .columns qos vm info
 qos
-[mega_tap1: rate 1mbit loss 5 delay 200ms]
+[0: rate 1mbit loss 5 delay 200ms]
 
 ## qos add vm0 0 rate 2 mbit
 ## .columns qos vm info
 qos
-[mega_tap1: rate 2mbit loss 5 delay 200ms]
+[0: rate 2mbit loss 5 delay 200ms]
 
 ## qos add vm0 0 loss 0.50
 ## .columns qos vm info
 qos
-[mega_tap1: rate 2mbit loss 0.50 delay 200ms]
+[0: rate 2mbit loss 0.50 delay 200ms]
 
 ## qos add vm0 0 loss 150
 E: `150` is not a valid loss percentage


### PR DESCRIPTION
Fixes #606. Qos info is now printed using the network index and updated the qos tests to reflect this change.