### PR TITLE
minimega/minirouter: add default route API

### DIFF
--- a/src/minimega/router.go
+++ b/src/minimega/router.go
@@ -30,6 +30,7 @@ type Router struct {
 	dhcp         map[string]*dhcp
 	dns          map[string][]string
 	upstream     string
+	gw           string
 	rad          map[string]bool // using a bool placeholder here for later RAD options
 	staticRoutes map[string]string
 	ospfRoutes   map[string]*ospf
@@ -88,6 +89,10 @@ func (r *Router) String() string {
 
 	if r.upstream != "" {
 		fmt.Fprintf(&o, "Upstream DNS: %v\n", r.upstream)
+	}
+
+	if r.gw != "" {
+		fmt.Fprintf(&o, "Default Gateway: %v\n", r.gw)
 	}
 
 	if len(r.rad) > 0 {
@@ -179,6 +184,11 @@ func (r *Router) generateConfig() error {
 	}
 	if r.upstream != "" {
 		fmt.Fprintf(&out, "dnsmasq upstream %v\n", r.upstream)
+	}
+	if r.gw != "" {
+		fmt.Fprintf(&out, "route add default gw %v\n", r.gw)
+	} else {
+		fmt.Fprintf(&out, "route del default")
 	}
 	for subnet, _ := range r.rad {
 		fmt.Fprintf(&out, "dnsmasq ra %v\n", subnet)
@@ -494,6 +504,16 @@ func (r *Router) Upstream(ip string) {
 
 func (r *Router) UpstreamDel() error {
 	r.upstream = ""
+
+	return nil
+}
+
+func (r *Router) Gateway(gw string) {
+	r.gw = gw
+}
+
+func (r *Router) GatewayDel() error {
+	r.gw = ""
 
 	return nil
 }

--- a/src/minimega/router_cli.go
+++ b/src/minimega/router_cli.go
@@ -17,9 +17,9 @@ var routerCLIHandlers = []minicli.Handler{
 Configure running minirouter VMs running minirouter and miniccc.
 
 Routers are configured by specifying or updating a configuration, and then
-applying that configuration with a commit command. For example, to configure
-a router on a running VM named 'foo' to serve DHCP on 10.0.0.0/24 with a
-range of IPs:
+applying that configuration with a commit command. For example, to configure a
+router on a running VM named 'foo' to serve DHCP on 10.0.0.0/24 with a range of
+IPs:
 
 	router foo dhcp 10.0.0.0 range 10.0.0.100 10.0.0.200
 	router foo commit
@@ -50,13 +50,15 @@ router takes a number of subcommands:
 
 - 'upstream': Set upstream server for DNS.
 
+- 'gw': Set default gateway which will be used if there is no matching route.
+
 - 'ra': Enable neighbor discovery protocol router advertisements for a given
   subnet.
 
 - 'route': Set static or OSPF routes. Static routes include a subnet and
-  next-hop. OSPF routes include an area and a network index corresponding to
-  the interface described in 'vm config net'. For example, to enable OSPF on
-  area 0 for both interfaces of a router:
+  next-hop. OSPF routes include an area and a network index corresponding to the
+  interface described in 'vm config net'. For example, to enable OSPF on area 0
+  for both interfaces of a router:
 
 	vm config net 100 200
 	# ...
@@ -74,6 +76,7 @@ router takes a number of subcommands:
 			"router <vm> <dhcp,> <listen address> <static,> <mac> <ip>",
 			"router <vm> <dns,> <ip> <hostname>",
 			"router <vm> <upstream,> <ip>",
+			"router <vm> <gw,> <gw>",
 			"router <vm> <ra,> <subnet>",
 			"router <vm> <route,> <static,> <network> <next-hop>",
 			"router <vm> <route,> <ospf,> <area> <network>",
@@ -99,6 +102,7 @@ router takes a number of subcommands:
 			"clear router <vm> <dns,>",
 			"clear router <vm> <dns,> <ip>",
 			"clear router <vm> <upstream,>",
+			"clear router <vm> <gw,>",
 			"clear router <vm> <ra,>",
 			"clear router <vm> <ra,> <subnet>",
 			"clear router <vm> <route,>",
@@ -181,6 +185,9 @@ func cliRouter(c *minicli.Command, resp *minicli.Response) error {
 	} else if c.BoolArgs["upstream"] {
 		ip := c.StringArgs["ip"]
 		rtr.Upstream(ip)
+		return nil
+	} else if c.BoolArgs["gw"] {
+		rtr.Gateway(c.StringArgs["gw"])
 		return nil
 	} else if c.BoolArgs["ra"] {
 		subnet := c.StringArgs["subnet"]
@@ -270,6 +277,8 @@ func cliClearRouter(c *minicli.Command, resp *minicli.Response) error {
 		return rtr.DNSDel(ip)
 	} else if c.BoolArgs["upstream"] {
 		return rtr.UpstreamDel()
+	} else if c.BoolArgs["gw"] {
+		return rtr.GatewayDel()
 	} else if c.BoolArgs["ra"] {
 		subnet := c.StringArgs["subnet"]
 		return rtr.RADDel(subnet)

--- a/src/minirouter/route.go
+++ b/src/minirouter/route.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"minicli"
+	log "minilog"
+	"os/exec"
+)
+
+func init() {
+	minicli.Register(&minicli.Handler{
+		Patterns: []string{
+			"route <add,> default gw <gw>",
+			"route <del,> default",
+		},
+		Call: handleRoute,
+	})
+}
+
+func handleRoute(c *minicli.Command, r chan<- minicli.Responses) {
+	defer func() {
+		r <- nil
+	}()
+
+	if c.BoolArgs["add"] {
+		gw := c.StringArgs["gw"]
+		log.Debug("setting default gw: %v", gw)
+
+		out, err := exec.Command("route", "add", "default", "gw", gw).CombinedOutput()
+		if err != nil {
+			log.Error("unable to set default route: %v: %v", err, string(out))
+		}
+	} else if c.BoolArgs["del"] {
+		log.Debug("deleting default route")
+
+		out, err := exec.Command("route", "del", "default").CombinedOutput()
+		if err != nil {
+			log.Error("unable to delete default route: %v: %v", err, string(out))
+		}
+	}
+}


### PR DESCRIPTION
Add API to set the default route for minirouter. Fixes #936.