### PR TITLE
bridge: fix deadlock in bridge.Destroy

### DIFF
--- a/src/bridge/bridges.go
+++ b/src/bridge/bridges.go
@@ -105,7 +105,7 @@ func (b Bridges) newBridge(name string) error {
 		}
 	}
 
-	if br.handle, err = pcap.OpenLive(br.Name, 1600, true, pcap.BlockForever); err != nil {
+	if br.handle, err = pcap.OpenLive(br.Name, 1600, true, time.Second); err != nil {
 		goto cleanup
 	}
 
@@ -278,7 +278,7 @@ func (b Bridges) FindTap(t string) (Tap, error) {
 	for _, br := range b.bridges {
 		for _, tap := range br.taps {
 			if tap.Name == t && !tap.Defunct {
-				log.Info("found tap %v on bridge %v", t, br.Name)
+				log.Debug("found tap %v on bridge %v", t, br.Name)
 				return *tap, nil
 			}
 		}

--- a/src/bridge/ipmac.go
+++ b/src/bridge/ipmac.go
@@ -15,11 +15,8 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
 )
-
-func (b *Bridge) Close() {
-	b.handle.Close()
-}
 
 func (b *Bridge) snooper() {
 	var (
@@ -42,10 +39,12 @@ func (b *Bridge) snooper() {
 
 	for {
 		data, _, err := b.handle.ReadPacketData()
-		if err != nil {
-			if err != io.EOF {
-				log.Error("error reading packet data: ", err)
-			}
+		if err == pcap.NextErrorTimeoutExpired {
+			continue
+		} else if err == io.EOF {
+			break
+		} else if err != nil {
+			log.Error("error reading packet data: ", err)
 			break
 		}
 


### PR DESCRIPTION
bridge.Destroy would block forever if there are running VMs since the
snooper was holding a lock and blocking on reading packets. Set a
timeout and loop if we timeout so that we can close the pcap handle.

Fixes #723