### PR TITLE
minimega: fix writeOrDie deadlock

### DIFF
--- a/src/minimega/bridge.go
+++ b/src/minimega/bridge.go
@@ -70,8 +70,7 @@ func getBridge(b string) (*bridge.Bridge, error) {
 		return nil, err
 	}
 
-	log.Debugln("updating bridge info")
-	writeOrDie(filepath.Join(*f_base, "bridges"), bridgeInfo())
+	mustWrite(filepath.Join(*f_base, "bridges"), bridgeInfo())
 
 	return br, nil
 }

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -801,8 +801,8 @@ func (vm *ContainerVM) launch() error {
 
 	// write the config for this vm
 	config := vm.BaseConfig.String() + vm.ContainerConfig.String()
-	writeOrDie(vm.path("config"), config)
-	writeOrDie(vm.path("name"), vm.Name)
+	mustWrite(vm.path("config"), config)
+	mustWrite(vm.path("name"), vm.Name)
 
 	// the child process will communicate with a fake console using pipes
 	// to mimic stdio, and a fourth pipe for logging before the child execs

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -569,8 +569,8 @@ func (vm *KvmVM) launch() error {
 
 	// write the config for this vm
 	config := vm.BaseConfig.String() + vm.KVMConfig.String()
-	writeOrDie(vm.path("config"), config)
-	writeOrDie(vm.path("name"), vm.Name)
+	mustWrite(vm.path("config"), config)
+	mustWrite(vm.path("name"), vm.Name)
 
 	// create and add taps if we are associated with any networks
 	for i := range vm.Networks {

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -182,11 +182,8 @@ func main() {
 		log.Fatal("mkdir base path: %v", err)
 	}
 
-	dst := filepath.Join(*f_base, "minimega.pid")
 	pid := strconv.Itoa(os.Getpid())
-	if err := ioutil.WriteFile(dst, []byte(pid), 0644); err != nil {
-		log.Fatal("unable to write pid: %v", err)
-	}
+	mustWrite(filepath.Join(*f_base, "minimega.pid"), pid)
 
 	// fan out to the number of cpus on the system if GOMAXPROCS env variable
 	// is not set.

--- a/src/minimega/misc.go
+++ b/src/minimega/misc.go
@@ -284,12 +284,13 @@ func hasWildcard(v map[string]bool) bool {
 	return v[Wildcard]
 }
 
-// writeOrDie writes data to the provided file. If there is an error, calls
-// teardown to kill minimega.
-func writeOrDie(fpath, data string) {
+// mustWrite writes data to the provided file. If there is an error, calls
+// log.Fatal to kill minimega.
+func mustWrite(fpath, data string) {
+	log.Debug("writing to %v", fpath)
+
 	if err := ioutil.WriteFile(fpath, []byte(data), 0664); err != nil {
-		log.Errorln(err)
-		teardown()
+		log.Fatal("write %v failed: %v", fpath, err)
 	}
 }
 

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -637,10 +637,7 @@ func (vm *BaseVM) setState(s VMState) {
 	log.Debug("updating vm %v state: %v -> %v", vm.ID, vm.State, s)
 	vm.State = s
 
-	err := ioutil.WriteFile(vm.path("state"), []byte(s.String()), 0666)
-	if err != nil {
-		log.Error("write instance state file: %v", err)
-	}
+	mustWrite(vm.path("state"), s.String())
 }
 
 // setError updates the vm state and records the error in the vm's tags.


### PR DESCRIPTION
Call log.Fatal instead of teardown if we aren't able to write data.
Renamed function to mustWrite.

Fixes #684