### PR TITLE
minimega/minicli/ranges: moving code

### DIFF
--- a/src/minimega/namespace_cli.go
+++ b/src/minimega/namespace_cli.go
@@ -89,6 +89,11 @@ func cliNamespace(c *minicli.Command, respChan chan<- minicli.Responses) {
 		return
 	}
 
+	hosts := []string{}
+	for h := range ns.Hosts {
+		hosts = append(hosts, h)
+	}
+
 	// TODO: Make this pretty or divide it up somehow
 	resp.Response = fmt.Sprintf(`Namespace: "%v"
 Hosts: %v
@@ -96,7 +101,7 @@ Taps: %v
 Number of queuedVMs: %v
 
 Schedules:
-`, namespace, ns.Hosts, ns.Taps, len(ns.queuedVMs))
+`, namespace, ranges.UnsplitList(hosts), ns.Taps, len(ns.queuedVMs))
 
 	var o bytes.Buffer
 	w := new(tabwriter.Writer)

--- a/src/ranges/trie.go
+++ b/src/ranges/trie.go
@@ -2,7 +2,7 @@
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 
-package minicli
+package ranges
 
 import (
 	"fmt"

--- a/src/ranges/trie_test.go
+++ b/src/ranges/trie_test.go
@@ -2,7 +2,7 @@
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 
-package minicli
+package ranges
 
 import "testing"
 


### PR DESCRIPTION
Moving `compressHosts` function from minicli to ranges as `UnsplitList`.
This function was previously used by minicli's output formatter to
condense a list of hostnames into a pretty range. We now use this when
printing the hosts that belong to a namespace.