### PR TITLE
minimega: check exists before unmounting

### DIFF
--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -1501,10 +1501,12 @@ func containerNuke() {
 		log.Errorln(err)
 	}
 
-	// umount cgroup_root
-	err = syscall.Unmount(CGROUP_ROOT, 0)
-	if err != nil {
-		log.Error("cgroup_root unmount: %v", err)
+	// umount cgroup_root, if it exists
+	if _, err := os.Stat(CGROUP_ROOT); err == nil {
+		err = syscall.Unmount(CGROUP_ROOT, 0)
+		if err != nil {
+			log.Error("cgroup_root unmount: %v", err)
+		}
 	}
 
 	// remove meganet_* from /var/run/netns


### PR DESCRIPTION
Check that CGROUP_ROOT exists before trying to unmount it. Removes:

ERROR container.go:1507: cgroup_root unmount: no such file or directory

Fixes #633.