### PR TITLE
misc: update init for virtio

### DIFF
--- a/misc/vmbetter_configs/ccc_host_ovs_overlay/init
+++ b/misc/vmbetter_configs/ccc_host_ovs_overlay/init
@@ -54,6 +54,9 @@ mount /dev/sda1 /scratch
 # bump open file handle limits
 ulimit -n 999999
 
+# increase max PID
+echo 999999 > /proc/sys/kernel/pid_max
+
 # bond all 10G/40G interfaces
 for i in `ls /sys/class/net`
 do

--- a/misc/vmbetter_configs/miniccc_virtio_overlay/init
+++ b/misc/vmbetter_configs/miniccc_virtio_overlay/init
@@ -36,6 +36,14 @@ dhclient -v eth0
 mkdir /var/run/sshd
 /usr/sbin/sshd
 
-/miniccc -serial /dev/vport1p1 -logfile /miniccc.log &
+# create symlinks for virtio devices
+mkdir /dev/virtio-ports
+
+for d in $(ls /sys/class/virtio-ports); do
+	name=$(cat /sys/class/virtio-ports/$d/name)
+	ln -s -T /dev/$d /dev/virtio-ports/$name
+done
+
+/miniccc -v=false -serial /dev/virtio-ports/cc -logfile /miniccc.log &
 
 setsid sh -c 'exec sh </dev/tty1 >/dev/tty1 2>&1'

--- a/misc/vmbetter_configs/minirouter_overlay/init
+++ b/misc/vmbetter_configs/minirouter_overlay/init
@@ -44,7 +44,15 @@ echo 32768 > /proc/sys/net/ipv6/neigh/default/gc_thresh1
 echo 32768 > /proc/sys/net/ipv6/neigh/default/gc_thresh2
 echo 65536 > /proc/sys/net/ipv6/neigh/default/gc_thresh3
 
-/miniccc -v=false -serial /dev/vport1p1 -logfile /miniccc.log &
+# create symlinks for virtio devices
+mkdir /dev/virtio-ports
+
+for d in $(ls /sys/class/virtio-ports); do
+	name=$(cat /sys/class/virtio-ports/$d/name)
+	ln -s -T /dev/$d /dev/virtio-ports/$name
+done
+
+/miniccc -v=false -serial /dev/virtio-ports/cc -logfile /miniccc.log &
 /minirouter -v=false -logfile /minirouter.log &
 
 # attach a real tty to the console


### PR DESCRIPTION
Use virtio port names from sys to populate /dev/virtio-ports and use
that instead for miniccc. More robust than using hardcoded vport1p1.