### PR TITLE
cgroups, systemdont

### DIFF
--- a/doc/content/articles/vmtypes.article
+++ b/doc/content/articles/vmtypes.article
@@ -139,7 +139,7 @@ enabled by default in linux 3.18+.
 When launching `container` type VMs, the following occurs, in order:
 
 - A new VM handler is created within minimega, which is populated with a copy of the VM configuration
-- If this is the first container to be launched, a new cgroup mount will be created within the minimega working directory (by default /tmp/minimega/cgroup)
+- If this is the first container to be launched, minimega cgroup subtrees will be created for the freezer, memory, and devices cgroup subsystems.
 - If this is a new container, checks are performed to ensure there are no networking or disk conflicts
 - An instance directory and container configuration are written to disk (by default /tmp/minimega/N, where N is the VM ID)
 - If the VM is in snapshot mode, an `overlayfs` mountpoint is created within the instance directory
@@ -177,3 +177,13 @@ cgroup. To enable this in GRUB on Debian, open /etc/default/grub and edit the
 `GRUB_CMDLINE_LINUX_DEFAULT` line to include the cgroup parameter. Then run
 `update-grub` to update the GRUB config. When you reboot, the cgroup will be
 enabled.
+
+To better work with systemd-based systems, minimega requires the cgroup hierarchy be mounted as individual mounts (as opposed to one large cgroup mount with all enabled subsystems). If you don't already have a cgroup hierarchy mounted, the following will create a minimal one for minimega:
+
+	mount -t tmpfs cgroup /sys/fs/cgroup
+	mkdir /sys/fs/cgroup/memory
+	mkdir /sys/fs/cgroup/freezer
+	mkdir /sys/fs/cgroup/devices
+	mount -t cgroup cgroup -o memory /sys/fs/cgroup/memory
+	mount -t cgroup cgroup -o freezer /sys/fs/cgroup/freezer
+	mount -t cgroup cgroup -o devices /sys/fs/cgroup/devices

--- a/misc/vmbetter_configs/ccc_host_ovs_overlay/init
+++ b/misc/vmbetter_configs/ccc_host_ovs_overlay/init
@@ -10,7 +10,13 @@ mkdir /dev/pts
 mount -n -t devpts -o newinstance,ptmxmode=666,gid=5,mode=620 none /dev/pts
 rm /dev/ptmx
 ln -s /dev/pts/ptmx /dev/ptmx
-mount -t cgroup cgroup /sys/fs/cgroup
+mount -t tmpfs cgroup /sys/fs/cgroup
+mkdir /sys/fs/cgroup/memory
+mkdir /sys/fs/cgroup/freezer
+mkdir /sys/fs/cgroup/devices
+mount -t cgroup cgroup -o memory /sys/fs/cgroup/memory
+mount -t cgroup cgroup -o freezer /sys/fs/cgroup/freezer
+mount -t cgroup cgroup -o devices /sys/fs/cgroup/devices
 
 # / needs permissions!?
 chmod a+rx /

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -97,11 +97,6 @@ const (
 	DEFAULT_CAPS = CAP_CHOWN | CAP_DAC_OVERRIDE | CAP_FSETID | CAP_FOWNER | CAP_MKNOD | CAP_NET_RAW | CAP_SETGID | CAP_SETUID | CAP_SETFCAP | CAP_SETPCAP | CAP_NET_BIND_SERVICE | CAP_SYS_CHROOT | CAP_KILL | CAP_AUDIT_WRITE | CAP_NET_ADMIN | CAP_DAC_READ_SEARCH | CAP_AUDIT_CONTROL
 )
 
