### PR TITLE
minilog: remove data race

### DIFF
--- a/src/minilog/logger.go
+++ b/src/minilog/logger.go
@@ -1,0 +1,89 @@
+package minilog
+
+import (
+	"fmt"
+	golog "log"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+type minilogger struct {
+	*golog.Logger
+	Level   int
+	Color   bool // print in color
+	filters []string
+}
+
+func (l *minilogger) prologue(level int, name string) (msg string) {
+	switch level {
+	case DEBUG:
+		msg += "DEBUG "
+	case INFO:
+		msg += "INFO "
+	case WARN:
+		msg += "WARN "
+	case ERROR:
+		msg += "ERROR "
+	default:
+		msg += "FATAL "
+	}
+
+	if name == "" {
+		_, file, line, _ := runtime.Caller(4)
+		short := file
+		for i := len(file) - 1; i > 0; i-- {
+			if file[i] == '/' {
+				short = file[i+1:]
+				break
+			}
+		}
+		msg += short + ":" + strconv.Itoa(line) + ": "
+	} else {
+		msg += name + ": "
+	}
+
+	if l.Color {
+		msg = colorLine + msg
+		switch level {
+		case DEBUG:
+			msg += colorDebug
+		case INFO:
+			msg += colorInfo
+		case WARN:
+			msg += colorWarn
+		case ERROR:
+			msg += colorError
+		default:
+			msg += colorFatal
+		}
+	}
+	return
+}
+
+func (l *minilogger) epilogue() string {
+	if l.Color {
+		return Reset
+	}
+	return ""
+}
+
+func (l *minilogger) log(level int, name, format string, arg ...interface{}) {
+	msg := l.prologue(level, name) + fmt.Sprintf(format, arg...) + l.epilogue()
+	for _, f := range l.filters {
+		if strings.Contains(msg, f) {
+			return
+		}
+	}
+	l.Print(msg)
+}
+
+func (l *minilogger) logln(level int, name string, arg ...interface{}) {
+	msg := l.prologue(level, name) + fmt.Sprint(arg...) + l.epilogue()
+	for _, f := range l.filters {
+		if strings.Contains(msg, f) {
+			return
+		}
+	}
+	l.Println(msg)
+}

--- a/src/minilog/minilog.go
+++ b/src/minilog/minilog.go
@@ -16,10 +16,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	golog "log"
 	"os"
-	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 )
@@ -36,7 +34,7 @@ const (
 
 var (
 	loggers = make(map[string]*minilogger)
-	logLock sync.Mutex
+	logLock sync.RWMutex
 )
 
 var (
@@ -48,13 +46,6 @@ var (
 	colorFatal = FgRed
 )
 
-type minilogger struct {
-	*log.Logger
-	Level   int
-	Color   bool // print in color
-	filters []string
-}
-
 // Adds a logger set to log only events at level specified or higher.
 // output: io.Writer instance to which to log (can be os.Stderr or os.Stdout)
 // level:  one of the minilogging levels defined as a constant
@@ -62,7 +53,7 @@ func AddLogger(name string, output io.Writer, level int, color bool) {
 	logLock.Lock()
 	defer logLock.Unlock()
 
-	loggers[name] = &minilogger{log.New(output, "", log.LstdFlags), level, color, nil}
+	loggers[name] = &minilogger{golog.New(output, "", golog.LstdFlags), level, color, nil}
 }
 
 // Remove a named logger that was added using AddLogger
@@ -121,23 +112,15 @@ func GetLevel(name string) (int, error) {
 	return loggers[name].Level, nil
 }
 
-// Log all input from an io.Reader, splitting on lines, until EOF. LogAll starts a goroutine and
-// returns immediately.
-//
-// TODO: How to lock properly for this?
+// Log all input from an io.Reader, splitting on lines, until EOF. LogAll
+// starts a goroutine and returns immediately.
 func LogAll(i io.Reader, level int, name string) {
 	go func(i io.Reader, level int, name string) {
 		r := bufio.NewReader(i)
 		for {
 			d, err := r.ReadString('\n')
-			d = strings.TrimSpace(d)
-			if d != "" {
-				for _, logger := range loggers {
-					if logger.Level <= level {
-						msg := logger.prologue(level, name) + d + logger.epilogue()
-						logger.Println(msg)
-					}
-				}
+			if d := strings.TrimSpace(d); d != "" {
+				log(level, name, d)
 			}
 			if level == FATAL {
 				os.Exit(1)
@@ -213,187 +196,68 @@ func DelFilter(name string, filter string) error {
 	}
 }
 
-func (l *minilogger) prologue(level int, name string) (msg string) {
-	switch level {
-	case DEBUG:
-		msg += "DEBUG "
-	case INFO:
-		msg += "INFO "
-	case WARN:
-		msg += "WARN "
-	case ERROR:
-		msg += "ERROR "
-	default:
-		msg += "FATAL "
-	}
+func log(level int, name, format string, arg ...interface{}) {
+	logLock.RLock()
+	defer logLock.RUnlock()
 
-	if name == "" {
-		_, file, line, _ := runtime.Caller(3)
-		short := file
-		for i := len(file) - 1; i > 0; i-- {
-			if file[i] == '/' {
-				short = file[i+1:]
-				break
-			}
-		}
-		msg += short + ":" + strconv.Itoa(line) + ": "
-	} else {
-		msg += name + ": "
-	}
-
-	if l.Color {
-		msg = colorLine + msg
-		switch level {
-		case DEBUG:
-			msg += colorDebug
-		case INFO:
-			msg += colorInfo
-		case WARN:
-			msg += colorWarn
-		case ERROR:
-			msg += colorError
-		default:
-			msg += colorFatal
+	for _, logger := range loggers {
+		if logger.Level <= level {
+			logger.log(level, name, format, arg...)
 		}
 	}
-	return
 }
 
-func (l *minilogger) epilogue() string {
-	if l.Color {
-		return Reset
-	}
-	return ""
-}
+func logln(level int, name string, arg ...interface{}) {
+	logLock.Lock()
+	defer logLock.Unlock()
 
-func (l *minilogger) log(level int, format string, arg ...interface{}) {
-	msg := l.prologue(level, "") + fmt.Sprintf(format, arg...) + l.epilogue()
-	for _, f := range l.filters {
-		if strings.Contains(msg, f) {
-			return
+	for _, logger := range loggers {
+		if logger.Level <= level {
+			logger.logln(level, name, arg...)
 		}
 	}
-	l.Print(msg)
-}
-
-func (l *minilogger) logln(level int, arg ...interface{}) {
-	msg := l.prologue(level, "") + fmt.Sprint(arg...) + l.epilogue()
-	for _, f := range l.filters {
-		if strings.Contains(msg, f) {
-			return
-		}
-	}
-	l.Println(msg)
 }
 
 func Debug(format string, arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
-
-	for _, logger := range loggers {
-		if logger.Level <= DEBUG {
-			logger.log(DEBUG, format, arg...)
-		}
-	}
+	log(DEBUG, "", format, arg...)
 }
 
 func Info(format string, arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
-
-	for _, logger := range loggers {
-		if logger.Level <= INFO {
-			logger.log(INFO, format, arg...)
-		}
-	}
+	log(INFO, "", format, arg...)
 }
 
 func Warn(format string, arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
-
-	for _, logger := range loggers {
-		if logger.Level <= WARN {
-			logger.log(WARN, format, arg...)
-		}
-	}
+	log(WARN, "", format, arg...)
 }
 
 func Error(format string, arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
-
-	for _, logger := range loggers {
-		if logger.Level <= ERROR {
-			logger.log(ERROR, format, arg...)
-		}
-	}
+	log(ERROR, "", format, arg...)
 }
 
 func Fatal(format string, arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
+	log(FATAL, "", format, arg)
 
-	for _, logger := range loggers {
-		if logger.Level <= FATAL {
-			logger.log(FATAL, format, arg...)
-		}
-	}
 	os.Exit(1)
 }
 
 func Debugln(arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
-
-	for _, logger := range loggers {
-		if logger.Level <= DEBUG {
-			logger.logln(DEBUG, arg...)
-		}
-	}
+	logln(DEBUG, "", arg...)
 }
 
 func Infoln(arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
-
-	for _, logger := range loggers {
-		if logger.Level <= INFO {
-			logger.logln(INFO, arg...)
-		}
-	}
+	logln(INFO, "", arg...)
 }
 
 func Warnln(arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
-
-	for _, logger := range loggers {
-		if logger.Level <= WARN {
-			logger.logln(WARN, arg...)
-		}
-	}
+	logln(WARN, "", arg...)
 }
 
 func Errorln(arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
-
-	for _, logger := range loggers {
-		if logger.Level <= ERROR {
-			logger.logln(ERROR, arg...)
-		}
-	}
+	logln(ERROR, "", arg...)
 }
 
 func Fatalln(arg ...interface{}) {
-	logLock.Lock()
-	defer logLock.Unlock()
+	logln(FATAL, "", arg...)
 
-	for _, logger := range loggers {
-		if logger.Level <= FATAL {
-			logger.logln(FATAL, arg...)
-		}
-	}
 	os.Exit(1)
 }


### PR DESCRIPTION
Add an RWMutex to minilog to synchronize access to global state. If you were adding a logger while something was logging, a concurrent map access could cause a panic.

This adds some overhead but it seems pretty minimal (from BenchmarkLogging):

Without lock: 77560 ns/op, total time: 3.022s
With lock: 78526 ns/op, total time: 3.052s

Fixes #515 