### PR TITLE
minicli: improvements for handling quoting

### DIFF
--- a/src/minicli/input.go
+++ b/src/minicli/input.go
@@ -36,6 +36,16 @@ type Input struct {
 	items    inputItems
 }
 
+var escapedChars = map[string]string{
+	"r":           "\r",
+	"n":           "\n",
+	"t":           "\t",
+	`\`:           `\`,
+	`"`:           `"`,
+	`'`:           `'`,
+	CommentLeader: CommentLeader,
+}
+
 func (items inputItems) String() string {
 	parts := make([]string, len(items))
 	for i, v := range items {
@@ -137,11 +147,11 @@ func (l *inputLexer) lexEscape() (stateFn, error) {
 		return nil, errors.New("expected escape character")
 	}
 
-	switch token := l.s.Text(); token {
-	case `\`, `"`, `'`:
-		l.content += token
+	token := l.s.Text()
+	if v, ok := escapedChars[token]; ok {
+		l.content += v
 		return l.prevState, nil
-	default:
-		return nil, fmt.Errorf("unexpected escaped character: %v", token)
 	}
+
+	return nil, fmt.Errorf("unexpected escaped character: %v", token)
 }

--- a/src/minicli/minicli.go
+++ b/src/minicli/minicli.go
@@ -80,6 +80,13 @@ type Response struct {
 
 type CLIFunc func(*Command, chan<- Responses)
 
+// Reset minicli state including all registered handlers.
+func Reset() {
+	handlers = nil
+	history = nil
+	firstHistoryTruncate = true
+}
+
 // MustRegister calls Register for a handler and panics if the handler has an
 // error registering.
 func MustRegister(h *Handler) {

--- a/src/minicli/minicli_test.go
+++ b/src/minicli/minicli_test.go
@@ -103,7 +103,19 @@ var testHandler = &Handler{
 	},
 }
 
+var echoArgHandler = &Handler{
+	Patterns: []string{"<arg>"},
+	Call: func(c *Command, out chan<- Responses) {
+		resp := &Response{
+			Response: c.StringArgs["arg"],
+		}
+		out <- Responses{resp}
+	},
+}
+
 func TestParse(t *testing.T) {
+	Reset()
+
 	for _, v := range validTestPatterns {
 		t.Logf("Testing pattern: `%s`", v.pattern)
 
@@ -128,6 +140,8 @@ func TestParse(t *testing.T) {
 }
 
 func TestInvalidPatterns(t *testing.T) {
+	Reset()
+
 	for _, p := range invalidTestPatterns {
 		t.Logf("Testing pattern: `%s`", p)
 
@@ -140,6 +154,8 @@ func TestInvalidPatterns(t *testing.T) {
 }
 
 func TestPrefix(t *testing.T) {
+	Reset()
+
 	for i := range testPrefixes {
 		want := testPrefixes[i].Prefix
 		patterns := testPrefixes[i].Patterns
@@ -167,6 +183,7 @@ func TestPrefix(t *testing.T) {
 }
 
 func TestHistoryComments(t *testing.T) {
+	Reset()
 	Register(testHandler)
 
 	comments := []string{
@@ -176,7 +193,6 @@ func TestHistoryComments(t *testing.T) {
 		"# four",
 	}
 
-	ClearHistory()
 	for _, c := range comments {
 		out, err := ProcessString(c, true)
 		if err != nil {
@@ -199,8 +215,8 @@ func TestHistoryComments(t *testing.T) {
 }
 
 func TestWhitespace(t *testing.T) {
+	Reset()
 	Register(testHandler)
-	ClearHistory()
 
 	inputs := []string{
 		"test",
@@ -228,4 +244,42 @@ func TestWhitespace(t *testing.T) {
 	}
 
 	t.Logf("history:\n`%s`", History())
+}
+
+func TestQuotes(t *testing.T) {
+	Reset()
+	Register(echoArgHandler)
+
+	inputs := [][]string{
+		[]string{`foo`, `foo`},
+		[]string{`"foo"`, `foo`},
+		[]string{`"foo bar"`, `foo bar`},
+		[]string{`"\"foo bar\""`, `"foo bar"`},
+		[]string{`"\"foo's bar\""`, `"foo's bar"`},
+		[]string{`'foo'`, `foo`},
+		[]string{`'foo bar'`, `foo bar`},
+		[]string{`'"foo bar"'`, `"foo bar"`},
+		[]string{`'"foo\'s bar"'`, `"foo's bar"`},
+		[]string{`"foo \"bar\""`, `foo "bar"`},
+	}
+
+	for _, v := range inputs {
+		t.Logf("processing input: `%s`, want: `%v`", v[0], v[1])
+
+		out, err := ProcessString(v[0], true)
+		if err != nil {
+			t.Fatalf("unable to ProcessString: `%s` -- %v", v[0], err)
+		}
+
+		for r := range out {
+			if len(r) != 1 {
+				t.Errorf("expected one response")
+				continue
+			}
+
+			if r[0].Response != v[1] {
+				t.Errorf("quote mismatch: `%v` != `%v`", r[0].Response, v[1])
+			}
+		}
+	}
 }

--- a/src/minicli/minicli_test.go
+++ b/src/minicli/minicli_test.go
@@ -261,6 +261,7 @@ func TestQuotes(t *testing.T) {
 		[]string{`'"foo bar"'`, `"foo bar"`},
 		[]string{`'"foo\'s bar"'`, `"foo's bar"`},
 		[]string{`"foo \"bar\""`, `foo "bar"`},
+		[]string{`""`, ``},
 	}
 
 	for _, v := range inputs {

--- a/src/minimega/vmconfig_cli.go
+++ b/src/minimega/vmconfig_cli.go
@@ -574,9 +574,8 @@ func cliVmConfigField(c *minicli.Command, resp *minicli.Response, field string) 
 
 func cliVmConfigTag(c *minicli.Command, resp *minicli.Response) error {
 	k := c.StringArgs["key"]
-	v := c.StringArgs["value"]
 
-	if v != "" {
+	if v, ok := c.StringArgs["value"]; ok {
 		// Setting a new value
 		vmConfig.Tags[k] = v
 	} else if k != "" {


### PR DESCRIPTION
Handle escaped quotes and empty quoted strings:

```
    minimega$ vm config tag foo "foo bar"
    minimega$ vm config tag
    {"foo":"foo bar"}
    minimega$ vm config tag foo "foo \"bar\""
    minimega$ vm config tag
    {"foo":"foo \"bar\""}
    minimega$ vm config tag foo ""
    minimega$ vm config tag
    {"foo":""}
```