### PR TITLE
minimega: add tags to filterString

### DIFF
--- a/src/minimega/cc.go
+++ b/src/minimega/cc.go
@@ -161,6 +161,10 @@ func filterString(f *ron.Client) string {
 			j = append(j, "mac="+y)
 		}
 	}
+	for k, v := range f.Tags {
+		j = append(j, fmt.Sprintf("%v=%v", k, v))
+	}
+
 	ret += strings.Join(j, " && ")
 
 	return ret


### PR DESCRIPTION
Display tags in `cc commands`:

minimega$ cc filter foo=bar
minimega$ cc filter
UUID | hostname | arch | OS | IP | MAC | Tags
     |          |      |    |    |     | {"foo":"bar"}
minimega$ cc exec ls
minimega$ .columns command,filter cc commands
command | filter
[ls]    | foo=bar

Fixes #572.