### PR TITLE
minimega: fix deadlock with flushing VMs

### DIFF
--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -423,8 +423,6 @@ func (vm *BaseVM) Kill() error {
 }
 
 func (vm *BaseVM) Flush() error {
-	ccNode.UnregisterVM(vm.UUID)
-
 	return os.RemoveAll(vm.instancePath)
 }
 

--- a/src/minimega/vmlist.go
+++ b/src/minimega/vmlist.go
@@ -405,6 +405,8 @@ func (vms VMs) Flush() {
 				log.Error("clogged VM: %v", err)
 			}
 
+			ccNode.UnregisterVM(vm.GetUUID())
+
 			delete(vms, i)
 		}
 	}


### PR DESCRIPTION
Call to ron.Server.UnregisterVM while holding VM's lock could result in
a deadlock. Moved call to unregister VM to VMs, mirroring how RegisterVM
is called.