### PR TITLE
igor: stricter usage of `cobbler profile list`

### DIFF
--- a/src/igor/cobbler.go
+++ b/src/igor/cobbler.go
@@ -1,0 +1,32 @@
+// Copyright (2017) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"bufio"
+	log "minilog"
+	"strings"
+)
+
+func getCobblerProfiles() map[string]bool {
+	res := map[string]bool{}
+
+	// Get a list of current profiles
+	out, err := processWrapper("cobbler", "profile", "list")
+	if err != nil {
+		log.Fatal("couldn't get list of cobbler profiles: %v\n", err)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		res[strings.TrimSpace(scanner.Text())] = true
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatal("unable to read cobbler profiles: %v", err)
+	}
+
+	return res
+}

--- a/src/igor/main.go
+++ b/src/igor/main.go
@@ -8,7 +8,6 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -18,7 +17,6 @@ import (
 	log "minilog"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -167,20 +165,7 @@ func housekeeping() {
 
 	cobblerProfiles := map[string]bool{}
 	if igorConfig.UseCobbler {
-		// Get a list of current profiles
-		out, err := processWrapper("cobbler", "profile", "list")
-		if err != nil {
-			log.Fatal("couldn't get list of cobbler profiles: %v\n", cobblerProfiles)
-		}
-
-		scanner := bufio.NewScanner(strings.NewReader(out))
-		for scanner.Scan() {
-			cobblerProfiles[strings.TrimSpace(scanner.Text())] = true
-		}
-
-		if err := scanner.Err(); err != nil {
-			log.Fatal("unable to read cobbler profiles: %v", err)
-		}
+		cobblerProfiles = getCobblerProfiles()
 	}
 
 	for _, r := range Reservations {

--- a/src/igor/sub.go
+++ b/src/igor/sub.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"ranges"
-	"strings"
 	"time"
 )
 
@@ -99,11 +98,8 @@ func runSub(cmd *Command, args []string) {
 
 	// Validate the cobbler profile
 	if subProfile != "" {
-		cobblerProfiles, err := processWrapper("cobbler", "profile", "list")
-		if err != nil {
-			log.Fatal("couldn't get list of cobbler profiles: %v\n", err)
-		}
-		if !strings.Contains(cobblerProfiles, subProfile) {
+		cobblerProfiles := getCobblerProfiles()
+		if !cobblerProfiles[subProfile] {
 			log.Fatal("Cobbler profile does not exist: ", subProfile)
 		}
 	}


### PR DESCRIPTION
Parse `cobbler profile list` into a map and check whether the requested
profile is in the map. This prevents a substring of a valid profile name
from being used.