-var (
-	CGROUP_PATH string
-	CGROUP_ROOT string
-)
-
 type capHeader struct {
 	version uint32
 	pid     int
@@ -258,54 +253,74 @@ func containerInit() error {
 	}
 	containerInitOnce = true
 
-	// mount our own cgroup namespace to avoid having to ever ever ever
-	// deal with systemd
-	log.Debug("cgroup mkdir: %v", CGROUP_ROOT)
+	// create minimega freezer and memory cgroups
+	log.Debug("cgroup init: %v", *f_cgroup)
 
-	err := os.MkdirAll(CGROUP_ROOT, 0755)
+	cgroupFreezer := filepath.Join(*f_cgroup, "freezer", "minimega")
+	cgroupMemory := filepath.Join(*f_cgroup, "memory", "minimega")
+	cgroupDevices := filepath.Join(*f_cgroup, "devices", "minimega")
+
+	err := os.Mkdir(cgroupFreezer, 0755)
 	if err != nil {
 		return fmt.Errorf("cgroup mkdir: %v", err)
 	}
 
-	err = syscall.Mount("minicgroup", CGROUP_ROOT, "cgroup", 0, "")
+	err = os.Mkdir(cgroupMemory, 0755)
 	if err != nil {
-		return fmt.Errorf("cgroup mount: %v", err)
+		return fmt.Errorf("cgroup mkdir: %v", err)
+	}
+
+	err = os.Mkdir(cgroupDevices, 0755)
+	if err != nil {
+		return fmt.Errorf("cgroup mkdir: %v", err)
 	}
 
 	// inherit cpusets
-	err = ioutil.WriteFile(filepath.Join(CGROUP_ROOT, "cgroup.clone_children"), []byte("1"), 0664)
+	err = ioutil.WriteFile(filepath.Join(cgroupFreezer, "cgroup.clone_children"), []byte("1"), 0664)
 	if err != nil {
 		return fmt.Errorf("setting cgroup: %v", err)
 	}
-	err = ioutil.WriteFile(filepath.Join(CGROUP_ROOT, "memory.use_hierarchy"), []byte("1"), 0664)
+
+	err = ioutil.WriteFile(filepath.Join(cgroupMemory, "cgroup.clone_children"), []byte("1"), 0664)
+	if err != nil {
+		return fmt.Errorf("setting cgroup: %v", err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(cgroupDevices, "cgroup.clone_children"), []byte("1"), 0664)
+	if err != nil {
+		return fmt.Errorf("setting cgroup: %v", err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(cgroupMemory, "memory.use_hierarchy"), []byte("1"), 0664)
 	if err != nil {
 		return fmt.Errorf("setting use_hierarchy: %v", err)
 	}
 
 	// clean potentially old cgroup noise
-	err = containerCleanCgroupDirs()
-	if err != nil {
-		return err
-	}
-
-	// create a minimega cgroup
-	err = os.MkdirAll(CGROUP_PATH, 0755)
-	if err != nil {
-		return fmt.Errorf("creating minimega cgroup: %v", err)
-	}
+	containerCleanCgroupDirs()
 
 	containerInitSuccess = true
 	return nil
 }
 
 func containerTeardown() {
-	err := os.Remove(CGROUP_PATH)
+	cgroupFreezer := filepath.Join(*f_cgroup, "freezer", "minimega")
+	cgroupMemory := filepath.Join(*f_cgroup, "memory", "minimega")
+	cgroupDevices := filepath.Join(*f_cgroup, "devices", "minimega")
+
+	err := os.Remove(cgroupFreezer)
 	if err != nil {
 		if containerInitSuccess {
 			log.Errorln(err)
 		}
 	}
-	err = syscall.Unmount(CGROUP_ROOT, 0)
+	err = os.Remove(cgroupMemory)
+	if err != nil {
+		if containerInitSuccess {
+			log.Errorln(err)
+		}
+	}
+	err = os.Remove(cgroupDevices)
 	if err != nil {
 		if containerInitSuccess {
 			log.Errorln(err)
@@ -937,7 +952,9 @@ func (vm *ContainerVM) launch() error {
 	}()
 
 	go func() {
-		cgroupPath := filepath.Join(CGROUP_PATH, fmt.Sprintf("%v", vm.ID))
+		cgroupFreezerPath := filepath.Join(*f_cgroup, "freezer", "minimega", fmt.Sprintf("%v", vm.ID))
+		cgroupMemoryPath := filepath.Join(*f_cgroup, "memory", "minimega", fmt.Sprintf("%v", vm.ID))
+		cgroupDevicesPath := filepath.Join(*f_cgroup, "devices", "minimega", fmt.Sprintf("%v", vm.ID))
 		sendKillAck := false
 
 		select {
@@ -970,7 +987,7 @@ func (vm *ContainerVM) launch() error {
 			// wait for the taskset to actually exit (from uninterruptible
 			// sleep state).
 			for {
-				t, err := ioutil.ReadFile(filepath.Join(cgroupPath, "tasks"))
+				t, err := ioutil.ReadFile(filepath.Join(cgroupFreezerPath, "tasks"))
 				if err != nil {
 					log.Errorln(err)
 					vm.setError(err)
@@ -1013,7 +1030,13 @@ func (vm *ContainerVM) launch() error {
 		}
 
 		// clean up the cgroup directory
-		if err := os.Remove(cgroupPath); err != nil {
+		if err := os.Remove(cgroupFreezerPath); err != nil {
+			log.Errorln(err)
+		}
+		if err := os.Remove(cgroupMemoryPath); err != nil {
+			log.Errorln(err)
+		}
+		if err := os.Remove(cgroupDevicesPath); err != nil {
 			log.Errorln(err)
 		}
 
@@ -1092,7 +1115,7 @@ func (vm *ContainerVM) unlinkNetns() error {
 	return os.Remove(dst)
 }
 
-// create an overlay mount (linux 3.18 or greater) is snapshot mode is
+// create an overlay mount (linux 3.18 or greater) if snapshot mode is
 // being used.
 func (vm *ContainerVM) overlayMount() error {
 	vm.effectivePath = vm.path("fs")
@@ -1178,7 +1201,7 @@ func (vm *ContainerVM) console(pseudotty *os.File) {
 }
 
 func (vm *ContainerVM) freeze() error {
-	freezer := filepath.Join(CGROUP_PATH, fmt.Sprintf("%v", vm.ID), "freezer.state")
+	freezer := filepath.Join(*f_cgroup, "freezer", "minimega", fmt.Sprintf("%v", vm.ID), "freezer.state")
 	if err := ioutil.WriteFile(freezer, []byte("FROZEN"), 0644); err != nil {
 		return fmt.Errorf("freezer: %v", err)
 	}
@@ -1187,7 +1210,7 @@ func (vm *ContainerVM) freeze() error {
 }
 
 func (vm *ContainerVM) thaw() error {
-	freezer := filepath.Join(CGROUP_PATH, fmt.Sprintf("%v", vm.ID), "freezer.state")
+	freezer := filepath.Join(*f_cgroup, "freezer", "minimega", fmt.Sprintf("%v", vm.ID), "freezer.state")
 	if err := ioutil.WriteFile(freezer, []byte("THAWED"), 0644); err != nil {
 		return fmt.Errorf("freezer: %v", err)
 	}
@@ -1283,20 +1306,26 @@ func containerChroot(fsPath string) error {
 }
 
 func containerPopulateCgroups(vmID, vmMemory int) error {
-	cgroupPath := filepath.Join(CGROUP_PATH, fmt.Sprintf("%v", vmID))
-	log.Debug("using cgroupPath: %v", cgroupPath)
+	cgroupFreezer := filepath.Join(*f_cgroup, "freezer", "minimega", fmt.Sprintf("%v", vmID))
+	cgroupMemory := filepath.Join(*f_cgroup, "memory", "minimega", fmt.Sprintf("%v", vmID))
+	cgroupDevices := filepath.Join(*f_cgroup, "devices", "minimega", fmt.Sprintf("%v", vmID))
 
-	err := os.MkdirAll(cgroupPath, 0755)
+	err := os.MkdirAll(cgroupFreezer, 0755)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(cgroupMemory, 0755)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(cgroupDevices, 0755)
 	if err != nil {
 		return err
 	}
 
-	deny := filepath.Join(cgroupPath, "devices.deny")
-	allow := filepath.Join(cgroupPath, "devices.allow")
-	tasks := filepath.Join(cgroupPath, "tasks")
-	memory := filepath.Join(cgroupPath, "memory.limit_in_bytes")
-
 	// devices
+	deny := filepath.Join(cgroupDevices, "devices.deny")
+	allow := filepath.Join(cgroupDevices, "devices.allow")
 	err = ioutil.WriteFile(deny, []byte("a"), 0200)
 	if err != nil {
 		return err
@@ -1309,13 +1338,25 @@ func containerPopulateCgroups(vmID, vmMemory int) error {
 	}
 
 	// memory
+	memory := filepath.Join(cgroupMemory, "memory.limit_in_bytes")
 	err = ioutil.WriteFile(memory, []byte(fmt.Sprintf("%vM", vmMemory)), 0644)
 	if err != nil {
 		return err
 	}
 
 	// associate the pid with these permissions
-	err = ioutil.WriteFile(tasks, []byte(fmt.Sprintf("%v", os.Getpid())), 0644)
+	fTasks := filepath.Join(cgroupFreezer, "tasks")
+	mTasks := filepath.Join(cgroupMemory, "tasks")
+	dTasks := filepath.Join(cgroupDevices, "tasks")
+	err = ioutil.WriteFile(fTasks, []byte(fmt.Sprintf("%v", os.Getpid())), 0644)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(mTasks, []byte(fmt.Sprintf("%v", os.Getpid())), 0644)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(dTasks, []byte(fmt.Sprintf("%v", os.Getpid())), 0644)
 	if err != nil {
 		return err
 	}
@@ -1467,9 +1508,24 @@ func containerMountDefaults(fsPath string) error {
 
 // aggressively cleanup container cruff, called by the nuke api
 func containerNuke() {
-	// walk CGROUP_PATH for tasks, killing each one
-	if _, err := os.Stat(CGROUP_PATH); err == nil {
-		err := filepath.Walk(CGROUP_PATH, containerNukeWalker)
+	// walk minimega cgroups for tasks, killing each one
+	cgroupFreezer := filepath.Join(*f_cgroup, "freezer", "minimega")
+	cgroupMemory := filepath.Join(*f_cgroup, "memory", "minimega")
+	cgroupDevices := filepath.Join(*f_cgroup, "devices", "minimega")
+	if _, err := os.Stat(cgroupFreezer); err == nil {
+		err := filepath.Walk(cgroupFreezer, containerNukeWalker)
+		if err != nil {
+			log.Errorln(err)
+		}
+	}
+	if _, err := os.Stat(cgroupMemory); err == nil {
+		err := filepath.Walk(cgroupFreezer, containerNukeWalker)
+		if err != nil {
+			log.Errorln(err)
+		}
+	}
+	if _, err := os.Stat(cgroupDevices); err == nil {
+		err := filepath.Walk(cgroupFreezer, containerNukeWalker)
 		if err != nil {
 			log.Errorln(err)
 		}
@@ -1494,18 +1550,7 @@ func containerNuke() {
 		}
 	}
 
-	err = containerCleanCgroupDirs()
-	if err != nil {
-		log.Errorln(err)
-	}
-
-	// umount cgroup_root, if it exists
-	if _, err := os.Stat(CGROUP_ROOT); err == nil {
-		err = syscall.Unmount(CGROUP_ROOT, 0)
-		if err != nil {
-			log.Error("cgroup_root unmount: %v", err)
-		}
-	}
+	containerCleanCgroupDirs()
 
 	// remove meganet_* from /var/run/netns
 	if _, err := os.Stat("/var/run/netns"); err == nil {
@@ -1552,36 +1597,46 @@ func containerNukeWalker(path string, info os.FileInfo, err error) error {
 }
 
 // remove state across cgroup mounts
-func containerCleanCgroupDirs() error {
-	_, err := os.Stat(CGROUP_PATH)
-	if err != nil {
-		return nil
+func containerCleanCgroupDirs() {
+	paths := []string{
+		filepath.Join(*f_cgroup, "freezer", "minimega"),
+		filepath.Join(*f_cgroup, "memory", "minimega"),
+		filepath.Join(*f_cgroup, "devices", "minimega"),
 	}
-
-	err = filepath.Walk(CGROUP_PATH, func(path string, info os.FileInfo, err error) error {
+	for _, d := range paths {
+		_, err := os.Stat(d)
 		if err != nil {
-			return nil
+			continue
 		}
 
-		if path == CGROUP_PATH {
-			return nil
-		}
-
-		log.Debug("walking file: %v", path)
-
-		if info.IsDir() {
-			err = os.Remove(path)
+		err = filepath.Walk(d, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				log.Errorln(err)
-				return err
+				return nil
 			}
+
+			if path == d {
+				return nil
+			}
+
+			log.Debug("walking file: %v", path)
+
+			if info.IsDir() {
+				err = os.Remove(path)
+				if err != nil {
+					log.Errorln(err)
+					return err
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			continue
 		}
 
-		return nil
-	})
-	if err != nil {
-		return err
+		err = os.Remove(d)
+		if err != nil {
+			log.Errorln(err)
+		}
 	}
-
-	return os.Remove(CGROUP_PATH)
 }

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -50,6 +50,7 @@ var (
 	f_attach     = flag.Bool("attach", false, "attach the minimega command line to a running instance of minimega")
 	f_cli        = flag.Bool("cli", false, "validate and print the minimega cli, in JSON, to stdout and exit")
 	f_panic      = flag.Bool("panic", false, "panic on quit, producing stack traces for debugging")
+	f_cgroup     = flag.String("cgroup", "/sys/fs/cgroup", "path to cgroup mount")
 
 	vms = VMs{}
 
@@ -80,11 +81,6 @@ func main() {
 
 	flag.Usage = usage
 	flag.Parse()
-
-	// Set the container globals based on the parsed args before we invoke the
-	// containerShim, if applicable.
-	CGROUP_ROOT = filepath.Join(*f_base, "cgroup")
-	CGROUP_PATH = filepath.Join(CGROUP_ROOT, "minimega")
 
 	logSetup()
 


### PR DESCRIPTION
Continue to work around systemd. This time by changing our non-systemd cgroup behavior to simply match the default systemd cgroup hierarchy on ubuntu 16.04.

@jcrussell