### PR TITLE
Changed VNC page title to VM name.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,6 +7,7 @@ Jeremy Erickson <jericks@sandia.gov>
 John Floren <jfflore@sandia.gov>
 David Fritz <djfritz@sandia.gov>
 Jason Gao <jhgao@sandia.gov>
+Casey Glatter <cglatte@sandia.gov>
 Darek Jensen <djjense@sandia.gov>
 Trey Keown <jfkeown@sandia.gov>
 Michael Kunz <mkunz@sandia.gov>

--- a/misc/web/vnc_auto.html
+++ b/misc/web/vnc_auto.html
@@ -192,8 +192,8 @@
             host = WebUtil.getConfigVar('host', window.location.hostname);
             port = WebUtil.getConfigVar('port', window.location.port);
 
-            // By default, use the host and port of server that served this file
-            document.title = unescape(WebUtil.getConfigVar('title', host));
+            // Set title to VM name
+            document.title = window.location.pathname.substring(window.location.pathname.lastIndexOf("/")+1);
 
             // if port == 80 (or 443) then it won't be present and should be
             // set manually


### PR DESCRIPTION
Previously it was set to just the hostname of the server that served the html file. It makes more sense for it to be the name of the VM.