### PR TITLE
nfcat: tool to read binary netflow

### DIFF
--- a/src/gonetflow/gonetflow.go
+++ b/src/gonetflow/gonetflow.go
@@ -285,38 +285,15 @@ func (nf *Netflow) process(n int, b []byte) (*Packet, error) {
 	numRecords := (n - NETFLOW_HEADER_LEN) / NETFLOW_RECORD_LEN
 
 	p := &Packet{
-		Header: &Header{
-			Version:   int(b[1]), // skip the first byte
-			Count:     int(b[3]),
-			Sequence:  (int32(b[16]) << 24) + (int32(b[17]) << 16) + (int32(b[18]) << 8) + (int32(b[19])),
-			Uptime:    (uint32(b[4]) << 24) + (uint32(b[5]) << 16) + (uint32(b[6]) << 8) + (uint32(b[7])),
-			EpochSec:  (uint32(b[8]) << 24) + (uint32(b[9]) << 16) + (uint32(b[10]) << 8) + (uint32(b[11])),
-			EpochNsec: (uint32(b[12]) << 24) + (uint32(b[13]) << 16) + (uint32(b[14]) << 8) + (uint32(b[15])),
-		},
-		Raw: b[:n],
+		Header: DecodeHeader(b),
+		Raw:    b[:n],
 	}
 
 	for i := 0; i < numRecords; i++ {
 		offset := (i * NETFLOW_RECORD_LEN) + NETFLOW_HEADER_LEN
 		c := b[offset:]
 
-		r := &Record{
-			Src:        net.IP([]byte{c[0], c[1], c[2], c[3]}),
-			Dst:        net.IP([]byte{c[4], c[5], c[6], c[7]}),
-			Nexthop:    net.IP([]byte{c[8], c[9], c[10], c[11]}),
-			Input:      (uint(c[12]) << 8) + uint(c[13]),
-			Output:     (uint(c[14]) << 8) + uint(c[15]),
-			NumPackets: (uint32(c[16]) << 24) + (uint32(c[17]) << 16) + (uint32(c[18]) << 8) + (uint32(c[19])),
-			NumOctets:  (uint32(c[20]) << 24) + (uint32(c[21]) << 16) + (uint32(c[22]) << 8) + (uint32(c[23])),
-			First:      (uint32(c[24]) << 24) + (uint32(c[25]) << 16) + (uint32(c[26]) << 8) + (uint32(c[27])),
-			Last:       (uint32(c[28]) << 24) + (uint32(c[29]) << 16) + (uint32(c[30]) << 8) + (uint32(c[31])),
-			SrcPort:    (int(c[32]) << 8) + int(c[33]),
-			DstPort:    (int(c[34]) << 8) + int(c[35]),
-			Protocol:   int(c[38]),
-			ToS:        int(c[39]),
-			SrcAS:      (int(c[40]) << 8) + int(c[41]),
-			DstAS:      (int(c[42]) << 8) + int(c[43]),
-		}
+		r := DecodeRecord(c)
 		p.Records = append(p.Records, r)
 
 		nf.statBytes += uint64(r.NumOctets)
@@ -328,4 +305,35 @@ func (nf *Netflow) process(n int, b []byte) (*Packet, error) {
 	nf.statNFRecords += uint64(len(p.Records))
 
 	return p, nil
+}
+
+func DecodeHeader(b []byte) *Header {
+	return &Header{
+		Version:   int(b[1]), // skip the first byte
+		Count:     int(b[3]),
+		Sequence:  (int32(b[16]) << 24) + (int32(b[17]) << 16) + (int32(b[18]) << 8) + (int32(b[19])),
+		Uptime:    (uint32(b[4]) << 24) + (uint32(b[5]) << 16) + (uint32(b[6]) << 8) + (uint32(b[7])),
+		EpochSec:  (uint32(b[8]) << 24) + (uint32(b[9]) << 16) + (uint32(b[10]) << 8) + (uint32(b[11])),
+		EpochNsec: (uint32(b[12]) << 24) + (uint32(b[13]) << 16) + (uint32(b[14]) << 8) + (uint32(b[15])),
+	}
+}
+
+func DecodeRecord(b []byte) *Record {
+	return &Record{
+		Src:        net.IP([]byte{b[0], b[1], b[2], b[3]}),
+		Dst:        net.IP([]byte{b[4], b[5], b[6], b[7]}),
+		Nexthop:    net.IP([]byte{b[8], b[9], b[10], b[11]}),
+		Input:      (uint(b[12]) << 8) + uint(b[13]),
+		Output:     (uint(b[14]) << 8) + uint(b[15]),
+		NumPackets: (uint32(b[16]) << 24) + (uint32(b[17]) << 16) + (uint32(b[18]) << 8) + (uint32(b[19])),
+		NumOctets:  (uint32(b[20]) << 24) + (uint32(b[21]) << 16) + (uint32(b[22]) << 8) + (uint32(b[23])),
+		First:      (uint32(b[24]) << 24) + (uint32(b[25]) << 16) + (uint32(b[26]) << 8) + (uint32(b[27])),
+		Last:       (uint32(b[28]) << 24) + (uint32(b[29]) << 16) + (uint32(b[30]) << 8) + (uint32(b[31])),
+		SrcPort:    (int(b[32]) << 8) + int(b[33]),
+		DstPort:    (int(b[34]) << 8) + int(b[35]),
+		Protocol:   int(b[38]),
+		ToS:        int(b[39]),
+		SrcAS:      (int(b[40]) << 8) + int(b[41]),
+		DstAS:      (int(b[42]) << 8) + int(b[43]),
+	}
 }

--- a/src/gonetflow/gonetflow.go
+++ b/src/gonetflow/gonetflow.go
@@ -309,8 +309,8 @@ func (nf *Netflow) process(n int, b []byte) (*Packet, error) {
 
 func DecodeHeader(b []byte) *Header {
 	return &Header{
-		Version:   int(b[1]), // skip the first byte
-		Count:     int(b[3]),
+		Version:   int(b[0])<<8 + int(b[1]),
+		Count:     int(b[2])<<8 + int(b[3]),
 		Sequence:  (int32(b[16]) << 24) + (int32(b[17]) << 16) + (int32(b[18]) << 8) + (int32(b[19])),
 		Uptime:    (uint32(b[4]) << 24) + (uint32(b[5]) << 16) + (uint32(b[6]) << 8) + (uint32(b[7])),
 		EpochSec:  (uint32(b[8]) << 24) + (uint32(b[9]) << 16) + (uint32(b[10]) << 8) + (uint32(b[11])),

--- a/src/nfcat/main.go
+++ b/src/nfcat/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bufio"
 	"compress/gzip"
 	"flag"
 	"fmt"
@@ -17,17 +18,12 @@ var (
 	f_gunzip = flag.Bool("gunzip", false, "gunzip input file(s)")
 )
 
-func readRecord(r io.Reader) (*gonetflow.Record, error) {
-	b := make([]byte, gonetflow.NETFLOW_RECORD_LEN)
+// TODO: This is what readPacket and readRecord *should* be. When we release
+// 2.3, we should kill the grotesque hacks that we are using currently.
 
-	_, err := io.ReadAtLeast(r, b, gonetflow.NETFLOW_RECORD_LEN)
-	if err != nil {
-		return nil, err
-	}
-
-	return gonetflow.DecodeRecord(b), nil
-}
-
+/*
+// readPacket reads a gonetflow.Packet from the Reader by first decoding a
+// header and then reading the correct number of Records.
 func readPacket(r io.Reader) (*gonetflow.Packet, error) {
 	b := make([]byte, gonetflow.NETFLOW_HEADER_LEN)
 
@@ -40,13 +36,105 @@ func readPacket(r io.Reader) (*gonetflow.Packet, error) {
 		Header: gonetflow.DecodeHeader(b),
 	}
 
-	for i := 0; i < p.Header.Count; i++ {
+	for i := 0; i < p.Header.Count-1; i++ {
 		v, err := readRecord(r)
 		if err != nil {
 			return nil, err
 		}
 
 		p.Records = append(p.Records, v)
+	}
+
+	return p, nil
+}
+
+// readRecord reads a single gonetflow.Record from the Reader.
+func readRecord(r io.Reader) (*gonetflow.Record, error) {
+	b := make([]byte, gonetflow.NETFLOW_RECORD_LEN)
+
+	_, err := io.ReadAtLeast(r, b, gonetflow.NETFLOW_RECORD_LEN)
+	if err != nil {
+		return nil, err
+	}
+
+	return gonetflow.DecodeRecord(b), nil
+}
+*/
+
+// Copied from io for bufio.Reader
+func ReadAtLeast(r *bufio.Reader, buf []byte, min int) (n int, err error) {
+	if len(buf) < min {
+		return 0, io.ErrShortBuffer
+	}
+	for n < min && err == nil {
+		var nn int
+		nn, err = r.Read(buf[n:])
+		n += nn
+	}
+	if n >= min {
+		err = nil
+	} else if n > 0 && err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	return
+}
+
+// Before we merged PR #559, there was an off-by-one error in minimega that
+// cause it to omit the last byte when writing out netflow packets so we only
+// read LEN-1. It is up to the caller to read the last byte, if necessary.
+func readRecordXXX(r *bufio.Reader) (*gonetflow.Record, error) {
+	b := make([]byte, gonetflow.NETFLOW_RECORD_LEN-1)
+
+	_, err := ReadAtLeast(r, b, gonetflow.NETFLOW_RECORD_LEN-1)
+	if err != nil {
+		return nil, err
+	}
+
+	return gonetflow.DecodeRecord(b), nil
+}
+
+func readPacketXXX(r *bufio.Reader) (*gonetflow.Packet, error) {
+	b := make([]byte, gonetflow.NETFLOW_HEADER_LEN)
+
+	_, err := ReadAtLeast(r, b, gonetflow.NETFLOW_HEADER_LEN)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &gonetflow.Packet{
+		Header: gonetflow.DecodeHeader(b),
+	}
+
+	for {
+		v, err := readRecordXXX(r)
+		if err != nil {
+			return nil, err
+		}
+
+		p.Records = append(p.Records, v)
+
+		// Since we can't trust the Count, we will just read until we peek and see
+		// what looks like a new header
+		peek, err := r.Peek(3)
+		if err == io.EOF {
+			return p, nil
+		} else if err != nil {
+			return nil, err
+		}
+
+		// Only looking for netflow v5 headers
+		if peek[0] == 0 && peek[1] == 5 {
+			return p, nil
+		}
+
+		// Handle the off-by-one case
+		if peek[1] == 0 && peek[2] == 5 {
+			r.ReadByte()
+			return p, nil
+		}
+
+		// consume byte of padding
+		r.ReadByte()
 	}
 
 	return p, nil
@@ -70,8 +158,9 @@ func cat(fname string) error {
 		r = r2
 	}
 
+	r2 := bufio.NewReader(r)
 	for {
-		p, err := readPacket(r)
+		p, err := readPacketXXX(r2)
 		if err == io.EOF {
 			break
 		} else if err != nil {

--- a/src/nfcat/main.go
+++ b/src/nfcat/main.go
@@ -1,0 +1,101 @@
+// Copyright (2016) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"compress/gzip"
+	"flag"
+	"fmt"
+	"gonetflow"
+	"io"
+	"os"
+)
+
+var (
+	f_gunzip = flag.Bool("gunzip", false, "gunzip input file(s)")
+)
+
+func readRecord(r io.Reader) (*gonetflow.Record, error) {
+	b := make([]byte, gonetflow.NETFLOW_RECORD_LEN)
+
+	_, err := io.ReadAtLeast(r, b, gonetflow.NETFLOW_RECORD_LEN)
+	if err != nil {
+		return nil, err
+	}
+
+	return gonetflow.DecodeRecord(b), nil
+}
+
+func readPacket(r io.Reader) (*gonetflow.Packet, error) {
+	b := make([]byte, gonetflow.NETFLOW_HEADER_LEN)
+
+	_, err := io.ReadAtLeast(r, b, gonetflow.NETFLOW_HEADER_LEN)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &gonetflow.Packet{
+		Header: gonetflow.DecodeHeader(b),
+	}
+
+	for i := 0; i < p.Header.Count; i++ {
+		v, err := readRecord(r)
+		if err != nil {
+			return nil, err
+		}
+
+		p.Records = append(p.Records, v)
+	}
+
+	return p, nil
+}
+
+func cat(fname string) error {
+	f, err := os.Open(fname)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var r io.Reader = f
+
+	if *f_gunzip {
+		r2, err := gzip.NewReader(f)
+		if err != nil {
+			return err
+		}
+		defer r2.Close()
+		r = r2
+	}
+
+	for {
+		p, err := readPacket(r)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		fmt.Printf("%#v", p)
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Printf("USAGE: %v [OPTIONS] FILE...\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	for _, v := range flag.Args() {
+		if err := cat(v); err != nil {
+			fmt.Printf("unable to read %v: %v\n", v, err)
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
Adding tool `nfcat` that reads the binary netflow format written by minimega.

Required small changes to gonetflow which haven't been tested yet... probably fine?