### PR TITLE
miniweb: clean up code, set record false, add `vm top` view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-  - 1.7.3
-  - 1.8
+  - 1.8.3
 addons:
   apt:
     packages:

--- a/doc/content/articles/installing.article
+++ b/doc/content/articles/installing.article
@@ -28,7 +28,7 @@ You may find it convenient to place the minimega directory in `/opt`.
 
 ** Building from source
 
-To build from source you will need a [[http://golang.org][Go compiler version 1.6 or higher]],
+To build from source you will need a [[http://golang.org][Go compiler version 1.8 or higher]],
 libpcap headers, and libreadline headers. On a Debian-type system, you can
 install compile-time dependencies with:
 
@@ -121,6 +121,6 @@ Then run update-grub and reboot for the change to take effect.
 
 * Getting help
 
-The mailing list is the primary resource for both developers and users. 
+The mailing list is the primary resource for both developers and users.
 
 .link https://groups.google.com/forum/#!forum/minimega-dev minimega mailing list

--- a/misc/web/js/glue.js
+++ b/misc/web/js/glue.js
@@ -30,11 +30,11 @@ var ssDataTable;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-// Initialize the VM DataTable and set up an automatic reload
-function initVMDataTable() {
+// Initialize the `vm info` DataTable and set up an automatic reload
+function initVMInfoDataTable() {
     var vmDataTable = $('#vms-dataTable').DataTable({
         "ajax": function( data, callback, settings) {
-            updateJSON('/vms.json', function(vmsData) {
+            updateJSON('/vms/info.json', function(vmsData) {
                 // disable auto-refresh there are too many VMs
                 VM_REFRESH_ENABLE = Object.keys(vmsData).length <= VM_REFRESH_THESHOLD;
 
@@ -127,6 +127,68 @@ function initVMDataTable() {
     }
 }
 
+// Initialize the `vm top` DataTable and set up an automatic reload
+function initVMTopDataTable() {
+    var vmDataTable = $('#vms-dataTable').DataTable({
+        "ajax": function( data, callback, settings) {
+            updateJSON('/vms/top.json', function(vmsData) {
+                // disable auto-refresh there are too many VMs
+                VM_REFRESH_ENABLE = Object.keys(vmsData).length <= VM_REFRESH_THESHOLD;
+
+                // put into a structure that DataTables expects
+                var dataTablesData = {"data": vmsData};
+
+                callback(dataTablesData);
+            });
+        },
+        // custom DOM with Boostrap integration
+        // http://stackoverflow.com/a/32253335
+        "dom":
+            "<'row'<'col-sm-5'i><'col-sm-7'p>>" +
+            //"<'row'<'col-sm-3'l><'col-sm-6 text-center'B><'col-sm-3'f>>" +
+            "<'row'<'col-sm-6'l><'col-sm-6'f>>" +
+            "<'row'<'col-sm-12 text-center'B>>" +
+            "<'row'<'col-sm-12'tr>>",
+        "buttons": [
+            'columnsVisibility',
+        ],
+        "autoWidth": false,
+        "paging": true,
+        "lengthChange": true,
+        "lengthMenu": [
+            [10, 25, 50, 100, 250, 500, -1],
+            [10, 25, 50, 100, 250, 500, "All"]
+        ],
+        "pageLength": 500,
+        "columns": [
+            { "title": "Namespace", "data": "namespace", "visible": false, render: handleEmptyString },
+            { "title": "Host", "data": "host" },
+            { "title": "Name", "data": "name" },
+            { "title": "Virtual", "data": "virt" },
+            { "title": "Resident", "data": "res", "visible": false },
+            { "title": "Shared", "data": "shr", "visible": false },
+            { "title": "CPU", "data": "cpu" },
+            { "title": "VCPU", "data": "vcpu" },
+            { "title": "Time", "data": "time" },
+            { "title": "Processes", "data": "procs" },
+            { "title": "Rx", "data": "rx" },
+            { "title": "Tx", "data": "tx" },
+        ],
+        "order": [[ 0, 'asc' ], [ 1, 'asc' ]],
+        "stateSave": true,
+        "stateDuration": 0
+    });
+
+
+    if (VM_REFRESH_TIMEOUT >= 1000) {
+        setInterval(function() {
+            if (VM_REFRESH_ENABLE) {
+                vmDataTable.ajax.reload(null, false);
+            }
+        }, VM_REFRESH_TIMEOUT);
+    }
+}
+
 
 // Initialize the Host DataTable and set up an automatic reload
 function initHostDataTable() {
@@ -199,12 +261,12 @@ function initHostDataTable() {
 
 // Initialize the Screenshot DataTable and set up an automatic reload
 function initScreenshotDataTable() {
-    updateJSON('/vms.json', updateScreenshotTable);
+    updateJSON('/vms/info.json', updateScreenshotTable);
 
     if (IMAGE_REFRESH_TIMEOUT > 0) {
         setInterval(function() {
             if (IMAGE_REFRESH_ENABLE) {
-                updateJSON('/vms.json', updateScreenshotTable);
+                updateJSON('/vms/info.json', updateScreenshotTable);
             }
         }, IMAGE_REFRESH_TIMEOUT);
     }

--- a/misc/web/templates/vms.tmpl
+++ b/misc/web/templates/vms.tmpl
@@ -1,32 +1,35 @@
-    {{define "content"}}
-    <div id="content">
-
-      <div id="vms-table" class="box">
+{{define "content"}}
+<div id="content">
+    <div id="vms-table" class="box">
         <h1 class="box-header">VM List</h1>
+        <div id="vms-switcher"></div>
         <div class="box-content">
-          <table id="vms-dataTable" class="table table-striped table-bordered dataTable no-footer"></table>
+            <table id="vms-dataTable" class="table table-striped table-bordered dataTable no-footer"></table>
         </div>
-      </div>
-
     </div>
+</div>
 
+<script type="text/javascript" src="libs/dataTables/jquery.dataTables.js"></script>
+<script type="text/javascript" src="libs/dataTables/dataTables.bootstrap.js"></script>
+<script type="text/javascript" src="libs/dataTables/dataTables.buttons.js"></script>
+<script type="text/javascript" src="libs/dataTables/buttons.colVis.js"></script>
+<script type="text/javascript" src="libs/dataTables/buttons.html5.js"></script>
+<script type="text/javascript" src="libs/dataTables/buttons.bootstrap.js"></script>
 
-
-    <script type="text/javascript" src="libs/dataTables/jquery.dataTables.js"></script>
-    <script type="text/javascript" src="libs/dataTables/dataTables.bootstrap.js"></script>
-    <script type="text/javascript" src="libs/dataTables/dataTables.buttons.js"></script>
-    <script type="text/javascript" src="libs/dataTables/buttons.colVis.js"></script>
-    <script type="text/javascript" src="libs/dataTables/buttons.html5.js"></script>
-    <script type="text/javascript" src="libs/dataTables/buttons.bootstrap.js"></script>
-    
-    <script type="text/javascript" src="js/glue.js"></script>
-    <script type="text/javascript">
-      $(document).ready(function() {
+<script type="text/javascript" src="js/glue.js"></script>
+<script type="text/javascript">
+    $(document).ready(function() {
         $('nav a[href$="' + "vms" + '"]').addClass("current-view");
 
-        initVMDataTable();
-        
+        if(window.location.href.indexOf("top") > -1) {
+            $("#vms-switcher").html("<a href=\"/vms\">Toggle info view</a>");
+            initVMTopDataTable();
+        } else {
+            $("#vms-switcher").html("<a href=\"/vms?top\">Toggle top view</a>");
+            initVMInfoDataTable();
+        }
+
         initCowbell();
-      });
-    </script>
-    {{end}}
+    });
+</script>
+{{end}}

--- a/src/miniweb/main.go
+++ b/src/miniweb/main.go
@@ -76,8 +76,9 @@ func main() {
 	mux.HandleFunc("/tilevnc", templateHander)
 
 	mux.HandleFunc("/hosts.json", hostsHandler)
-	mux.HandleFunc("/vms.json", vmsHandler)
 	mux.HandleFunc("/vlans.json", vlansHandler)
+	mux.HandleFunc("/vms/info.json", vmsHandler)
+	mux.HandleFunc("/vms/top.json", vmsHandler)
 
 	mux.HandleFunc("/connect/", connectHandler)
 	mux.HandleFunc("/screenshot/", screenshotHandler)

--- a/src/miniweb/tabular.go
+++ b/src/miniweb/tabular.go
@@ -1,0 +1,92 @@
+// Copyright (2017) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"fmt"
+	"minicli"
+	log "minilog"
+	"strings"
+)
+
+type tabularToMapper func(*minicli.Response, []string) map[string]string
+
+func tabularToMap(resp *minicli.Response, row []string) map[string]string {
+	res := map[string]string{
+		"host": resp.Host,
+	}
+
+	for i, header := range resp.Header {
+		res[header] = row[i]
+	}
+
+	return res
+}
+
+func tabularToMapCols(columns []string) tabularToMapper {
+	// create local copy of columns in case they get changed
+	cols := make([]string, len(columns))
+	copy(cols, columns)
+
+	return func(resp *minicli.Response, row []string) map[string]string {
+		res := map[string]string{}
+		for _, column := range cols {
+			if strings.Contains(column, "host") {
+				res["host"] = resp.Host
+				continue
+			}
+
+			for i, header := range resp.Header {
+				if strings.Contains(column, header) {
+					res[header] = row[i]
+				}
+			}
+		}
+		return res
+	}
+}
+
+func runTabular(cmd string, columns, filters []string) []map[string]string {
+	// apply filters first so we don't need to worry about the columns not
+	// including the filtered fields.
+	for _, f := range filters {
+		cmd = fmt.Sprintf(".filter %v %v", f, cmd)
+	}
+
+	// copy all fields in header order
+	mapper := tabularToMap
+
+	if len(columns) > 0 {
+		// replace mapper to only copy fields in column order
+		mapper = tabularToMapCols(columns)
+
+		// quote all the columns in case there are spaces
+		for i, c := range columns {
+			columns[i] = fmt.Sprintf("%q", c)
+		}
+
+		cmd = fmt.Sprintf(".columns %v %v", strings.Join(columns, ","), cmd)
+	}
+
+	// don't record command in history
+	cmd = fmt.Sprintf(".record false %v", cmd)
+
+	res := []map[string]string{}
+
+	for resps := range mm.Run(cmd) {
+		for _, resp := range resps.Resp {
+			if resp.Error != "" {
+				log.Errorln(resp.Error)
+				continue
+			}
+
+			for _, row := range resp.Tabular {
+				res = append(res, mapper(resp, row))
+			}
+		}
+	}
+
+	return res
+}


### PR DESCRIPTION
Use sort.Slice to clean up some code. Made vmInfo cleaner and use in the
vms handler. Set record false so we don't clutter the history.