### PR TITLE
iomeshage: don't delete the root

### DIFF
--- a/src/iomeshage/iomeshage.go
+++ b/src/iomeshage/iomeshage.go
@@ -627,11 +627,13 @@ func (iom *IOMeshage) Delete(file string) error {
 
 // Get a full path, with the iom base directory and any trailing "/".
 func (iom *IOMeshage) dirPrep(dir string) string {
-	if strings.HasPrefix(dir, "/") {
-		dir = strings.TrimLeft(dir, "/")
-	}
-	log.Debug("dir is %v%v", iom.base, dir)
-	return filepath.Join(iom.base, dir)
+	// prepend a "/" to the directory so that commands can't affect files above
+	// the iom.base directory. For example, filepath.Clean will replace "/../"
+	// with "/".
+	dir = filepath.Join(iom.base, filepath.Clean("/"+dir))
+	log.Info("dir is %v", dir)
+
+	return dir
 }
 
 // Generate a random 63 bit TID (positive int64).

--- a/src/iomeshage/iomeshage.go
+++ b/src/iomeshage/iomeshage.go
@@ -67,9 +67,7 @@ var (
 // New returns a new iomeshage object service base directory b on meshage node
 // n
 func New(base string, node *meshage.Node) (*IOMeshage, error) {
-	if !strings.HasSuffix(base, "/") {
-		base += "/"
-	}
+	base = filepath.Clean(base)
 	log.Debug("new iomeshage node on base %v", base)
 	err := os.MkdirAll(base, 0755)
 
@@ -87,7 +85,7 @@ func New(base string, node *meshage.Node) (*IOMeshage, error) {
 	return r, err
 }
 
-// List files and directories starting at iom.Base+dir
+// List files and directories starting at iom.base+dir
 func (iom *IOMeshage) List(dir string) ([]FileInfo, error) {
 	dir = iom.dirPrep(dir)
 	files, err := ioutil.ReadDir(dir)

--- a/src/iomeshage/iomeshage.go
+++ b/src/iomeshage/iomeshage.go
@@ -620,6 +620,26 @@ func (iom *IOMeshage) Status() []*Transfer {
 // Delete a file
 func (iom *IOMeshage) Delete(file string) error {
 	file = iom.dirPrep(file)
+
+	if file == iom.base {
+		// the user *probably* doesn't want to actually remove the iom.base
+		// directory since them they wouldn't be able to transfer any more
+		// files. Instead, remove all it's contents.
+		log.Info("deleting iomeshage directory contents")
+		files, err := ioutil.ReadDir(file)
+		if err != nil {
+			return err
+		}
+
+		for _, file := range files {
+			if err := os.RemoveAll(filepath.Join(iom.base, file.Name())); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
 	return os.RemoveAll(file)
 }
 


### PR DESCRIPTION
Delete the contents but not `iom.base` when called via `file delete /`.

Restrict paths to within the `iom.base` directory (e.g. not `file delete ../../../../`).

Fixes #574 