### PR TITLE
minimega: never copy VM mutex

### DIFF
--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -216,7 +216,7 @@ type ContainerConfig struct {
 }
 
 type ContainerVM struct {
-	BaseVM          // embed
+	*BaseVM         // embed
 	ContainerConfig // embed
 
 	pid             int
@@ -558,7 +558,7 @@ func (vm *ContainerVM) Config() *BaseConfig {
 func NewContainer(name string, config VMConfig) (*ContainerVM, error) {
 	vm := new(ContainerVM)
 
-	vm.BaseVM = *NewBaseVM(name, config)
+	vm.BaseVM = NewBaseVM(name, config)
 	vm.Type = CONTAINER
 
 	vm.ContainerConfig = config.ContainerConfig.Copy() // deep-copy configured fields
@@ -579,11 +579,8 @@ func (vm *ContainerVM) Copy() VM {
 	// Make shallow copies of all fields
 	*vm2 = *vm
 
-	// We copied a locked VM so we have to unlock it too...
-	defer vm2.lock.Unlock()
-
 	// Make deep copies
-	vm2.BaseConfig = vm.BaseConfig.Copy()
+	vm2.BaseVM = vm.BaseVM.copy()
 	vm2.ContainerConfig = vm.ContainerConfig.Copy()
 
 	return vm2

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -53,7 +53,7 @@ type KVMConfig struct {
 }
 
 type KvmVM struct {
-	BaseVM    // embed
+	*BaseVM   // embed
 	KVMConfig // embed
 
 	// Internal variables
@@ -111,7 +111,7 @@ func (old KVMConfig) Copy() KVMConfig {
 func NewKVM(name string, config VMConfig) (*KvmVM, error) {
 	vm := new(KvmVM)
 
-	vm.BaseVM = *NewBaseVM(name, config)
+	vm.BaseVM = NewBaseVM(name, config)
 	vm.Type = KVM
 
 	vm.KVMConfig = config.KVMConfig.Copy() // deep-copy configured fields
@@ -130,11 +130,8 @@ func (vm *KvmVM) Copy() VM {
 	// Make shallow copies of all fields
 	*vm2 = *vm
 
-	// We copied a locked VM so we have to unlock it too...
-	defer vm2.lock.Unlock()
-
 	// Make deep copies
-	vm2.BaseConfig = vm.BaseConfig.Copy()
+	vm2.BaseVM = vm.BaseVM.copy()
 	vm2.KVMConfig = vm.KVMConfig.Copy()
 
 	return vm2

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -240,6 +240,21 @@ func NewBaseVM(name string, config VMConfig) *BaseVM {
 	return vm
 }
 
+// copy a BaseVM... assume that lock is held.
+func (vm *BaseVM) copy() *BaseVM {
+	vm2 := new(BaseVM)
+
+	// Make copies of all fields except lock/kill
+	vm2.BaseConfig = vm.BaseConfig.Copy()
+	vm2.ID = vm.ID
+	vm2.Name = vm.Name
+	vm2.State = vm.State
+	vm2.Type = vm.Type
+	vm2.instancePath = vm.instancePath
+
+	return vm2
+}
+
 func (s VMType) String() string {
 	switch s {
 	case KVM:
@@ -768,7 +783,7 @@ func (vm *BaseVM) writeTaps() error {
 	return nil
 }
 
-func (vm *BaseVM) conflicts(vm2 BaseVM) error {
+func (vm *BaseVM) conflicts(vm2 *BaseVM) error {
 	// Return error if two VMs have same name or UUID
 	if vm.Namespace == vm2.Namespace {
 		if vm.Name == vm2.Name {


### PR DESCRIPTION
The race detector detects a possible race with the copied VM mutex. In
order to avoid this entirely, don't copy the mutex.

Fixes #650