### PR TITLE
minimega: tweak vnc shim loop, remove race

### DIFF
--- a/src/minimega/vnc_record.go
+++ b/src/minimega/vnc_record.go
@@ -197,6 +197,16 @@ func vncRecordFB(vm *KvmVM, filename string) error {
 	return nil
 }
 
+// vncRoute records a message for the correct recording based on ID
+func vncRoute(ID string, msg interface{}) {
+	vncRecordingLock.RLock()
+	defer vncRecordingLock.RUnlock()
+
+	if r, ok := vncKBRecording[ID]; ok {
+		r.RecordMessage(msg)
+	}
+}
+
 // Returns the duration of a given kbrecording file
 func getDuration(filename string) time.Duration {
 	d := 0


### PR DESCRIPTION
Tweak the vnc shim loop so that we disconnect the VNC client when the VM
shuts down. Moved access to vncKBRecording to vncRoute to wrap with lock
to remove race.

@cdshann 