### PR TITLE
protonuke: smarter file size parsing

### DIFF
--- a/src/protonuke/flag.go
+++ b/src/protonuke/flag.go
@@ -1,0 +1,51 @@
+// Copyright (2016) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type FileSize uint
+
+// DefaultFileSize is 3MB
+const DefaultFileSize = FileSize(3 * 1 << 20)
+
+func (f *FileSize) Set(s string) error {
+	for i, suffix := range []string{"B", "KB", "MB"} {
+		if strings.HasSuffix(s, suffix) {
+			v, err := strconv.Atoi(strings.TrimSuffix(s, suffix))
+			if err != nil {
+				continue
+			}
+
+			*f = FileSize(v * (1 << uint(10*i)))
+			return nil
+		}
+	}
+
+	// Assume MB
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return errors.New("invalid file size, expected value[B,KB,MB]")
+	}
+
+	*f = FileSize(v * (1 << 20))
+	return nil
+}
+
+func (f *FileSize) String() string {
+	for i, suffix := range []string{"B", "KB", "MB"} {
+		if *f < 2<<uint(10*(i+1)) {
+			return fmt.Sprintf("%v%v", *f/(1<<uint(10*i)), suffix)
+		}
+	}
+
+	// Default is MB
+	return fmt.Sprintf("%vMB", *f/(1<<20))
+}

