### PR TITLE
minimega: add locking in vncClear, other tweak

### DIFF
--- a/src/minimega/vnc.go
+++ b/src/minimega/vnc.go
@@ -79,6 +79,11 @@ func vncInject(vm *KvmVM, e Event) error {
 }
 
 func vncClear() {
+	vncRecordingLock.Lock()
+	defer vncRecordingLock.Unlock()
+	vncPlayingLock.Lock()
+	defer vncPlayingLock.Unlock()
+
 	for k, v := range vncKBRecording {
 		if inNamespace(v.VM) {
 			log.Debug("stopping kb recording for %v", k)


### PR DESCRIPTION
Added missing locking in vncClear. vncRecordingLock > vncPlayingLock.
Return standard error rather than custom error when vm not found.