### PR TITLE
minimega: fix bugs with minicli flags

### DIFF
--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -391,7 +391,7 @@ func namespaceCommands(ns *Namespace, cmd *minicli.Command) []*minicli.Command {
 	for _, cmd2 := range cmds {
 		cmd2.SetSource(ns.Name)
 		cmd2.SetRecord(false)
-		cmd2.Preprocess = cmd.Preprocess
+		cmd2.SetPreprocess(cmd.Preprocess)
 	}
 
 	return cmds

--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -388,9 +388,10 @@ func namespaceCommands(ns *Namespace, cmd *minicli.Command) []*minicli.Command {
 		cmds = append(cmds, cmd2)
 	}
 
-	for _, cmd := range cmds {
-		cmd.SetSource(ns.Name)
-		cmd.SetRecord(false)
+	for _, cmd2 := range cmds {
+		cmd2.SetSource(ns.Name)
+		cmd2.SetRecord(false)
+		cmd2.Preprocess = cmd.Preprocess
 	}
 
 	return cmds

--- a/src/minimega/command_meshage.go
+++ b/src/minimega/command_meshage.go
@@ -112,11 +112,11 @@ func meshageHandler() {
 				return
 			}
 
-			// Copy the Record flag at each level of nested command
+			// Copy the flags at each level of nested command
 			for c, c2 := cmd, &mCmd.Command; c != nil && c2 != nil; {
-				// could all be the post statement...
 				c.Record = c2.Record
 				c.Source = c2.Source
+				c.Preprocess = c2.Preprocess
 				c, c2 = c.Subcommand, c2.Subcommand
 			}
 

--- a/src/minimega/namespace_cli.go
+++ b/src/minimega/namespace_cli.go
@@ -131,6 +131,13 @@ func cliNamespace(c *minicli.Command, respChan chan<- minicli.Responses) {
 				defer RevertNamespace(ns, ns2)
 			}
 
+			// we don't want to see both:
+			// 		namespace foo vm info
+			// 		vm info
+			// in the logs (well, we would actually see them in reverse order
+			// because the inner command runs first).
+			c.Subcommand.Record = false
+
 			// Run the subcommand and forward the responses.
 			//
 			// LOCK: This is a CLI so we already hold cmdLock (can call


### PR DESCRIPTION
Make sure preprocess gets set on all subcommands. Set record=false on namespace subcommands.