### PR TITLE
minimega/minirouter: add upstream dns

### DIFF
--- a/src/minimega/router.go
+++ b/src/minimega/router.go
@@ -29,6 +29,7 @@ type Router struct {
 	updateIPs    bool // only update IPs if we've made changes
 	dhcp         map[string]*dhcp
 	dns          map[string]string
+	upstream     string
 	rad          map[string]bool // using a bool placeholder here for later RAD options
 	staticRoutes map[string]string
 	ospfRoutes   map[string]*ospf
@@ -81,6 +82,10 @@ func (r *Router) String() string {
 			fmt.Fprintf(&o, "%v\t%v\n", ip, host)
 		}
 		fmt.Fprintln(&o)
+	}
+
+	if r.upstream != "" {
+		fmt.Fprintf(&o, "Upstream DNS: %v\n", r.upstream)
 	}
 
 	if len(r.rad) > 0 {
@@ -173,6 +178,9 @@ func (r *Router) generateConfig() error {
 	}
 	for ip, host := range r.dns {
 		fmt.Fprintf(&out, "dnsmasq dns %v %v\n", ip, host)
+	}
+	if r.upstream != "" {
+		fmt.Fprintf(&out, "dnsmasq upstream %v\n", r.upstream)
 	}
 	for subnet, _ := range r.rad {
 		fmt.Fprintf(&out, "dnsmasq ra %v\n", subnet)
@@ -480,6 +488,16 @@ func (r *Router) DNSDel(ip string) error {
 	} else {
 		return fmt.Errorf("no such ip: %v", ip)
 	}
+	return nil
+}
+
+func (r *Router) Upstream(ip string) {
+	r.upstream = ip
+}
+
+func (r *Router) UpstreamDel() error {
+	r.upstream = ""
+
 	return nil
 }
 

--- a/src/minimega/router_cli.go
+++ b/src/minimega/router_cli.go
@@ -48,6 +48,8 @@ router takes a number of subcommands:
 
 - 'dns': Set DNS records for IPv4 or IPv6 hosts.
 
+- 'upstream': Set upstream server for DNS.
+
 - 'ra': Enable neighbor discovery protocol router advertisements for a given
   subnet.
 
@@ -71,6 +73,7 @@ router takes a number of subcommands:
 			"router <vm> <dhcp,> <listen address> <dns,> <address>",
 			"router <vm> <dhcp,> <listen address> <static,> <mac> <ip>",
 			"router <vm> <dns,> <ip> <hostname>",
+			"router <vm> <upstream,> <ip>",
 			"router <vm> <ra,> <subnet>",
 			"router <vm> <route,> <static,> <network> <next-hop>",
 			"router <vm> <route,> <ospf,> <area> <network>",
@@ -94,6 +97,7 @@ router takes a number of subcommands:
 			"clear router <vm> <dhcp,> <listen address> <static,> <mac>",
 			"clear router <vm> <dns,>",
 			"clear router <vm> <dns,> <ip>",
+			"clear router <vm> <upstream,>",
 			"clear router <vm> <ra,>",
 			"clear router <vm> <ra,> <subnet>",
 			"clear router <vm> <route,>",
@@ -173,6 +177,10 @@ func cliRouter(c *minicli.Command, resp *minicli.Response) error {
 		hostname := c.StringArgs["hostname"]
 		rtr.DNSAdd(ip, hostname)
 		return nil
+	} else if c.BoolArgs["upstream"] {
+		ip := c.StringArgs["ip"]
+		rtr.Upstream(ip)
+		return nil
 	} else if c.BoolArgs["ra"] {
 		subnet := c.StringArgs["subnet"]
 		rtr.RADAdd(subnet)
@@ -251,6 +259,8 @@ func cliClearRouter(c *minicli.Command, resp *minicli.Response) error {
 	} else if c.BoolArgs["dns"] {
 		ip := c.StringArgs["ip"]
 		return rtr.DNSDel(ip)
+	} else if c.BoolArgs["upstream"] {
+		return rtr.UpstreamDel()
 	} else if c.BoolArgs["ra"] {
 		subnet := c.StringArgs["subnet"]
 		return rtr.RADDel(subnet)


### PR DESCRIPTION
Add option to set upstream dns server. Useful when creating a hierarchy.