### PR TITLE
minimega: change external program reporting from Warn to Info

### DIFF
--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -199,7 +199,8 @@ func main() {
 
 	err = checkExternal()
 	if err != nil {
-		log.Warnln(err.Error())
+		// Info, because in many cases missing binaries are just fine.
+		log.Infoln(err.Error())
 	}
 
 	// attempt to set up the base path


### PR DESCRIPTION
When minimega starts, main() calls checkExternal() to make sure all our
external programs exist. However, as minimega grows, we come to call on
more external programs that aren't sensible for all use cases. For
example, an experiment using containers and minirouter will probably
not need dnsmasq or kvm. We can still notify at the Info level, and
if the user attempts to use a missing binary, he will receive an error
message at that time.