### PR TITLE
vmbetter: add 'components' option to cli

### DIFF
--- a/src/vmbetter/debootstrap.go
+++ b/src/vmbetter/debootstrap.go
@@ -21,6 +21,9 @@ func Debootstrap(buildPath string, c vmconfig.Config) error {
 	var args []string
 	args = append(args, "--variant=minbase")
 	args = append(args, fmt.Sprintf("--include=%v", strings.Join(c.Packages, ",")))
+	if *f_components != "" {
+		args = append(args, fmt.Sprintf("--components=%v", *f_components))
+	}
 	args = append(args, *f_branch)
 	args = append(args, buildPath)
 	args = append(args, *f_debian_mirror)

--- a/src/vmbetter/main.go
+++ b/src/vmbetter/main.go
@@ -25,6 +25,7 @@ var (
 	f_stage1        = flag.Bool("1", false, "stop after stage one, and copy build files to <config>_stage1")
 	f_stage2        = flag.String("2", "", "complete stage 2 from an existing stage 1 directory")
 	f_branch        = flag.String("branch", "testing", "debian branch to use")
+	f_components    = flag.String("components", "", "use packages from the listed components of the archive")
 	f_qcow          = flag.Bool("qcow", false, "generate a qcow2 image instead of a kernel/initrd pair")
 	f_qcowsize      = flag.String("qcowsize", "1G", "qcow2 image size (eg 1G, 1024M)")
 	f_mbr           = flag.String("mbr", "/usr/lib/syslinux/mbr.bin", "path to mbr.bin if building qcow2 images")


### PR DESCRIPTION
Like to be able to specify the archive components to use (e.g. main, restricted, universe and/or multiverse for an ubuntu mirror) on the vmbetter cli.