--- a/src/protonuke/http.go
+++ b/src/protonuke/http.go
@@ -389,7 +389,7 @@ func httpMakeImage() {
 	s := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(s)
 
-	pixelcount := *f_httpImageSize * 1024 * 1024 / 4
+	pixelcount := f_httpImageSize / 4
 	side := int(math.Sqrt(float64(pixelcount)))
 	log.Debug("Image served will be %v by %v", side, side)
 

--- a/src/protonuke/protonuke.go
+++ b/src/protonuke/protonuke.go
@@ -15,35 +15,38 @@ import (
 )
 
 var (
-	f_serve         = flag.Bool("serve", false, "act as a server for enabled services")
-	f_dns           = flag.Bool("dns", false, "enable dns service")
-	f_dnsv4         = flag.Bool("dnsv4", false, "dns client only requests type A records")
-	f_dnsv6         = flag.Bool("dnsv6", false, "dns client only requests type AAAA records")
-	f_randomhosts   = flag.Bool("random-hosts", false, "if no host range is supplied return a randomly generated ip")
-	f_http          = flag.Bool("http", false, "enable http service")
-	f_https         = flag.Bool("https", false, "enable https (TLS) service")
-	f_httproot      = flag.String("httproot", "", "serve directory with http(s) instead of the builtin page generator")
-	f_ssh           = flag.Bool("ssh", false, "enable ssh service")
-	f_smtp          = flag.Bool("smtp", false, "enable smtp service")
-	f_smtpUser      = flag.String("smtpuser", "", "specify a particular user to send email to for the given domain, otherwise random")
-	f_smtpTls       = flag.Bool("smtptls", true, "enable or disable sending mail with TLS")
-	f_smtpmail      = flag.String("smtpmail", "", "send email from a given file instead of the builtin email corpus")
-	f_mean          = flag.Duration("u", time.Duration(1000*time.Millisecond), "mean time between actions")
-	f_stddev        = flag.Duration("s", time.Duration(0), "standard deviation between actions")
-	f_min           = flag.Duration("min", time.Duration(0), "minimum time allowable for events")
-	f_max           = flag.Duration("max", time.Duration(60000*time.Millisecond), "maximum time allowable for events")
-	f_loglevel      = flag.String("level", "warn", "set log level: [debug, info, warn, error, fatal]")
-	f_log           = flag.Bool("log", true, "log on stderr")
-	f_logfile       = flag.String("logfile", "", "also log to file")
-	f_v4            = flag.Bool("ipv4", true, "use IPv4. Can be used together with -ipv6")
-	f_v6            = flag.Bool("ipv6", true, "use IPv6. Can be used together with -ipv4")
-	f_report        = flag.Duration("report", time.Duration(10*time.Second), "time between reports, set to 0 to disable")
-	f_httpImageSize = flag.Int("httpimagesize", 3, "size of image, in megabytes, to serve in http/https pages")
-	f_httpTLSCert   = flag.String("httptlscert", "", "file containing public certificate for TLS")
-	f_httpTLSKey    = flag.String("httptlskey", "", "file containing private key for TLS")
-	f_tlsVersion    = flag.String("tlsversion", "", "Select a TLS version for the client: tls1.0, tls1.1, tls1.2")
-	hosts           map[string]string
-	keys            []string
+	f_serve       = flag.Bool("serve", false, "act as a server for enabled services")
+	f_dns         = flag.Bool("dns", false, "enable dns service")
+	f_dnsv4       = flag.Bool("dnsv4", false, "dns client only requests type A records")
+	f_dnsv6       = flag.Bool("dnsv6", false, "dns client only requests type AAAA records")
+	f_randomhosts = flag.Bool("random-hosts", false, "if no host range is supplied return a randomly generated ip")
+	f_http        = flag.Bool("http", false, "enable http service")
+	f_https       = flag.Bool("https", false, "enable https (TLS) service")
+	f_httproot    = flag.String("httproot", "", "serve directory with http(s) instead of the builtin page generator")
+	f_ssh         = flag.Bool("ssh", false, "enable ssh service")
+	f_smtp        = flag.Bool("smtp", false, "enable smtp service")
+	f_smtpUser    = flag.String("smtpuser", "", "specify a particular user to send email to for the given domain, otherwise random")
+	f_smtpTls     = flag.Bool("smtptls", true, "enable or disable sending mail with TLS")
+	f_smtpmail    = flag.String("smtpmail", "", "send email from a given file instead of the builtin email corpus")
+	f_mean        = flag.Duration("u", time.Duration(1000*time.Millisecond), "mean time between actions")
+	f_stddev      = flag.Duration("s", time.Duration(0), "standard deviation between actions")
+	f_min         = flag.Duration("min", time.Duration(0), "minimum time allowable for events")
+	f_max         = flag.Duration("max", time.Duration(60000*time.Millisecond), "maximum time allowable for events")
+	f_loglevel    = flag.String("level", "warn", "set log level: [debug, info, warn, error, fatal]")
+	f_log         = flag.Bool("log", true, "log on stderr")
+	f_logfile     = flag.String("logfile", "", "also log to file")
+	f_v4          = flag.Bool("ipv4", true, "use IPv4. Can be used together with -ipv6")
+	f_v6          = flag.Bool("ipv6", true, "use IPv6. Can be used together with -ipv4")
+	f_report      = flag.Duration("report", time.Duration(10*time.Second), "time between reports, set to 0 to disable")
+	f_httpTLSCert = flag.String("httptlscert", "", "file containing public certificate for TLS")
+	f_httpTLSKey  = flag.String("httptlskey", "", "file containing private key for TLS")
+	f_tlsVersion  = flag.String("tlsversion", "", "Select a TLS version for the client: tls1.0, tls1.1, tls1.2")
+
+	// See main for registering with flag
+	f_httpImageSize = DefaultFileSize
+
+	hosts map[string]string
+	keys  []string
 )
 
 func usage() {
@@ -59,6 +62,10 @@ func usage() {
 
 func main() {
 	flag.Usage = usage
+
+	// Add non-builtin flag type
+	flag.Var(&f_httpImageSize, "httpimagesize", "size of image to serve in http/https pages (optional suffixes: B, KB, MB. default: MB)")
+
 	flag.Parse()
 
 	sig := make(chan os.Signal, 1024)


### PR DESCRIPTION
Parse the file size as a custom flag type so that we can have suffixes
like B/KB/MB. Default is still MB but now we can specify images smaller
than 1MB using the B or KB suffix.