### PR TITLE
minimega/web: merge vnc/terminal URLs

### DIFF
--- a/misc/web/js/glue.js
+++ b/misc/web/js/glue.js
@@ -53,12 +53,9 @@ function screenshotURL (vm, size) {
     return "./screenshot/" + vm.host + "/" + vm.id + ".png?size=" + size;
 }
 
-// Generate the appropriate URL for requesting a VNC connection
-function vncURL (vm) {
-	if (vm.type == "container") {
-        return "./terminal#" + vm.name
-	}
-    return "./vnc#" + vm.name
+// Generate the appropriate URL for a connection
+function connectURL (vm) {
+    return "./connect/" + vm.name
 }
 
 // Get the screenshot for the requested row, or restore it from the cache of screenshots if available
@@ -190,7 +187,7 @@ function updateTables () {
         var vm = grapher.jsonData[i];
 
         toAppend.find("h3").text(vm.name);
-        toAppend.find("a.connect-vm-button").attr("href", vncURL(vm));
+        toAppend.find("a.connect-vm-button").attr("href", connectURL(vm));
         toAppend.find("img").attr("data-url", screenshotURL(vm, 300));
         toAppend.find(".screenshot-state").addClass(COLOR_CLASSES[vm.state]).html(vm.state);
 

--- a/misc/web/js/graph.js
+++ b/misc/web/js/graph.js
@@ -356,7 +356,7 @@ function setSidebarNode (id) {
         d3.select(config.selectors.sidebarTable).html("");
     } else {
         container.attr("class", "");
- 
+
         if (grapher.graph.nodes[id].group == config.types.normal) {
             var vlan = grapher.graph.nodes[id].vlans[0];
             header.text("VLAN " + vlan);
@@ -382,7 +382,7 @@ function setSidebarNode (id) {
             var node = grapher.graph.nodes[id].machines[0];
             header.text(node.name);
             subheader.text("Router");
-            
+
             toReturn = listMachines(ul, id, [node.uuid]);
             makeTable(d3.select(config.selectors.sidebarTable), {});
             vmAlwaysHighlighted(d3.select(".member-node").node(), false, true);
@@ -394,18 +394,18 @@ function setSidebarNode (id) {
 
             toReturn = listMachines(ul, id);
             makeTable(d3.select(config.selectors.sidebarTable), {});
-                
+
         } else if (grapher.graph.nodes[id].group == config.types.unconnected) {
             var node = grapher.graph.nodes[id].machines[0];
             header.text(node.name);
             subheader.text("Unconnected");
-            
+
             toReturn = listMachines(ul, id, [node.uuid]);
             makeTable(d3.select(config.selectors.sidebarTable), grapher.graph.nodes[id].machines[0]);
             addVNClink(d3.select(config.selectors.sidebarTable), grapher.graph.nodes[id].machines[0]);
             vmAlwaysHighlighted(d3.select(".member-node").node(), true, false);
         }
-        
+
         subheader.style("color", nodeColor(grapher.graph.nodes[id], true));
     }
 
@@ -526,7 +526,7 @@ function setPopupMachine (vm, node) {
 }
 
 function makeVNClink(vm) {
-    return "<a target=\"_blank\" href=\"" + vncURL(vm) + "\">" + vm.host + ":" + (5900 + vm.id) + "</a>"
+    return "<a target=\"_blank\" href=\"" + connectURL(vm) + "\">" + vm.name + "</a>"
 }
 
 function addVNClink(parent, vm) {
@@ -703,7 +703,7 @@ function makeGraph (response, ethers) {
             vm["node_type"] = "unconnected";
             unconnected.push(vm);
             network.machines.unconnected.push(vm);
-        
+
         // Router (multiple VLANs)
         } else if (vm.network.length > 1) {
             vm["node_type"] = "router";
@@ -926,14 +926,14 @@ $(document).ready(function () {
 
         if (cursor.movedTo == null) {   // If the cursor hasn't moved...
             var nodeId = eventNode(e);
-            
+
             if (nodeId > -1) {          // And we clicked on a node...
 
                 // If the selected node isn't null and the selected node isn't the newly clicked node...
                 if ((grapher.selectedNode != null) && (grapher.selectedNode != nodeId)) {
                     setColor(grapher.selectedNode);
                 }
-                
+
                 // If we didn't go from hovering over a node to immediately leaving the graph
                 if (!((e.type == "mouseleave") && (cursor.hoveringOver != null))) {
                     outlineNode(nodeId);

--- a/misc/web/terminal.html
+++ b/misc/web/terminal.html
@@ -11,7 +11,7 @@
 		term.open(terminalContainer);
 		term.resize(80, 24);
 
-		path = "/termws/" + window.location.hash.substring(1);
+		path = "/tunnel/" + window.location.pathname.substring(window.location.pathname.lastIndexOf("/")+1)
 		socketURL = "ws://"+window.location.hostname+":"+window.location.port+path;
 		socket = new WebSocket(socketURL);
 		socket.onopen = runterminal;

--- a/misc/web/vnc_auto.html
+++ b/misc/web/vnc_auto.html
@@ -209,7 +209,7 @@
             password = WebUtil.getConfigVar('password', '');
 
             // minimega: grab VM name from URL
-            path = "ws/" + window.location.hash.substring(1);
+            path = "tunnel/" + window.location.pathname.substring(window.location.pathname.lastIndexOf("/")+1)
 
             // If a token variable is passed in, set the parameter in a cookie.
             // This is used by nova-novncproxy.


### PR DESCRIPTION
"Do the right thing" based on the VM type rather than using specific
URLs. Makes it really nice to connect to either the VNC or terminal for
a VM by name. For example:

```
web
vm config filesystem /data/minimega/containerfs
vm launch container 1
vm launch kvm 1
vm start all
```

The URLS to connect are then:

http://localhost:9001/connect/vm-0
http://localhost:9001/connect/vm-1