### PR TITLE
minilog: add linux specific build files for syslog helper

### DIFF
--- a/src/minilog/minilog.go
+++ b/src/minilog/minilog.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"log/syslog"
 	"os"
 	"runtime"
 	"strconv"
@@ -65,29 +64,6 @@ func AddLogger(name string, output io.Writer, level int, color bool) {
 // Remove a named logger that was added using AddLogger
 func DelLogger(name string) {
 	delete(loggers, name)
-}
-
-// Helper function to add syslog output by connecting to address raddr on the
-// specified network. Events are logged with a specified tag. Calling more than
-// once overwrites existing syslog writers. If network == "local", log to the
-// local syslog daemon.
-func AddSyslog(network, raddr, tag string, level int) error {
-	var w *syslog.Writer
-	var err error
-
-	priority := syslog.LOG_INFO | syslog.LOG_DAEMON
-
-	if network == "local" {
-		w, err = syslog.New(priority, tag)
-	} else {
-		w, err = syslog.Dial(network, raddr, priority, tag)
-	}
-	if err != nil {
-		return err
-	}
-
-	AddLogger("syslog", w, level, false)
-	return nil
 }
 
 func Loggers() []string {

--- a/src/minilog/minilog_linux.go
+++ b/src/minilog/minilog_linux.go
@@ -1,0 +1,34 @@
+// Copyright (2016) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+// +build linux
+
+package minilog
+
+import (
+	"log/syslog"
+)
+
+// Helper function to add syslog output by connecting to address raddr on the
+// specified network. Events are logged with a specified tag. Calling more than
+// once overwrites existing syslog writers. If network == "local", log to the
+// local syslog daemon.
+func AddSyslog(network, raddr, tag string, level int) error {
+	var w *syslog.Writer
+	var err error
+
+	priority := syslog.LOG_INFO | syslog.LOG_DAEMON
+
+	if network == "local" {
+		w, err = syslog.New(priority, tag)
+	} else {
+		w, err = syslog.Dial(network, raddr, priority, tag)
+	}
+	if err != nil {
+		return err
+	}
+
+	AddLogger("syslog", w, level, false)
+	return nil
+}


### PR DESCRIPTION
#690 breaks windows builds of protonuke, miniccc, etc. This moves the syslog helper in minilog to a linux specific source file. 

@jcrussell 