### PR TITLE
minimega: improve vm net

### DIFF
--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -519,7 +519,17 @@ func (vm *BaseVM) NetworkConnect(pos int, bridge string, vlan int) error {
 
 	net := &vm.Networks[pos]
 
-	log.Debug("moving network connection: %v %v %v -> %v %v", vm.ID, pos, net.VLAN, bridge, vlan)
+	// special case -- if bridge is not specified, reconnect tap to the same
+	// bridge if it is already on a bridge.
+	if bridge == "" {
+		bridge = net.Bridge
+	}
+	// fallback -- connect to the default bridge.
+	if bridge == "" {
+		bridge = DefaultBridge
+	}
+
+	log.Info("moving network connection: %v %v %v:%v -> %v:%v", vm.ID, pos, net.Bridge, net.VLAN, bridge, vlan)
 
 	// Do this before disconnecting from the old bridge in case the new one was
 	// mistyped or invalid.

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -242,7 +242,9 @@ optional bridge:
 
 	vm net vm-0 0 100 mega_bridge
 
-If the bridge name is omitted, the VM will be connected to "mega_bridge".`,
+If the bridge name is omitted, the interface will be reconnected to the same
+bridge that it is already on. If the interface is not connected to a bridge, it
+will be connected to the default bridge, "mega_bridge".`,
 		Patterns: []string{
 			"vm net <connect,> <vm target> <tap position> <vlan> [bridge]",
 			"vm net <disconnect,> <vm target> <tap position>",

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -805,9 +805,6 @@ func cliVMNetMod(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 	}
 
 	bridge := c.StringArgs["bridge"]
-	if bridge == "" {
-		bridge = DefaultBridge
-	}
 
 	return ns.VMs.Apply(target, func(vm VM, wild bool) (bool, error) {
 		if c.BoolArgs["disconnect"] {

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -224,31 +224,37 @@ See "vm start" for a full description of allowable targets.`,
 	{ // vm net
 		HelpShort: "disconnect or move network connections",
 		HelpLong: `
-Disconnect or move existing network connections on a running VM.
+Disconnect or move existing network connections for one or more VMs. See "vm
+start" for a full description of allowable targets.
 
 Network connections are indicated by their position in vm net (same order in vm
 info) and are zero indexed. For example, to disconnect the first network
-connection from a VM named vm-0 with 4 network connections:
+connection from a VM named vm-0:
 
 	vm net disconnect vm-0 0
 
-To disconnect the second connection:
+To disconnect the second interface:
 
 	vm net disconnect vm-0 1
 
-To move a connection, specify the new VLAN tag and bridge:
+To move a connection, specify the interface number, the new VLAN tag and
+optional bridge:
 
-	vm net <vm name> 0 bridgeX 100`,
+	vm net vm-0 0 100 mega_bridge
+
+If the bridge name is omitted, the VM will be connected to "mega_bridge".`,
 		Patterns: []string{
-			"vm net <connect,> <vm name> <tap position> <bridge> <vlan>",
-			"vm net <disconnect,> <vm name> <tap position>",
+			"vm net <connect,> <vm target> <tap position> <vlan> [bridge]",
+			"vm net <disconnect,> <vm target> <tap position>",
 		},
-		Call: wrapSimpleCLI(cliVMNetMod),
+		Call: wrapVMTargetCLI(cliVMNetMod),
 		Suggest: wrapSuggest(func(ns *Namespace, val, prefix string) []string {
 			if val == "vm" {
 				return cliVMSuggest(ns, prefix, VM_ANY_STATE, false)
 			} else if val == "vlan" {
 				return cliVLANSuggest(ns, prefix)
+			} else if val == "bridge" {
+				return cliBridgeSuggest(ns, prefix)
 			}
 			return nil
 		}),
@@ -783,26 +789,33 @@ func cliVMHotplug(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 }
 
 func cliVMNetMod(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	vm := ns.FindVM(c.StringArgs["vm"])
-	if vm == nil {
-		return vmNotFound(c.StringArgs["vm"])
-	}
+	target := c.StringArgs["vm"]
 
 	pos, err := strconv.Atoi(c.StringArgs["tap"])
 	if err != nil {
 		return err
 	}
 
-	if c.BoolArgs["disconnect"] {
-		return vm.NetworkDisconnect(pos)
+	var vlan int
+	if !c.BoolArgs["disconnect"] {
+		vlan, err = lookupVLAN(ns.Name, c.StringArgs["vlan"])
+		if err != nil {
+			return err
+		}
 	}
 
-	vlan, err := lookupVLAN(ns.Name, c.StringArgs["vlan"])
-	if err != nil {
-		return err
+	bridge := c.StringArgs["bridge"]
+	if bridge == "" {
+		bridge = DefaultBridge
 	}
 
-	return vm.NetworkConnect(pos, c.StringArgs["bridge"], vlan)
+	return ns.VMs.Apply(target, func(vm VM, wild bool) (bool, error) {
+		if c.BoolArgs["disconnect"] {
+			return true, vm.NetworkDisconnect(pos)
+		}
+
+		return true, vm.NetworkConnect(pos, bridge, vlan)
+	})
 }
 
 func cliVMTop(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/tests/vm_net
+++ b/tests/vm_net
@@ -28,6 +28,9 @@ vm net connect c0 0 LAN3
 vm net connect all 0 LAN3
 .columns name,vlan,bridge vm info
 
+# reconnect back to mega_bridge
+vm net connect all 0 LAN3 mega_bridge
+
 # start everything and repeat
 vm start all
 
@@ -54,6 +57,9 @@ vm net connect c0 0 LAN3
 .columns name,vlan,bridge vm info
 vm net connect all 0 LAN3
 .columns name,vlan,bridge vm info
+
+# reconnect back to mega_bridge
+vm net connect all 0 LAN3 mega_bridge
 
 # kill all and repeat
 vm kill all

--- a/tests/vm_net
+++ b/tests/vm_net
@@ -1,12 +1,83 @@
-vm config net 0
-vm launch kvm vm0
+vm config net LAN
+vm launch kvm k[0-1]
+vm config filesystem $minicccfs
+vm launch container c[0-1]
+.columns name,vlan,bridge vm info
 
+# disconnect single and multiple VMs
+vm net disconnect k0 0
 .columns name,vlan,bridge vm info
-vm net disconnect vm0 0
+vm net disconnect c0 0
 .columns name,vlan,bridge vm info
-vm net connect vm0 0 foo 1
+vm net disconnect all 0
 .columns name,vlan,bridge vm info
-vm net connect vm0 0 bar 0
+
+# connect single and multiple VMs
+vm net connect k0 0 LAN2
 .columns name,vlan,bridge vm info
-vm net disconnect vm0 0
+vm net connect c0 0 LAN2
+.columns name,vlan,bridge vm info
+vm net connect all 0 LAN2 mega_bridge2
+.columns name,vlan,bridge vm info
+
+# reconnect single and multiple VMs
+vm net connect k0 0 LAN3
+.columns name,vlan,bridge vm info
+vm net connect c0 0 LAN3
+.columns name,vlan,bridge vm info
+vm net connect all 0 LAN3
+.columns name,vlan,bridge vm info
+
+# start everything and repeat
+vm start all
+
+# disconnect single and multiple VMs
+vm net disconnect k0 0
+.columns name,vlan,bridge vm info
+vm net disconnect c0 0
+.columns name,vlan,bridge vm info
+vm net disconnect all 0
+.columns name,vlan,bridge vm info
+
+# connect single and multiple VMs
+vm net connect k0 0 LAN2
+.columns name,vlan,bridge vm info
+vm net connect c0 0 LAN2
+.columns name,vlan,bridge vm info
+vm net connect all 0 LAN2 mega_bridge2
+.columns name,vlan,bridge vm info
+
+# reconnect single and multiple VMs
+vm net connect k0 0 LAN3
+.columns name,vlan,bridge vm info
+vm net connect c0 0 LAN3
+.columns name,vlan,bridge vm info
+vm net connect all 0 LAN3
+.columns name,vlan,bridge vm info
+
+# kill all and repeat
+vm kill all
+
+# disconnect single and multiple VMs
+vm net disconnect k0 0
+.columns name,vlan,bridge vm info
+vm net disconnect c0 0
+.columns name,vlan,bridge vm info
+vm net disconnect all 0
+.columns name,vlan,bridge vm info
+
+# connect single and multiple VMs
+vm net connect k0 0 LAN2
+.columns name,vlan,bridge vm info
+vm net connect c0 0 LAN2
+.columns name,vlan,bridge vm info
+vm net connect all 0 LAN2 mega_bridge2
+.columns name,vlan,bridge vm info
+
+# reconnect single and multiple VMs
+vm net connect k0 0 LAN3
+.columns name,vlan,bridge vm info
+vm net connect c0 0 LAN3
+.columns name,vlan,bridge vm info
+vm net connect all 0 LAN3
 .columns name,vlan,bridge vm info

--- a/tests/vm_net.want
+++ b/tests/vm_net.want
@@ -61,22 +61,25 @@ k1   | [LAN2 (102)] | [mega_bridge2]
 name | vlan         | bridge
 c0   | [LAN2 (102)] | [mega_bridge2]
 c1   | [LAN2 (102)] | [mega_bridge2]
-k0   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge2]
 k1   | [LAN2 (102)] | [mega_bridge2]
 ## vm net connect c0 0 LAN3
 ## .columns name,vlan,bridge vm info
 name | vlan         | bridge
-c0   | [LAN3 (103)] | [mega_bridge]
+c0   | [LAN3 (103)] | [mega_bridge2]
 c1   | [LAN2 (102)] | [mega_bridge2]
-k0   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge2]
 k1   | [LAN2 (102)] | [mega_bridge2]
 ## vm net connect all 0 LAN3
 ## .columns name,vlan,bridge vm info
 name | vlan         | bridge
-c0   | [LAN3 (103)] | [mega_bridge]
-c1   | [LAN3 (103)] | [mega_bridge]
-k0   | [LAN3 (103)] | [mega_bridge]
-k1   | [LAN3 (103)] | [mega_bridge]
+c0   | [LAN3 (103)] | [mega_bridge2]
+c1   | [LAN3 (103)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge2]
+k1   | [LAN3 (103)] | [mega_bridge2]
+
+## # reconnect back to mega_bridge
+## vm net connect all 0 LAN3 mega_bridge
 
 ## # start everything and repeat
 ## vm start all
@@ -133,22 +136,25 @@ k1   | [LAN2 (102)] | [mega_bridge2]
 name | vlan         | bridge
 c0   | [LAN2 (102)] | [mega_bridge2]
 c1   | [LAN2 (102)] | [mega_bridge2]
-k0   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge2]
 k1   | [LAN2 (102)] | [mega_bridge2]
 ## vm net connect c0 0 LAN3
 ## .columns name,vlan,bridge vm info
 name | vlan         | bridge
-c0   | [LAN3 (103)] | [mega_bridge]
+c0   | [LAN3 (103)] | [mega_bridge2]
 c1   | [LAN2 (102)] | [mega_bridge2]
-k0   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge2]
 k1   | [LAN2 (102)] | [mega_bridge2]
 ## vm net connect all 0 LAN3
 ## .columns name,vlan,bridge vm info
 name | vlan         | bridge
-c0   | [LAN3 (103)] | [mega_bridge]
-c1   | [LAN3 (103)] | [mega_bridge]
-k0   | [LAN3 (103)] | [mega_bridge]
-k1   | [LAN3 (103)] | [mega_bridge]
+c0   | [LAN3 (103)] | [mega_bridge2]
+c1   | [LAN3 (103)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge2]
+k1   | [LAN3 (103)] | [mega_bridge2]
+
+## # reconnect back to mega_bridge
+## vm net connect all 0 LAN3 mega_bridge
 
 ## # kill all and repeat
 ## vm kill all
@@ -205,19 +211,19 @@ k1   | [LAN2 (102)] | [mega_bridge2]
 name | vlan         | bridge
 c0   | [LAN2 (102)] | [mega_bridge2]
 c1   | [LAN2 (102)] | [mega_bridge2]
-k0   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge2]
 k1   | [LAN2 (102)] | [mega_bridge2]
 ## vm net connect c0 0 LAN3
 ## .columns name,vlan,bridge vm info
 name | vlan         | bridge
-c0   | [LAN3 (103)] | [mega_bridge]
+c0   | [LAN3 (103)] | [mega_bridge2]
 c1   | [LAN2 (102)] | [mega_bridge2]
-k0   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge2]
 k1   | [LAN2 (102)] | [mega_bridge2]
 ## vm net connect all 0 LAN3
 ## .columns name,vlan,bridge vm info
 name | vlan         | bridge
-c0   | [LAN3 (103)] | [mega_bridge]
-c1   | [LAN3 (103)] | [mega_bridge]
-k0   | [LAN3 (103)] | [mega_bridge]
-k1   | [LAN3 (103)] | [mega_bridge]
+c0   | [LAN3 (103)] | [mega_bridge2]
+c1   | [LAN3 (103)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge2]
+k1   | [LAN3 (103)] | [mega_bridge2]

--- a/tests/vm_net.want
+++ b/tests/vm_net.want
@@ -1,22 +1,223 @@
-## vm config net 0
-## vm launch kvm vm0
+## vm config net LAN
+## vm launch kvm k[0-1]
+## vm config filesystem $minicccfs
+## vm launch container c[0-1]
+## .columns name,vlan,bridge vm info
+name | vlan        | bridge
+c0   | [LAN (101)] | [mega_bridge]
+c1   | [LAN (101)] | [mega_bridge]
+k0   | [LAN (101)] | [mega_bridge]
+k1   | [LAN (101)] | [mega_bridge]
 
-## .columns name,vlan,bridge vm info
-name | vlan | bridge
-vm0  | [0]  | [mega_bridge]
-## vm net disconnect vm0 0
+## # disconnect single and multiple VMs
+## vm net disconnect k0 0
 ## .columns name,vlan,bridge vm info
 name | vlan           | bridge
-vm0  | [disconnected] | []
-## vm net connect vm0 0 foo 1
-## .columns name,vlan,bridge vm info
-name | vlan | bridge
-vm0  | [1]  | [foo]
-## vm net connect vm0 0 bar 0
-## .columns name,vlan,bridge vm info
-name | vlan | bridge
-vm0  | [0]  | [bar]
-## vm net disconnect vm0 0
+c0   | [LAN (101)]    | [mega_bridge]
+c1   | [LAN (101)]    | [mega_bridge]
+k0   | [disconnected] | []
+k1   | [LAN (101)]    | [mega_bridge]
+## vm net disconnect c0 0
 ## .columns name,vlan,bridge vm info
 name | vlan           | bridge
-vm0  | [disconnected] | []
+c0   | [disconnected] | []
+c1   | [LAN (101)]    | [mega_bridge]
+k0   | [disconnected] | []
+k1   | [LAN (101)]    | [mega_bridge]
+## vm net disconnect all 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [disconnected] | []
+c1   | [disconnected] | []
+k0   | [disconnected] | []
+k1   | [disconnected] | []
+
+## # connect single and multiple VMs
+## vm net connect k0 0 LAN2
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [disconnected] | []
+c1   | [disconnected] | []
+k0   | [LAN2 (102)]   | [mega_bridge]
+k1   | [disconnected] | []
+## vm net connect c0 0 LAN2
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [LAN2 (102)]   | [mega_bridge]
+c1   | [disconnected] | []
+k0   | [LAN2 (102)]   | [mega_bridge]
+k1   | [disconnected] | []
+## vm net connect all 0 LAN2 mega_bridge2
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN2 (102)] | [mega_bridge2]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN2 (102)] | [mega_bridge2]
+k1   | [LAN2 (102)] | [mega_bridge2]
+
+## # reconnect single and multiple VMs
+## vm net connect k0 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN2 (102)] | [mega_bridge2]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN2 (102)] | [mega_bridge2]
+## vm net connect c0 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN3 (103)] | [mega_bridge]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN2 (102)] | [mega_bridge2]
+## vm net connect all 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN3 (103)] | [mega_bridge]
+c1   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN3 (103)] | [mega_bridge]
+
+## # start everything and repeat
+## vm start all
+
+## # disconnect single and multiple VMs
+## vm net disconnect k0 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [LAN3 (103)]   | [mega_bridge]
+c1   | [LAN3 (103)]   | [mega_bridge]
+k0   | [disconnected] | []
+k1   | [LAN3 (103)]   | [mega_bridge]
+## vm net disconnect c0 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [disconnected] | []
+c1   | [LAN3 (103)]   | [mega_bridge]
+k0   | [disconnected] | []
+k1   | [LAN3 (103)]   | [mega_bridge]
+## vm net disconnect all 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [disconnected] | []
+c1   | [disconnected] | []
+k0   | [disconnected] | []
+k1   | [disconnected] | []
+
+## # connect single and multiple VMs
+## vm net connect k0 0 LAN2
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [disconnected] | []
+c1   | [disconnected] | []
+k0   | [LAN2 (102)]   | [mega_bridge]
+k1   | [disconnected] | []
+## vm net connect c0 0 LAN2
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [LAN2 (102)]   | [mega_bridge]
+c1   | [disconnected] | []
+k0   | [LAN2 (102)]   | [mega_bridge]
+k1   | [disconnected] | []
+## vm net connect all 0 LAN2 mega_bridge2
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN2 (102)] | [mega_bridge2]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN2 (102)] | [mega_bridge2]
+k1   | [LAN2 (102)] | [mega_bridge2]
+
+## # reconnect single and multiple VMs
+## vm net connect k0 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN2 (102)] | [mega_bridge2]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN2 (102)] | [mega_bridge2]
+## vm net connect c0 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN3 (103)] | [mega_bridge]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN2 (102)] | [mega_bridge2]
+## vm net connect all 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN3 (103)] | [mega_bridge]
+c1   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN3 (103)] | [mega_bridge]
+
+## # kill all and repeat
+## vm kill all
+
+## # disconnect single and multiple VMs
+## vm net disconnect k0 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [LAN3 (103)]   | [mega_bridge]
+c1   | [LAN3 (103)]   | [mega_bridge]
+k0   | [disconnected] | []
+k1   | [LAN3 (103)]   | [mega_bridge]
+## vm net disconnect c0 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [disconnected] | []
+c1   | [LAN3 (103)]   | [mega_bridge]
+k0   | [disconnected] | []
+k1   | [LAN3 (103)]   | [mega_bridge]
+## vm net disconnect all 0
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [disconnected] | []
+c1   | [disconnected] | []
+k0   | [disconnected] | []
+k1   | [disconnected] | []
+
+## # connect single and multiple VMs
+## vm net connect k0 0 LAN2
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [disconnected] | []
+c1   | [disconnected] | []
+k0   | [LAN2 (102)]   | [mega_bridge]
+k1   | [disconnected] | []
+## vm net connect c0 0 LAN2
+## .columns name,vlan,bridge vm info
+name | vlan           | bridge
+c0   | [LAN2 (102)]   | [mega_bridge]
+c1   | [disconnected] | []
+k0   | [LAN2 (102)]   | [mega_bridge]
+k1   | [disconnected] | []
+## vm net connect all 0 LAN2 mega_bridge2
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN2 (102)] | [mega_bridge2]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN2 (102)] | [mega_bridge2]
+k1   | [LAN2 (102)] | [mega_bridge2]
+
+## # reconnect single and multiple VMs
+## vm net connect k0 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN2 (102)] | [mega_bridge2]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN2 (102)] | [mega_bridge2]
+## vm net connect c0 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN3 (103)] | [mega_bridge]
+c1   | [LAN2 (102)] | [mega_bridge2]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN2 (102)] | [mega_bridge2]
+## vm net connect all 0 LAN3
+## .columns name,vlan,bridge vm info
+name | vlan         | bridge
+c0   | [LAN3 (103)] | [mega_bridge]
+c1   | [LAN3 (103)] | [mega_bridge]
+k0   | [LAN3 (103)] | [mega_bridge]
+k1   | [LAN3 (103)] | [mega_bridge]


### PR DESCRIPTION
`vm net` now supports the same vm target syntax as `vm start`. Made
bridge an optional parameter that defaults to `mega_bridge`. Fixes bug
where `vm net` used wrapSimpleCLI instead of wrapVMTargetCLI -- before
it wouldn't work across a namespace.

Fixes #994.

We should merge this before 2.4 since it includes a bug fix (and a
useful feature). Most of the additions are tests.