### PR TITLE
minimega: split env variable on space and slash

### DIFF
--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -408,8 +408,12 @@ func cliLocal() {
 // string or an error.
 func cliPreprocess(v string) (string, error) {
 	if strings.HasPrefix(v, "$") {
-		if v2 := os.Getenv(v[1:]); v2 != "" {
-			return v2, nil
+		end := strings.IndexAny(v, "/ ")
+		if end == -1 {
+			end = len(v)
+		}
+		if v2 := os.Getenv(v[1:end]); v2 != "" {
+			return v2 + v[end:], nil
 		}
 
 		return "", fmt.Errorf("undefined: %v", v)


### PR DESCRIPTION
For example:

```
minimega$ vm config filesystem $minirouterfs
INFO cli.go:473: cliPreprocess: [filesystem] $minirouterfs -> /data/minimega/minirouterfs
minimega$ vm config filesystem
/data/minimega/minirouterfs
minimega$ vm config preinit $minirouterfs/preinit
INFO cli.go:473: cliPreprocess: [preinit] $minirouterfs/preinit -> /data/minimega/minirouterfs/preinit
minimega$ vm config preinit
/data/minimega/minirouterfs/preinit
```