### PR TITLE
protonuke: add cookie jar to http/https clients

### DIFF
--- a/src/protonuke/cookie_test/server.go
+++ b/src/protonuke/cookie_test/server.go
@@ -1,0 +1,55 @@
+// Copyright (2016) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+// This simple server is used to test whether a client properly stores cookies
+// or not. If the "id" cookie is not set by the client, the server sets it in
+// the response to a random string.
+
+package main
+
+import (
+	"encoding/hex"
+	"log"
+	"math/rand"
+	"net/http"
+)
+
+// generateID returns a random hex string to use as the client ID.
+func generateID() string {
+	b := make([]byte, 20)
+	n, err := rand.Read(b)
+	if err != nil {
+		log.Fatalf("unable to generate id: %v", err)
+	}
+
+	return hex.EncodeToString(b[:n])
+}
+
+// handler for all requests, checks for cookie and sets if not already set
+func handler(w http.ResponseWriter, r *http.Request) {
+	c, err := r.Cookie("id")
+	if err == http.ErrNoCookie {
+		id := generateID()
+
+		log.Printf("setting cookie for new client to %v", id)
+
+		http.SetCookie(w, &http.Cookie{
+			Name:  "id",
+			Value: id,
+		})
+	} else if err != nil {
+		log.Printf("unable to get cookie: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	} else {
+		log.Printf("welcome back to %v", c.Value)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":80", nil)
+}

--- a/src/protonuke/http.go
+++ b/src/protonuke/http.go
@@ -19,6 +19,7 @@ import (
 	log "minilog"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"regexp"
 	"strings"
 	"sync"
@@ -73,6 +74,11 @@ func httpClient(protocol string) {
 		//Timeout:   30 * time.Second,
 	}
 
+	if *f_httpCookies {
+		// TODO: see note about PublicSuffixList in cookiejar.Options
+		client.Jar, _ = cookiejar.New(nil)
+	}
+
 	for {
 		t.Tick()
 		h, o := randomHost()
@@ -118,6 +124,11 @@ func httpTLSClient(protocol string) {
 		Transport: transport,
 		// TODO: max client read timeouts configurable?
 		//Timeout:   30 * time.Second,
+	}
+
+	if *f_httpCookies {
+		// TODO: see note about PublicSuffixList in cookiejar.Options
+		client.Jar, _ = cookiejar.New(nil)
 	}
 
 	for {

--- a/src/protonuke/protonuke.go
+++ b/src/protonuke/protonuke.go
@@ -24,6 +24,7 @@ var (
 	f_https       = flag.Bool("https", false, "enable https (TLS) service")
 	f_httproot    = flag.String("httproot", "", "serve directory with http(s) instead of the builtin page generator")
 	f_httpGzip    = flag.Bool("httpgzip", false, "gzip image served in http/https pages")
+	f_httpCookies = flag.Bool("httpcookies", false, "enable cookie jar in http/https clients")
 	f_ssh         = flag.Bool("ssh", false, "enable ssh service")
 	f_smtp        = flag.Bool("smtp", false, "enable smtp service")
 	f_smtpUser    = flag.String("smtpuser", "", "specify a particular user to send email to for the given domain, otherwise random")


### PR DESCRIPTION
Add a new flag to enable cookie jar in http/https clients. Added a test
server that can be used to verify that the cookie jar is working as
intended. Blocking on #817.

Fixes #809.