### PR TITLE
minirouter: handle v6 static routes better

### DIFF
--- a/src/minirouter/misc.go
+++ b/src/minirouter/misc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	log "minilog"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -51,4 +52,14 @@ func findEth(idx int) (string, error) {
 		return ethNames[idx], nil
 	}
 	return "", fmt.Errorf("no such network")
+}
+
+func isIPv4(s string) bool {
+	ip := net.ParseIP(s)
+	return ip != nil && ip.To4() != nil
+}
+
+func isIPv6(s string) bool {
+	ip := net.ParseIP(s)
+	return ip != nil && ip.To4() == nil
 }


### PR DESCRIPTION
Bird was choking if you defined static routes, because it used only one
config file. If you defined ipv4 static routes, bird6 would die because
it couldn't parse the v4 routes, and vice versa. This creates /etc/bird6.conf
and makes bird6 use that instead, which has solved the problem in testing.