### PR TITLE
minimega: fix concurrent map access

### DIFF
--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -608,6 +608,7 @@ func (vm *ContainerVM) Copy() VM {
 	defer vm2.lock.Unlock()
 
 	// Make deep copies
+	vm2.BaseConfig = vm.BaseConfig.Copy()
 	vm2.ContainerConfig = vm.ContainerConfig.Copy()
 
 	return vm2

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -133,6 +133,7 @@ func (vm *KvmVM) Copy() VM {
 	defer vm2.lock.Unlock()
 
 	// Make deep copies
+	vm2.BaseConfig = vm.BaseConfig.Copy()
 	vm2.KVMConfig = vm.KVMConfig.Copy()
 
 	return vm2


### PR DESCRIPTION
Need to copy the BaseConfig which contains the VM's tags in the VM Copy
functions. Fixes #653. Tested with 20k curls to localhost:9001/vms/.

@floren 