### PR TITLE
minimega: make capture more namespace aware

### DIFF
--- a/src/minicli/handler.go
+++ b/src/minicli/handler.go
@@ -61,6 +61,19 @@ func (h *Handler) compile(input *Input) (*Command, int, bool) {
 	return nil, maxMatchLen, false
 }
 
+func (h *Handler) parsePatterns() error {
+	for _, pattern := range h.Patterns {
+		items, err := lexPattern(pattern)
+		if err != nil {
+			return err
+		}
+
+		h.PatternItems = append(h.PatternItems, items)
+	}
+
+	return nil
+}
+
 func (h *Handler) suggest(input *Input) []string {
 	suggestions := []string{}
 

--- a/src/minimega/capture.go
+++ b/src/minimega/capture.go
@@ -114,7 +114,7 @@ func clearCapture(captureType, bridgeOrVM, name string) (err error) {
 		}
 
 		if entry == nil {
-			return fmt.Errorf("a capture for %v %v does not exist", bridgeOrVM, name)
+			return vmNotFound(name)
 		}
 
 		if entry.Type != captureType {

--- a/src/minimega/capture.go
+++ b/src/minimega/capture.go
@@ -104,7 +104,7 @@ func clearCapture(captureType, bridgeOrVM, name string) (err error) {
 					continue
 				}
 			} else if bridgeOrVM == "vm" {
-				if val.VM.GetName() == name {
+				if val.VM.GetName() == name && val.VM.GetNamespace() == namespace {
 					entry = val
 					break
 				} else {
@@ -115,10 +115,6 @@ func clearCapture(captureType, bridgeOrVM, name string) (err error) {
 
 		if entry == nil {
 			return fmt.Errorf("a capture for %v %v does not exist", bridgeOrVM, name)
-		}
-
-		if !entry.InNamespace(namespace) {
-			return fmt.Errorf("%v %v is not in active namespace", bridgeOrVM, name)
 		}
 
 		if entry.Type != captureType {

--- a/src/minimega/capture.go
+++ b/src/minimega/capture.go
@@ -10,6 +10,7 @@ import (
 	"gonetflow"
 	"gopcap"
 	log "minilog"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -123,6 +124,11 @@ func startCapturePcap(v string, iface int, filename string) error {
 	bridge := config.Networks[iface].Bridge
 	tap := config.Networks[iface].Tap
 
+	// Ensure that relative paths are always relative to /files/
+	if !filepath.IsAbs(filename) {
+		filename = filepath.Join(*f_iomBase, filename)
+	}
+
 	// attempt to start pcap on the bridge
 	p, err := gopcap.NewPCAP(tap, filename)
 	if err != nil {
@@ -159,6 +165,11 @@ func startBridgeCapturePcap(b, filename string) error {
 	tap, err := br.CreateMirror()
 	if err != nil {
 		return err
+	}
+
+	// Ensure that relative paths are always relative to /files/
+	if !filepath.IsAbs(filename) {
+		filename = filepath.Join(*f_iomBase, filename)
 	}
 
 	// attempt to start pcap on the mirrored tap
@@ -198,6 +209,11 @@ func startCaptureNetflowFile(bridge, filename string, ascii, compress bool) erro
 	if ascii {
 		mode = gonetflow.ASCII
 		modeStr = "ascii"
+	}
+
+	// Ensure that relative paths are always relative to /files/
+	if !filepath.IsAbs(filename) {
+		filename = filepath.Join(*f_iomBase, filename)
 	}
 
 	err = nf.NewFileWriter(filename, mode, compress)

--- a/src/minimega/capture_cli.go
+++ b/src/minimega/capture_cli.go
@@ -25,7 +25,7 @@ var captureCLIHandlers = []minicli.Handler{
 		HelpShort: "capture experiment data for a VM",
 		Patterns: []string{
 			"capture <pcap,> vm <name> <interface index> <filename>",
-			"capture <pcap,> <delete,> vm <name>",	
+			"capture <pcap,> <delete,> vm <name>",
 		},
 		Call: wrapVMTargetCLI(cliCaptureVM),
 	},
@@ -67,11 +67,14 @@ VM:
 When run without arguments, capture prints all running captures. To stop a
 capture, use the delete commands:
 
-	capture netflow delete <id>
-	capture pcap delete <id>
+	capture netflow delete bridge <bridge>
+	capture pcap delete bridge <bridge>
+	capture pcap delete vm <name>
 
 To stop all captures of a particular kind, replace id with "all". To stop all
-capture of all types, use "clear capture".
+capture of all types, use "clear capture". If a VM has multiple interfaces and
+there are multiple captures running, calling "capture pcap delete vm <name>"
+stops all the captures for that VM.
 
 Notes with namespaces:
  * "capture [netflow,pcap]" lists captures across the namespace

--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -188,6 +188,8 @@ func wrapVMTargetCLI(fn func(*minicli.Command, *minicli.Response) error) minicli
 		res := minicli.Responses{}
 		var ok bool
 
+		var notFound string
+
 		// Broadcast to all machines, collecting errors and forwarding
 		// successful commands.
 		//
@@ -196,7 +198,9 @@ func wrapVMTargetCLI(fn func(*minicli.Command, *minicli.Response) error) minicli
 			for _, resp := range resps {
 				ok = ok || (resp.Error == "")
 
-				if resp.Error == "" || !isVmNotFound(resp.Error) {
+				if isVMNotFound(resp.Error) {
+					notFound = resp.Error
+				} else {
 					// Record successes and unexpected errors
 					res = append(res, resp)
 				}
@@ -207,7 +211,7 @@ func wrapVMTargetCLI(fn func(*minicli.Command, *minicli.Response) error) minicli
 			// Presumably, we weren't able to find the VM
 			res = append(res, &minicli.Response{
 				Host:  hostname,
-				Error: vmNotFound(c.StringArgs["target"]).Error(),
+				Error: notFound,
 			})
 		}
 

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -495,7 +495,6 @@ func (vm *KvmVM) launch() error {
 	// create and add taps if we are associated with any networks
 	for i := range vm.Networks {
 		nic := &vm.Networks[i]
-		log.Info("%#v", nic)
 
 		br, err := getBridge(nic.Bridge)
 		if err != nil {

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -255,13 +255,14 @@ func teardown() {
 	// Clear namespace so that we hit all the VMs
 	SetNamespace("")
 
-	vncClear()
 	clearAllCaptures()
-	vms.Kill(Wildcard)
+	vncClear()
 	dnsmasqKillAll()
-	ksmDisable()
+
+	vms.Kill(Wildcard)
 	vms.Flush()
-	vms.CleanDirs()
+
+	ksmDisable()
 	containerTeardown()
 
 	if err := bridgesDestroy(); err != nil {

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -830,7 +830,7 @@ func vmNotContainer(idOrName string) error {
 	return fmt.Errorf("vm not container: %v", idOrName)
 }
 
-func isVmNotFound(err string) bool {
+func isVMNotFound(err string) bool {
 	return strings.HasPrefix(err, "vm not found: ")
 }
 

--- a/tests/capture
+++ b/tests/capture
@@ -1,0 +1,38 @@
+# Shorthands
+.alias list=.columns Bridge,Type,VM/interface,Mode,Compress,Path capture
+.alias nslist=.columns Bridge,Type,VM/interface,Mode,Compress,Path,Namespace capture
+
+# Start VMs in different namespaces
+vm config net A
+namespace foo vm launch kvm foo
+namespace foo vm launch kvm car
+namespace foo vm launch
+namespace bar vm launch kvm bar
+namespace bar vm launch kvm car
+namespace bar vm launch
+
+# Start captures in respective namespaces
+namespace foo capture pcap vm foo 0 /dev/null
+namespace bar capture pcap vm bar 0 /dev/null
+nslist
+namespace foo list
+namespace bar list
+
+# Make sure we only clear the capture in foo namespace
+namespace foo clear capture
+nslist
+namespace foo list
+namespace bar list
+
+# Clear out all captures
+clear capture
+nslist
+
+# Capture VMs with same names in different namespaces
+namespace foo capture pcap vm car 0 /dev/null
+namespace bar capture pcap vm car 0 /dev/null
+nslist
+
+# Cleanup
+.unalias list
+.unalias nslist

--- a/tests/capture
+++ b/tests/capture
@@ -26,6 +26,8 @@ capture
 
 # Capture VMs with same names in different namespaces
 namespace foo capture pcap vm car 0 /dev/null
+namespace foo capture pcap vm car 0 /dev/null
+namespace bar capture pcap vm car 0 /dev/null
 namespace bar capture pcap vm car 0 /dev/null
 capture
 
@@ -36,3 +38,8 @@ capture
 # Delete all captures in the other namespace
 namespace bar capture pcap delete vm all
 capture
+
+# Try some things that shouldn't work
+namespace foo capture pcap vm car 1 /dev/null
+namespace foo capture pcap vm bar 0 /dev/null
+namespace foo capture pcap delete vm bar

--- a/tests/capture
+++ b/tests/capture
@@ -28,3 +28,11 @@ capture
 namespace foo capture pcap vm car 0 /dev/null
 namespace bar capture pcap vm car 0 /dev/null
 capture
+
+# Delete a capture in one namespace but not the other
+namespace foo capture pcap delete vm car
+capture
+
+# Delete all captures in the other namespace
+namespace bar capture pcap delete vm all
+capture

--- a/tests/capture
+++ b/tests/capture
@@ -1,7 +1,3 @@
-# Shorthands
-.alias list=.columns Bridge,Type,VM/interface,Mode,Compress,Path capture
-.alias nslist=.columns Bridge,Type,VM/interface,Mode,Compress,Path,Namespace capture
-
 # Start VMs in different namespaces
 vm config net A
 namespace foo vm launch kvm foo
@@ -14,25 +10,21 @@ namespace bar vm launch
 # Start captures in respective namespaces
 namespace foo capture pcap vm foo 0 /dev/null
 namespace bar capture pcap vm bar 0 /dev/null
-nslist
-namespace foo list
-namespace bar list
+capture
+namespace foo capture
+namespace bar capture
 
 # Make sure we only clear the capture in foo namespace
 namespace foo clear capture
-nslist
-namespace foo list
-namespace bar list
+capture
+namespace foo capture
+namespace bar capture
 
 # Clear out all captures
 clear capture
-nslist
+capture
 
 # Capture VMs with same names in different namespaces
 namespace foo capture pcap vm car 0 /dev/null
 namespace bar capture pcap vm car 0 /dev/null
-nslist
-
-# Cleanup
-.unalias list
-.unalias nslist
+capture

--- a/tests/capture.want
+++ b/tests/capture.want
@@ -42,3 +42,13 @@ mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null
 Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
 mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | bar
 mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | foo
+
+## # Delete a capture in one namespace but not the other
+## namespace foo capture pcap delete vm car
+## capture
+Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
+mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | bar
+
+## # Delete all captures in the other namespace
+## namespace bar capture pcap delete vm all
+## capture

--- a/tests/capture.want
+++ b/tests/capture.want
@@ -37,10 +37,14 @@ mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null
 
 ## # Capture VMs with same names in different namespaces
 ## namespace foo capture pcap vm car 0 /dev/null
+## namespace foo capture pcap vm car 0 /dev/null
+## namespace bar capture pcap vm car 0 /dev/null
 ## namespace bar capture pcap vm car 0 /dev/null
 ## capture
 Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
 mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | bar
+mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | bar
+mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | foo
 mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | foo
 
 ## # Delete a capture in one namespace but not the other
@@ -48,7 +52,16 @@ mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | foo
 ## capture
 Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
 mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | bar
+mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | bar
 
 ## # Delete all captures in the other namespace
 ## namespace bar capture pcap delete vm all
 ## capture
+
+## # Try some things that shouldn't work
+## namespace foo capture pcap vm car 1 /dev/null
+E: no such interface 1
+## namespace foo capture pcap vm bar 0 /dev/null
+E: vm not found: bar
+## namespace foo capture pcap delete vm bar
+E: vm not found: bar

--- a/tests/capture.want
+++ b/tests/capture.want
@@ -1,0 +1,52 @@
+## # Shorthands
+## .alias list=.columns Bridge,Type,VM/interface,Mode,Compress,Path capture
+## .alias nslist=.columns Bridge,Type,VM/interface,Mode,Compress,Path,Namespace capture
+
+## # Start VMs in different namespaces
+## vm config net A
+## namespace foo vm launch kvm foo
+## namespace foo vm launch kvm car
+## namespace foo vm launch
+## namespace bar vm launch kvm bar
+## namespace bar vm launch kvm car
+## namespace bar vm launch
+
+## # Start captures in respective namespaces
+## namespace foo capture pcap vm foo 0 /dev/null
+## namespace bar capture pcap vm bar 0 /dev/null
+## nslist
+Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
+mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null | bar
+mega_bridge | pcap | foo:0        | N/A  | false    | /dev/null | foo
+## namespace foo list
+Bridge      | Type | VM/interface | Mode | Compress | Path
+mega_bridge | pcap | foo:0        | N/A  | false    | /dev/null
+## namespace bar list
+Bridge      | Type | VM/interface | Mode | Compress | Path
+mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null
+
+## # Make sure we only clear the capture in foo namespace
+## namespace foo clear capture
+## nslist
+Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
+mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null | bar
+## namespace foo list
+## namespace bar list
+Bridge      | Type | VM/interface | Mode | Compress | Path
+mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null
+
+## # Clear out all captures
+## clear capture
+## nslist
+
+## # Capture VMs with same names in different namespaces
+## namespace foo capture pcap vm car 0 /dev/null
+## namespace bar capture pcap vm car 0 /dev/null
+## nslist
+Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
+mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | bar
+mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | foo
+
+## # Cleanup
+## .unalias list
+## .unalias nslist

--- a/tests/capture.want
+++ b/tests/capture.want
@@ -1,7 +1,3 @@
-## # Shorthands
-## .alias list=.columns Bridge,Type,VM/interface,Mode,Compress,Path capture
-## .alias nslist=.columns Bridge,Type,VM/interface,Mode,Compress,Path,Namespace capture
-
 ## # Start VMs in different namespaces
 ## vm config net A
 ## namespace foo vm launch kvm foo
@@ -14,39 +10,35 @@
 ## # Start captures in respective namespaces
 ## namespace foo capture pcap vm foo 0 /dev/null
 ## namespace bar capture pcap vm bar 0 /dev/null
-## nslist
+## capture
 Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
 mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null | bar
 mega_bridge | pcap | foo:0        | N/A  | false    | /dev/null | foo
-## namespace foo list
+## namespace foo capture
 Bridge      | Type | VM/interface | Mode | Compress | Path
 mega_bridge | pcap | foo:0        | N/A  | false    | /dev/null
-## namespace bar list
+## namespace bar capture
 Bridge      | Type | VM/interface | Mode | Compress | Path
 mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null
 
 ## # Make sure we only clear the capture in foo namespace
 ## namespace foo clear capture
-## nslist
+## capture
 Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
 mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null | bar
-## namespace foo list
-## namespace bar list
+## namespace foo capture
+## namespace bar capture
 Bridge      | Type | VM/interface | Mode | Compress | Path
 mega_bridge | pcap | bar:0        | N/A  | false    | /dev/null
 
 ## # Clear out all captures
 ## clear capture
-## nslist
+## capture
 
 ## # Capture VMs with same names in different namespaces
 ## namespace foo capture pcap vm car 0 /dev/null
 ## namespace bar capture pcap vm car 0 /dev/null
-## nslist
+## capture
 Bridge      | Type | VM/interface | Mode | Compress | Path      | Namespace
 mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | bar
 mega_bridge | pcap | car:0        | N/A  | false    | /dev/null | foo
-
-## # Cleanup
-## .unalias list
-## .unalias nslist

--- a/tests/epilog
+++ b/tests/epilog
@@ -1,7 +1,8 @@
 clear namespace
-clear vlans
-clear vm config
+clear capture
+clear cc
 vm kill all
 vm flush
-clear cc
+clear vlans
+clear vm config
 clear history


### PR DESCRIPTION
Made the capture API more namespace aware, still not fully though. Fixed
a bug in `clear capture` where it was only stopping the first capture.
Passes local test, need to try in a multiple node experiment.

Also: fix segfault in gopcap and minor improvement to minicli.

Fixes #707

@glattercj -- do you want to test this?
