### PR TITLE
test.bash: remove python test

### DIFF
--- a/test.bash
+++ b/test.bash
@@ -21,12 +21,3 @@ for i in `ls $SCRIPT_DIR/src | grep -v vendor`
 do
 	go test $i
 done
-
-# test python bindings
-$SCRIPT_DIR/misc/python/test_minimega.py &> /dev/null
-if [[ $? != 0 ]]; then
-    echo -e "FAIL\tminimega.py"
-else
-    echo -e "ok\tminimega.py"
-fi
-echo


### PR DESCRIPTION
Should have been removed with python bindings, whoops.