### PR TITLE
minicli/minimega: rewrite minicli.Help

### DIFF
--- a/src/minicli/command.go
+++ b/src/minicli/command.go
@@ -123,10 +123,10 @@ outer:
 	// problematic as we have commands: "vm info" and "vm info search <terms>"
 	// that share the same prefix.
 	if len(pattern) != len(input.items) {
-		return nil, len(pattern) - 1, exact
+		return nil, len(pattern), exact
 	}
 
-	return &cmd, len(pattern) - 1, exact
+	return &cmd, len(pattern), exact
 }
 
 // SetSource sets the Source field for a command and all nested subcommands.

--- a/src/minicli/util.go
+++ b/src/minicli/util.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 	"text/tabwriter"
 )
 
@@ -24,19 +25,26 @@ func identicalHelp(handlers []*Handler) bool {
 	return true
 }
 
-func printHelpShort(helpShort map[string]string) string {
-	var sortedNames []string
-	for c, _ := range helpShort {
-		sortedNames = append(sortedNames, c)
+func printHelpShort(handlers []*Handler) string {
+	sort.Slice(handlers, func(i, j int) bool {
+		return strings.Compare(handlers[i].SharedPrefix, handlers[j].SharedPrefix) <= 0
+	})
+	keys := []string{}
+	vals := map[string]string{}
+	for _, h := range handlers {
+		for _, p := range h.Patterns {
+			keys = append(keys, p)
+			vals[p] = h.helpShort()
+		}
 	}
-	sort.Strings(sortedNames)
+	sort.Strings(keys)
 
 	res := "Display help on a command. Here is a list of commands:\n"
 	w := new(tabwriter.Writer)
 	buf := bytes.NewBufferString(res)
 	w.Init(buf, 0, 8, 0, '\t', 0)
-	for _, c := range sortedNames {
-		fmt.Fprintln(w, c, "\t", ":\t", helpShort[c], "\t")
+	for _, v := range keys {
+		fmt.Fprintln(w, v, "\t", ":\t", vals[v], "\t")
 	}
 	w.Flush()
 

--- a/src/minimega/plumber.go
+++ b/src/minimega/plumber.go
@@ -23,7 +23,7 @@ var (
 
 var plumbCLIHandlers = []minicli.Handler{
 	{ // plumb
-		HelpShort: "plumb external programs with minimega, VMs, and other external programs",
+		HelpShort: "plumb I/O between minimega, VMs, and external programs",
 		HelpLong: `
 Create pipelines composed of named pipes and external programs. Pipelines pass
 data on standard I/O, with messages split on newlines. Pipelines are


### PR DESCRIPTION
Rewrite minicli.Help to be easier to understand and print help for
commands like `vnc record`. Shortened the short help for plumb so that
the line does not wrap.

Fixes #1022.