### PR TITLE
minimega: dnsmasq needs to run as root

### DIFF
--- a/src/minimega/dnsmasq.go
+++ b/src/minimega/dnsmasq.go
@@ -416,6 +416,8 @@ func dnsmasqStart(ip, min, max, hosts string) error {
 		Path: p,
 		Args: []string{
 			p,
+			"-u",
+			"root",
 			fmt.Sprintf("--pid-file=%v/dnsmasq.pid", d.Path),
 			"-o",
 			"-k",


### PR DESCRIPTION
If dnsmasq defaults to running as "nobody", it won't be able to access its directory under /tmp/minimega. This fixes that.