### PR TITLE
mini*: downgrade miniclient to string

### DIFF
--- a/src/minimega/command_socket.go
+++ b/src/minimega/command_socket.go
@@ -52,25 +52,43 @@ func commandSocketHandle(c net.Conn) {
 
 	for err == nil {
 		var r *miniclient.Request
+		var cmd *minicli.Command
 
 		r, err = readLocalRequest(dec)
 		if err != nil {
 			break
 		}
 
+		// should have a command or suggestion but not both
+		if (r.Command == "") == (r.Suggest == "") {
+			resp := &minicli.Response{
+				Host:  hostname,
+				Error: "must specify either command or suggest",
+			}
+			err = sendLocalResp(enc, minicli.Responses{resp}, false)
+			continue
+		}
+
+		// client wants a suggestion
 		if r.Suggest != "" {
 			err = sendLocalSuggest(enc, minicli.Suggest(r.Suggest))
 			continue
 		}
 
-		if r.Command == nil {
-			err = sendLocalResp(enc, nil, false)
+		// client specified a command
+		cmd, err = minicli.Compile(r.Command)
+		if err != nil {
+			resp := &minicli.Response{
+				Host:  hostname,
+				Error: err.Error(),
+			}
+			err = sendLocalResp(enc, minicli.Responses{resp}, false)
 			continue
 		}
 
 		// HAX: Don't record the read command
-		if hasCommand(r.Command, "read") {
-			r.Command.SetRecord(false)
+		if hasCommand(cmd, "read") {
+			cmd.SetRecord(false)
 		}
 
 		// HAX: Work around so that we can add the more boolean.
@@ -78,7 +96,7 @@ func commandSocketHandle(c net.Conn) {
 
 		// Keep sending until we hit the first error, then just consume the
 		// channel to ensure that we release any locks acquired by cmd.
-		for resp := range RunCommands(r.Command) {
+		for resp := range RunCommands(cmd) {
 			if prev != nil && err == nil {
 				err = sendLocalResp(enc, prev, true)
 			} else if err != nil && len(resp) > 0 {
@@ -111,17 +129,6 @@ func readLocalRequest(dec *json.Decoder) (*miniclient.Request, error) {
 	}
 
 	log.Debug("got request over socket: %v", r)
-
-	if r.Command != nil {
-		// HAX: Reprocess the original command since the Call target cannot be
-		// serialized... is there a cleaner way to do this?
-		cmd, err := minicli.Compile(r.Command.Original)
-		if err != nil {
-			return nil, err
-		}
-
-		r.Command = cmd
-	}
 
 	return &r, nil
 }

--- a/src/minimega/command_socket.go
+++ b/src/minimega/command_socket.go
@@ -86,6 +86,13 @@ func commandSocketHandle(c net.Conn) {
 			continue
 		}
 
+		// No command was returned, must have been a blank line or a comment
+		// line. Either way, don't try to run a nil command.
+		if cmd == nil {
+			err = sendLocalResp(enc, nil, false)
+			continue
+		}
+
 		// HAX: Don't record the read command
 		if hasCommand(cmd, "read") {
 			cmd.SetRecord(false)

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -135,8 +135,8 @@ func main() {
 			log.Debugln("got args:", a)
 
 			// TODO: Need to escape?
-			cmd := minicli.MustCompile(strings.Join(a, " "))
-			log.Infoln("got command:", cmd)
+			cmd := strings.Join(a, " ")
+			log.Infoln("got command: `%v`", cmd)
 
 			mm.RunAndPrint(cmd, false)
 		} else {

--- a/src/minitest/main.go
+++ b/src/minitest/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"minicli"
 	"miniclient"
 	log "minilog"
 	"os"
@@ -49,12 +48,10 @@ func runCommands(mm *miniclient.Conn, file string) (string, error) {
 	s := bufio.NewScanner(f)
 
 	for s.Scan() {
-		// Can't use Compile since minimega, not minitest, registers handlers
-		// with minicli
-		cmd := &minicli.Command{Original: s.Text()}
+		cmd := s.Text()
 
-		if len(cmd.Original) > 0 {
-			res += fmt.Sprintf("## %v\n", cmd.Original)
+		if len(cmd) > 0 {
+			res += fmt.Sprintf("## %v\n", cmd)
 		} else {
 			res += "\n"
 		}


### PR DESCRIPTION
Downgrade the interface between minimega and miniclient to a string
rather than a compile `minicli.Command`. This is for (at least) two
reasons:

 * minimega had to recompile the command anyways since the function
   pointer cannot be encoded
 * non-minimega clients (e.g. minitest, miniweb) are unable to compile
   minimega commands (since they have not registered the same handlers)

Fixes #827