### PR TITLE
documentation: create cluster.article

### DIFF
--- a/doc/content/articles/cluster.article
+++ b/doc/content/articles/cluster.article
@@ -1,0 +1,188 @@
+Running minimega on a cluster
+
+The minimega authors
+24 Oct 2016
+
+* Intro & Pre-requisites
+
+This guide covers the basics of setting up a cluster to run minimega
+and the process of launching minimega across a cluster.
+
+You'll need minimega, either compiled from source or downloaded as a
+tarball. See the [[installing.article][article on installing minimega]] for
+information on how to fetch and compile minimega. Although you only need
+the minimega tree on *one* node, you do need the external dependencies
+installed on every individual node, so make sure to install those.
+
+Although minimega is decentralized, we like to pick one node as a
+head node. This node is then the one that will store the minimega
+tree, plus any disk images or results files we may generate. We
+like to put the minimega tree under `/opt`, as mentioned in the
+[[installing.article][installation article]]
+
+** On node names
+
+minimega works best if all nodes have the same prefix followed
+by a number; this also makes it easier to write shell scripts for
+administering the cluster. For example, one of our minimega production
+clusters is called "The Country Club Cluster", so the nodes are named
+`ccc1`, `ccc2`, `ccc3`, and so on. We recommend against "themed"
+naming schemes, such as `dopey`, `sleepy`, `grumpy`.
+
+For the purposes of this document, we will assume you have 10 nodes,
+named `node1` through `node10`.
+
+* Setting up the network
+
+In order to have VMs on different host nodes talk to each other, we need
+to make a change to the networking. In short, we will use Open vSwitch to
+set up a bridge and add our physical ethernet device to that bridge. The
+bridge will then be able to act as the physical interface (get an IP,
+serve ssh, etc.) but will *also* move VLAN-tagged traffic from the VMs
+to the physical network.
+
+If you are in a hurry, you can skip the Background section and go straight
+to Configuring Open vSwitch.
+
+** Background: Open vSwitch
+
+minimega uses Open vSwitch to manage networking. Open vSwitch is a
+software package that can manipulate virtual and real network interfaces
+for advanced functionality beyond standard Linux tools. It can set
+up vlan-tagged virtual interfaces for virtual machines, then trunk
+vlan-tagged traffic up to the physical switch connected to the node
+running minimega.
+
+If your switch supports IEEE 802.1q vlan tagging (and most should), then
+vlan tagged interfaces with the same tag number should be able to see
+other interfaces with that tag number, even on other physical nodes. So
+if you have lots of VMs running across a cluster, as long as they were
+all configured with the same virtual network via `vm`config`net`, they
+will all be able to communicate.  If configured correctly, Open vSwitch
+and your switch hardware will interpret the vlan tag and switch traffic
+for that vlan as if on an isolated network.
+
+It is also possible to have multiple, isolated vlans running on several nodes
+in a cluster. That is, you can have nodes A and B both running VMs with vlans
+100 and 200, and Open vSwitch and your switch hardware will isolate the two
+networks, even though the traffic is going to both physical nodes. 
+
+If software defined networking and setting up Open vSwitch is new to you, check
+out the [[http://openvswitch.org][Open vSwitch website]] for more information. 
+
+** Configuring Open vSwitch for cluster operation
+
+minimega by default does *not* bridge any physical interfaces to the
+virtual switch. In order to allow multiple nodes to have VMs on the same
+vlan, you must attach a physical interface from each node to the virtual
+bridge in trunking mode. Doing so will disallow the physical interface
+from having an IP, you will need to assign an IP (or request one via DHCP)
+for the new virtual bridge we create.
+
+By default, minimega uses a bridge called `mega_bridge`. If such a bridge
+already exists, minimega will use it. We will therefore set up a bridge
+that includes the physical ethernet device.
+
+Let us assume each cluster node has a single physical interface called
+eth0 and gets its IP via DHCP. We will demonstrate two different
+ways of setting up the bridge, with the same results: a bridge called
+`mega_bridge` with `eth0` attached to it.
+
+*NOTE*: NetworkManager may interfere with both methods. We strongly
+recommend against using NetworkManager, it is unecessary in a cluster
+environment (and usually in a desktop environment, too)
+
+*** Shell commands
+
+You can create the bridge manually using the following commands, although
+*adding*eth0*will*cause*the*device*to*stop*responding*to*the*network*until*you*assign*an*IP*to*the*bridge*,
+so *do*not*run*these*commands*over*ssh*:
+
+	$ ovs-vsctl add-br mega_bridge
+	
+	# This will drop you from the network
+	$ ovs-vsctl add-port mega_bridge eth0
+	
+	# Now we can get an IP for the bridge instead
+	$ dhclient mega_bridge
+
+You can add those commands to e.g. `/etc/rc.local` so they will run on bootup.
+
+*** /etc/network/interfaces
+
+An alternative supported by some distributions is to configure the bridge
+via `/etc/network/interfaces`. You can add an entry to the file like this:
+
+	allow-ovs mega_bridge
+	iface mega_bridge inet dhcp
+	    ovs_type OVSBridge
+	    ovs_ports eth0
+
+After editing the file, running `service`networking`restart` should leave
+you with a `mega_bridge` device that has a DHCP address assigned. It
+should also come up correctly at boot.
+
+* Deploying minimega
+
+As mentioned above, you only need the minimega tree on one node of
+the cluster--we'll call this the head node. Using the `deploy` api,
+minimega can copy itself to other nodes in the cluster, launch itself,
+and discover the other cluster members to form a mesh.
+
+** Start minimega on the head node
+
+On the head node, we launch minimega by hand. Command line flags passed
+to this instance will be used on all the other instances we deploy across
+the cluster. The flags we're concerned with are:
+
+	-degree: specifies the number of other nodes minimega should try to connect to. This is the most important flag! 3 or 4 is a good value.
+	-context: a string that will distinguish your minimega instances from any others on the network. Your username is usually a good choice
+	-nostdin: specifies that this particular minimega should not accept input from the terminal; we will send it commands over a socket instead.
+
+Given those flags, you might start minimega like this (as root):
+
+	$ /opt/minimega/bin/minimega -degree 3 -context john -nostdin &
+
+** Start minimega on the other nodes
+
+Now that minimega is running on the head node, we can connect to it over
+the Unix socket:
+
+	$ /opt/minimega/bin/minimega -attach
+
+This will give you a minimega prompt where we'll enter the command to
+launch on the other nodes:
+
+	minimega$ deploy launch node[2-10]
+
+The `deploy` command copies the current minimega binary to the nodes
+you specify using `scp`, then launches them with `ssh` using the same
+set of command line flags as the minimega instance that ran `deploy`.
+
+After a minute or so, the other instances of minimega should have located
+each other and created a communications mesh. You can check the status
+like this:
+
+	minimega$ mesh status
+	host  | mesh size | degree | peers | context | port
+	node1 | 10        | 3      | 6     | john    | 9000
+
+	minimega$ mesh list
+	node1: node10
+	 |--node1
+	 |--node3
+	 |--node7
+	node3
+	 |--node7
+	 |--node2
+	 |--node1
+		(...)
+
+`mesh`status` shows general information about the communications mesh,
+including "mesh size", the number of nodes in the mesh. Because it shows
+a mesh size of 10, we know our entire 10-node cluster is in the mesh.
+
+`mesh`list` lists each mesh node and the nodes to which it is
+connected. Note that because we specified `-degree`3`, each node is
+connected to 3 others. Some nodes may be connected to more than 3 nodes,
+but each should have at least 3 connections.

--- a/doc/content/articles/cluster.article
+++ b/doc/content/articles/cluster.article
@@ -20,6 +20,25 @@ tree, plus any disk images or results files we may generate. We
 like to put the minimega tree under `/opt`, as mentioned in the
 [[installing.article][installation article]]
 
+** Passwordless login
+
+Cluster administration is much easier if you have it set up so you don't
+have to type a password to log in. The more secure way to do this is by
+setting up SSH keys for root on every node.
+
+Another option, if your cluster is not accessible to the public, is to
+simply turn on password-less root login. The following script should set
+it up:
+
+	#!/bin/bash
+        sed -i 's/nullok_secure/nullok/' /etc/pam.d/common-auth
+        sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+        sed -i 's/PermitEmptyPasswords no/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
+        passwd -d root
+
+Again, this is only a good idea if your cluster is secured behind a
+front-end node.
+
 ** On node names
 
 minimega works best if all nodes have the same prefix followed
@@ -127,7 +146,9 @@ should also come up correctly at boot.
 As mentioned above, you only need the minimega tree on one node of
 the cluster--we'll call this the head node. Using the `deploy` api,
 minimega can copy itself to other nodes in the cluster, launch itself,
-and discover the other cluster members to form a mesh.
+and discover the other cluster members to form a mesh. The `deploy`
+api requires password-less root SSH logins for each node, see the Intro
+section for more information.
 
 ** Start minimega on the head node
 

--- a/doc/content/articles/installing.article
+++ b/doc/content/articles/installing.article
@@ -5,40 +5,52 @@ The minimega authors
 
 * Obtaining minimega
 
+There are two ways to get minimega: by downloading a pre-compiled
+binary distribution, or by building from source yourself. Using a binary
+distribution is more convenient, but building from source means you can
+get the most up-to-date development version if desired.
+
 ** Binary distribution
 
 minimega is available as a prebuilt, x86-64 debian package, or as a standalone
 tarball. The debian package is known to work on debian 7 (wheezy) and debian 8
-(testing/jessie), and is available
-[[https://storage.googleapis.com/minimega-files/minimega-2.2.deb][here]].
+(jessie), and is available
+[[https://storage.googleapis.com/minimega-files/minimega-2.3.deb][here]].
 
 For other x86-64 systems, use the prebuilt tarball, available
-[[https://storage.googleapis.com/minimega-files/minimega-2.2.tar.bz2][here]].
+[[https://storage.googleapis.com/minimega-files/minimega-2.3.tar.bz2][here]].
 Simply unpack minimega and run it from the top level directory:
 
-	tar xjf minimega.tar.bz2 && cd minimega
-	bin/minimega
+	$ tar xjf minimega.tar.bz2 && cd minimega
+	$ ./bin/minimega
+
+You may find it convenient to place the minimega directory in `/opt`.
 
 ** Building from source
 
-To build from source you will need a [[http://golang.org][Go compiler]],
-libpcap headers, and libreadline headers. On a debian type system, you can
+To build from source you will need a [[http://golang.org][Go compiler version 1.6 or higher]],
+libpcap headers, and libreadline headers. On a Debian-type system, you can
 install compile-time dependencies with:
 
-   apt-get install libpcap-dev libreadline-dev
+	$ apt-get install libpcap-dev libreadline-dev
 
-The Go compiler must be at least version 1.6.
+Having installed the dependencies, grab the minimega source:
 
-First, obtain the minimega source, then run the all.bash script from the top of
-the repo:
+       $ git clone git@github.com:sandia-minimega/minimega.git
+       $ cd minimega
 
-       git clone git@github.com:sandia-minimega/minimega.git
-       cd minimega
-       ./all.bash
+Next, check out the 2.3 release. If you wish to run the development
+version ("tip") of minimega, skip this command.
+
+	$ git checkout tags/2.3
+
+Finally, compile minimega:
+
+       $ ./all.bash
 
 This will build and test each of the libraries and tools in the minimega
 distribution and create a bin/ sudirectory containing each of the minimega
-tools. If you have a windows cross compiler for Go setup, it will also build
+tools. If you have a Windows cross compiler for Go set up, it will also build
 windows binaries of several tools.
 
 * Deploying minimega
@@ -55,8 +67,8 @@ minimega.
 Depending on your cluster configuration, it is also possible to have minimega
 deploy itself. By launching minimega on a single node, you can use the `deploy`
 API which will cause minimega to copy itself and run remotely using `ssh` on a
-provided list of nodes. Se the [[api.article][API documentation]] on `deploy`
-for more information.
+provided list of nodes. See the [[api.article][API documentation]] on `deploy`
+for more information, or read the [[cluster.article][article on setting up a cluster]].
 
 ** System requirements and runtime dependencies
 
@@ -64,27 +76,29 @@ minimega is designed to be simple to deploy. It has only two runtime
 dependencies - libpcap and libreadline, both of which are usually included on
 standard linux distros.
 
-minimega also has a number of external tools it executes. When you start
-minimega, it will check to see if each of the tools it may need are available
-in `$PATH`. If you plan to use minimega on a head node and only send messages
-to other nodes to launch and control VMs, you can ignore any external tool
-warnings at launch. 
+minimega also has a number of external tools it executes. When you
+start minimega, it will check to see if each of the tools it may need
+are available in `$PATH`. Depending on your intended use case, you may
+not need every single external program.
 
-If you plan to launch and maintain VMs, you'll need the following programs:
+If you plan to launch and maintain VMs, you'll need the following programs at a minimum:
 
 - kvm - qemu-kvm with the kvm kernel module loaded (minimum version 1.6)
 - ip - ip tool for manipulating devices
 - ovs-vsctl - Open vSwitch switch control with daemon running and kernel module loaded (minimum version 1.4)
 - ovs-ofctl - Open vSwitch openflow control with daemon running and kernel module loaded
+
+We also recommend installing the following; they are not strictly
+necessary for basic VM use but are required for some more advanced
+operations:
+
 - dhclient - dhcp client
 - dnsmasq - DNS and DHCP server
 - qemu-nbd/qemu-img - tool for interacting with qemu disk images (in the Debian package "qemu-tools")
-- mount/umount - used when creating router images and injecting files into existing images
 - mkdosfs - used when creating router images
 - taskset - set CPU affinity for VMs
 - ntfs-3g - NTFS with write support for injecting files into NTFS images
-- ssh/scp
-- kill
+- ssh/scp - used to deploy minimega to other nodes in a cluster
 
 *** Grub note
 
@@ -104,50 +118,6 @@ looking something like this:
 	GRUB_CMDLINE_LINUX_DEFAULT="quiet cgroup_enable=memory"
 
 Then run update-grub and reboot for the change to take effect.
-
-** Network configuration
-
-(This section is primarily relevant for people running minimega on a cluster)
-
-minimega is designed to run on one or more nodes and uses Open vSwitch, a
-software switch and networking package that allows dynamically vlan-tagging
-network interfaces attached to virtual machines. Open vSwitch can trunk
-vlan-tagged traffic up to the physical switch connected to the node running
-minimega.
-
-If your switch supports IEEE 802.1q vlan tagging (and most should), then vlan
-tagged interfaces with the same tag number should be able to see other
-interfaces with that tag number, even on other physical nodes. For example, if
-you wanted to create a private network of VMs that spanned across 5 nodes of a
-cluster, you could simply tag each VM's network interface with the same vlan
-tag, say, 100 (802.1q vlan tags must be between 1-4096). If configured
-correctly, Open vSwitch and your switch hardware will interpret the vlan tag
-and switch traffic for that vlan as if on an isolated network.
-
-It is also possible to have multiple, isolated vlans running on several nodes
-in a cluster. That is, you can have nodes A and B both running VMs with vlans
-100 and 200, and Open vSwitch and your switch hardware will isolate the two
-networks, even though the traffic is going to both physical nodes. 
-
-If software defined networking and setting up Open vSwitch is new to you, check
-out the [[http://openvswitch.org][Open vSwitch website]] for more information. 
-
-*NOTE:* minimega by default does *not* bridge any physical interfaces to the
-virtual switch. In order to allow multiple nodes to have VMs on the same vlan,
-you must attach a physical interface from each node to the virtual switch in
-trunking mode. Doing so will disallow the physical interface from having an IP,
-although you can assign/obtain an IP in place of the physical interface by
-assigning/obtaining an IP on the access port of the bridge device. 
-
-For example, if you have only one physical interface, eth0, on your node and
-you want to bridge that interface to Open vSwitch to support vlan tagged
-traffic between nodes:
-
-	bridge trunk mega_bridge eth0
-
-The above adds eth0 to the default minimega bridge `mega_bridge` as a trunk
-port, which has the same MAC as eth0 and will behave as eth0 did before you
-added it to the bridge. Do this on each node running minimega. 
 
 * Getting help
 

--- a/doc/content/articles/installing.article
+++ b/doc/content/articles/installing.article
@@ -42,7 +42,7 @@ Having installed the dependencies, grab the minimega source:
 Next, check out the 2.3 release. If you wish to run the development
 version ("tip") of minimega, skip this command.
 
-	$ git checkout tags/2.3
+	$ git checkout 2.3
 
 Finally, compile minimega:
 
@@ -85,7 +85,7 @@ If you plan to launch and maintain VMs, you'll need the following programs at a 
 
 - kvm - qemu-kvm with the kvm kernel module loaded (minimum version 1.6)
 - ip - ip tool for manipulating devices
-- ovs-vsctl - Open vSwitch switch control with daemon running and kernel module loaded (minimum version 1.4)
+- ovs-vsctl - Open vSwitch switch control with daemon running and kernel module loaded (minimum version 1.11)
 - ovs-ofctl - Open vSwitch openflow control with daemon running and kernel module loaded
 
 We also recommend installing the following; they are not strictly
@@ -93,7 +93,7 @@ necessary for basic VM use but are required for some more advanced
 operations:
 
 - dhclient - dhcp client
-- dnsmasq - DNS and DHCP server
+- dnsmasq - DNS and DHCP server (minimum version 2.73)
 - qemu-nbd/qemu-img - tool for interacting with qemu disk images (in the Debian package "qemu-tools")
 - mkdosfs - used when creating router images
 - taskset - set CPU affinity for VMs


### PR DESCRIPTION
installing.article no longer contains information about setting up the network. Instead,
the new file cluster.article describes in more detail how you can set up a cluster
to run minimega.