### PR TITLE
minimega: fix empty VLAN bug

### DIFF
--- a/src/minimega/misc.go
+++ b/src/minimega/misc.go
@@ -343,7 +343,7 @@ func processVMNet(namespace, spec string) (res NetConfig, err error) {
 		return NetConfig{}, errors.New("malformed netspec, invalid driver: " + d)
 	}
 
-	log.Debug("got bridge=%v, vlan=%v, mac=%v, driver=%v", b, v, m, d)
+	log.Info(`got bridge="%v", vlan="%v", mac="%v", driver="%v"`, b, v, m, d)
 
 	vlan, err := lookupVLAN(namespace, v)
 	if err != nil {
@@ -378,6 +378,10 @@ func processVMNet(namespace, spec string) (res NetConfig, err error) {
 // into a VLAN. If the VLAN didn't already exist, broadcasts the update to the
 // cluster.
 func lookupVLAN(namespace, alias string) (int, error) {
+	if alias == "" {
+		return 0, errors.New("VLAN must be non-empty string")
+	}
+
 	vlan, err := allocatedVLANs.ParseVLAN(namespace, alias)
 	if err != vlans.ErrUnallocated {
 		// nil or other error


### PR DESCRIPTION
Return an error if the VLAN is empty instead of hitting `log.Fatal`.

Fixes #1031.

@mkunz7 