### PR TITLE
minicli: if values are int, sort using int compare

### DIFF
--- a/src/minicli/output.go
+++ b/src/minicli/output.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"ranges"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 )
@@ -30,6 +31,13 @@ func (t table) Swap(i, j int) {
 func (t table) Less(i, j int) bool {
 	for k := 0; k < len(t[i]) && k < len(t[j]); k++ {
 		if t[i][k] != t[j][k] {
+			// If both convert to ints, compare using int comparison
+			v, err := strconv.Atoi(t[i][k])
+			v2, err2 := strconv.Atoi(t[j][k])
+			if err == nil && err2 == nil {
+				return v < v2
+			}
+
 			return t[i][k] < t[j][k]
 		}
 	}

--- a/src/minicli/output_test.go
+++ b/src/minicli/output_test.go
@@ -1,0 +1,59 @@
+// Copyright (2015) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package minicli
+
+import (
+	"sort"
+	"strconv"
+	"testing"
+)
+
+// sortData is in a random order and the third column is the correct order.
+var sortData = [][]string{
+	[]string{"b", "b", "2"},
+	[]string{"a", "a", "0"},
+	[]string{"d", "a", "4"},
+	[]string{"a", "b", "1"},
+	[]string{"e", "a", "5"},
+	[]string{"c", "a", "3"},
+}
+
+// sortDataInts is in a random order and the third column is the correct order.
+var sortDataInts = [][]string{
+	[]string{"2", "b", "2"},
+	[]string{"0", "a", "0"},
+	[]string{"4", "a", "4"},
+	[]string{"1", "b", "1"},
+	[]string{"5", "a", "5"},
+	[]string{"3", "a", "3"},
+}
+
+func TestSort(t *testing.T) {
+	data := make([][]string, len(sortData))
+	copy(data, sortData)
+
+	sort.Sort(table(data))
+
+	for i := 0; i < len(data); i++ {
+		v, _ := strconv.Atoi(data[i][2])
+		if i != v {
+			t.Errorf("out of order, %v: %v", i, data)
+		}
+	}
+}
+
+func TestSortInts(t *testing.T) {
+	data := make([][]string, len(sortDataInts))
+	copy(data, sortData)
+
+	sort.Sort(table(data))
+
+	for i := 0; i < len(data); i++ {
+		v, _ := strconv.Atoi(data[i][2])
+		if i != v {
+			t.Errorf("out of order, %v: %v", i, data)
+		}
+	}
+}


### PR DESCRIPTION
Displays IDs in the correct order (e.g. `cc commands`). Fixes #538.

Includes unit tests.