### PR TITLE
minimega/miniccc: namespace API improvements

### DIFF
--- a/src/minicli/handler.go
+++ b/src/minicli/handler.go
@@ -151,7 +151,7 @@ outer:
 					suggestions = append(suggestions, choice)
 				}
 			}
-		case stringItem, listItem:
+		case stringItem, listItem, stringItem | optionalItem, listItem | optionalItem:
 			if h.Suggest != nil {
 				var prefix string
 				if i < len(input.items) {

--- a/tests/epilog
+++ b/tests/epilog
@@ -1,4 +1,5 @@
 clear namespace
+clear namespace all
 clear capture
 clear cc
 clear router

--- a/tests/namespace
+++ b/tests/namespace
@@ -2,13 +2,11 @@
 vm launch kvm foo
 .columns name,state vm info
 namespace ns1
-nsmod add-host localhost
 .columns name,state vm info
 vm launch kvm foo
 vm launch
 .columns name,state vm info
 namespace ns2
-nsmod add-host localhost
 .columns name,state vm info
 vm launch kvm foo
 vm launch
@@ -35,3 +33,15 @@ vm kill all
 .columns name,namespace,state vm info
 vm flush
 .columns name,namespace,state vm info
+
+# Test clear/delete namespace
+namespace
+namespace ns3
+namespace ns3
+clear namespace
+clear namespace
+namespace
+clear namespace ns3
+namespace
+clear namespace all
+namespace

--- a/tests/namespace.want
+++ b/tests/namespace.want
@@ -4,7 +4,6 @@
 name | state
 foo  | BUILDING
 ## namespace ns1
-## nsmod add-host localhost
 ## .columns name,state vm info
 ## vm launch kvm foo
 ## vm launch
@@ -12,7 +11,6 @@ foo  | BUILDING
 name | state
 foo  | BUILDING
 ## namespace ns2
-## nsmod add-host localhost
 ## .columns name,state vm info
 ## vm launch kvm foo
 ## vm launch
@@ -71,3 +69,21 @@ name | namespace | state
 foo  |           | QUIT
 ## vm flush
 ## .columns name,namespace,state vm info
+
+## # Test clear/delete namespace
+## namespace
+Namespaces: [ns1 ns2]
+## namespace ns3
+## namespace ns3
+E: already in namespace: ns3
+## clear namespace
+## clear namespace
+E: namespaces are already disabled
+## namespace
+Namespaces: [ns1 ns2 ns3]
+## clear namespace ns3
+## namespace
+Namespaces: [ns1 ns2]
+## clear namespace all
+## namespace
+Namespaces: []


### PR DESCRIPTION
Make it an error to switch to the same namespace as the active namespace. Make it an error to "clear namespace" when no namespace is active. Support "clear namespace all" to delete all namespaces. Change miniccc to support suggestions on optional items. Add suggestions for namespace names to namespace API.
