### PR TITLE
minimega: fix `vm config qemu` with namespaces

### DIFF
--- a/src/minimega/vmconfig.go
+++ b/src/minimega/vmconfig.go
@@ -211,14 +211,9 @@ var kvmConfigFns = map[string]VMConfigFns{
 		Clear: func(vm interface{}) { mustKVMConfig(vm).Append = "" },
 		Print: func(vm interface{}) string { return mustKVMConfig(vm).Append },
 	},
-	"qemu": {
-		Update: func(_ interface{}, c *minicli.Command) error {
-			customExternalProcesses["qemu"] = c.StringArgs["path"]
-			return nil
-		},
-		Clear: func(_ interface{}) { delete(customExternalProcesses, "qemu") },
-		Print: func(_ interface{}) string { return process("qemu") },
-	},
+	"qemu": vmConfigString(func(vm interface{}) *string {
+		return &mustKVMConfig(vm).QemuPath
+	}, ""),
 	"qemu-override": {
 		Update: func(_ interface{}, c *minicli.Command) error {
 			if c.StringArgs["match"] != "" {

--- a/src/minimega/vmconfig_cli.go
+++ b/src/minimega/vmconfig_cli.go
@@ -176,7 +176,9 @@ Note: this configuration only applies to KVM-based VMs.`,
 	{ // vm config qemu
 		HelpShort: "set the QEMU process to invoke. Relative paths are ok.",
 		HelpLong: `
-Set the QEMU process to invoke. Relative paths are ok.
+Set the QEMU process to invoke. Relative paths are ok. When unspecified,
+minimega uses "kvm" in the default path.
+
 
 Note: this configuration only applies to KVM-based VMs.`,
 		Patterns: []string{

--- a/tests/vm_config_save.want
+++ b/tests/vm_config_save.want
@@ -14,7 +14,7 @@ CDROM Path:
 Kernel Path:        
 Initrd Path:        
 Kernel Append:      
-QEMU Path:          /usr/bin/kvm
+QEMU Path:          
 QEMU Append:        []
 SerialPorts:        0
 Virtio-SerialPorts: 0
@@ -48,7 +48,7 @@ CDROM Path:
 Kernel Path:        
 Initrd Path:        
 Kernel Append:      
-QEMU Path:          /usr/bin/kvm
+QEMU Path:          
 QEMU Append:        [-k en-us]
 SerialPorts:        0
 Virtio-SerialPorts: 0
@@ -79,7 +79,7 @@ CDROM Path:
 Kernel Path:        
 Initrd Path:        
 Kernel Append:      
-QEMU Path:          /usr/bin/kvm
+QEMU Path:          
 QEMU Append:        []
 SerialPorts:        0
 Virtio-SerialPorts: 0
@@ -107,7 +107,7 @@ CDROM Path:
 Kernel Path:        
 Initrd Path:        
 Kernel Append:      
-QEMU Path:          /usr/bin/kvm
+QEMU Path:          
 QEMU Append:        [-k en-us]
 SerialPorts:        0
 Virtio-SerialPorts: 0


### PR DESCRIPTION
Before, `vm config qemu` would only affect the local minimega instance.
Add field to KvmConfig for QemuPath and fallback on `process("kvm")` if
not set.

Fixes #786