### PR TITLE
vmbetter: fix root login...

### DIFF
--- a/misc/vmbetter_configs/ccc_host_ovs.conf
+++ b/misc/vmbetter_configs/ccc_host_ovs.conf
@@ -8,6 +8,7 @@ overlay = "misc/vmbetter_configs/ccc_host_ovs_overlay"
 postbuild = `
 	sed -i 's/nullok_secure/nullok/' /etc/pam.d/common-auth
 	sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+	sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 	sed -i 's/PermitEmptyPasswords no/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
 	passwd -d root
 	echo "root soft nofile 999999" >> /etc/security/limits.conf


### PR DESCRIPTION
... for ccc host images. "without-password" is apparently an alias for
"prohibit-password". Trying to replace both seems to work.