### PR TITLE
minicli: fix history recording

### DIFF
--- a/src/minicli/builtins.go
+++ b/src/minicli/builtins.go
@@ -327,8 +327,10 @@ func cliFilter(c *Command, out chan<- Responses) {
 		return
 	}
 
+	c.Subcommand.SetRecord(false)
+
 outer:
-	for resps := range processCommand(c.Subcommand, false) {
+	for resps := range ProcessCommand(c.Subcommand) {
 		newResps := Responses{}
 
 		for _, r := range resps {
@@ -352,8 +354,10 @@ outer:
 func cliColumns(c *Command, out chan<- Responses) {
 	columns := strings.Split(c.StringArgs["columns"], ",")
 
+	c.Subcommand.SetRecord(false)
+
 outer:
-	for resps := range processCommand(c.Subcommand, false) {
+	for resps := range ProcessCommand(c.Subcommand) {
 		for _, r := range resps {
 			if r.Header == nil {
 				continue
@@ -421,7 +425,9 @@ func cliModeHelper(c *Command, out chan<- Responses, newMode int) {
 		return
 	}
 
-	for r := range processCommand(c.Subcommand, false) {
+	c.Subcommand.SetRecord(false)
+
+	for r := range ProcessCommand(c.Subcommand) {
 		if len(r) > 0 {
 			if r[0].Flags == nil {
 				r[0].Flags = copyFlags()
@@ -459,7 +465,9 @@ func cliFlagHelper(c *Command, out chan<- Responses, get func(*Flags) *bool) {
 		return
 	}
 
-	for r := range processCommand(c.Subcommand, false) {
+	c.Subcommand.SetRecord(false)
+
+	for r := range ProcessCommand(c.Subcommand) {
 		if len(r) > 0 {
 			if r[0].Flags == nil {
 				r[0].Flags = copyFlags()

--- a/src/minicli/command.go
+++ b/src/minicli/command.go
@@ -21,7 +21,9 @@ type Command struct {
 
 	Call CLIFunc `json:"-"`
 
-	Record bool // record command in history (or not), default is true
+	// Record command in history (or not). Checked after the command is
+	// executed so the CLIFunc can set Record according to its own logic.
+	Record bool
 
 	// Set when the command is intentionally a NoOp (the original string
 	// contains just a comment). This was added to ensure that lines containing

--- a/src/minicli/minicli.go
+++ b/src/minicli/minicli.go
@@ -139,10 +139,6 @@ func ProcessString(input string, record bool) (<-chan Responses, error) {
 
 // Process a prepopulated Command
 func ProcessCommand(c *Command) <-chan Responses {
-	return processCommand(c, c.Record)
-}
-
-func processCommand(c *Command, record bool) <-chan Responses {
 	if !c.noOp && c.Call == nil {
 		log.Fatal("command %v has no callback!", c)
 	}
@@ -166,7 +162,7 @@ func processCommand(c *Command, record bool) <-chan Responses {
 		}
 
 		// Append the command to the history
-		if record {
+		if c.Record {
 			history = append(history, c.Original)
 
 			if len(history) > HistoryLen && HistoryLen > 0 {


### PR DESCRIPTION
We weren't passing the history minitest because of a bug in minicli.
Added note to `minicli.Command.Record` to explain why we did things the
way we did.