### PR TITLE
misc: disable ovs bonding

### DIFF
--- a/misc/vmbetter_configs/ccc_host_ovs_overlay/init
+++ b/misc/vmbetter_configs/ccc_host_ovs_overlay/init
@@ -58,14 +58,15 @@ ulimit -n 999999
 echo 999999 > /proc/sys/kernel/pid_max
 
 # bond all 10G/40G interfaces
-for i in `ls /sys/class/net`
-do
-        G=`ls -l /sys/class/net/$i/device/driver 2>/dev/null | grep -e "ixgbe" -e "mlx4_core"`
-        if [ -n "$G" ]
-        then
-                NETS="$NETS $i"
+for i in $(ls /sys/class/net); do
+	out=$(ls -l /sys/class/net/$i/device/driver 2>/dev/null | grep -e "ixgbe" -e "mlx4_core")
+	if [ -n "$out" ]; then
+		NETS="$NETS $i"
 		ifconfig $i up
-        fi
+		# disable bonding for now -- only one host could use bonding and it
+		# only has one wired connection so bonding doesn't work
+		break
+	fi
 done
 
 echo "bonding nets $NETS"
@@ -80,6 +81,7 @@ if [ $numnets -eq 1 ]
 then
 	ovs-vsctl add-port mega_bridge $NETS
 else
+	# see above -- we have disabled bonding for now
 	ovs-vsctl add-bond mega_bridge bond0 $NETS lacp=active
 	ovs-vsctl set port bond0 bond_mode=balance-tcp
 fi


### PR DESCRIPTION
The only node that uses bonding isn't fully wired so there's no point to
bonding the interfaces (and the switch isn't configured for LACP on that
interface).