### PR TITLE
minimega: ensure unique names for unspecified vms

### DIFF
--- a/tests/distributed/vm_names
+++ b/tests/distributed/vm_names
@@ -1,0 +1,5 @@
+vm config filesystem /root/uminicccfs
+vm launch container 6
+
+# should all have a unique name
+.column name vm info

--- a/tests/distributed/vm_names.want
+++ b/tests/distributed/vm_names.want
@@ -1,0 +1,12 @@
+## vm config filesystem /root/uminicccfs
+## vm launch container 6
+
+## # should all have a unique name
+## .column name vm info
+name
+vm-distributed-0
+vm-distributed-1
+vm-distributed-2
+vm-distributed-3
+vm-distributed-4
+vm-distributed-5


### PR DESCRIPTION
Ensure that `vm launch ... N` results in VMs with unique names. Fixes
regression from 550f4b. Thanks to `git log -S` for helping me find when
it broke.

Fixes #988.