### PR TITLE
protonuke: parameter for image size, header for version

### DIFF
--- a/src/protonuke/flag.go
+++ b/src/protonuke/flag.go
@@ -19,7 +19,7 @@ const DefaultFileSize = FileSize(3 * 1 << 20)
 // DefaultFTPFileSize is 500KB
 const DefaultFTPFileSize = FileSize(500 * 1 << 10)
 
-func (f *FileSize) Set(s string) error {
+func ParseFileSize(s string) (FileSize, error) {
 	for i, suffix := range []string{"B", "KB", "MB"} {
 		if strings.HasSuffix(s, suffix) {
 			v, err := strconv.Atoi(strings.TrimSuffix(s, suffix))
@@ -27,19 +27,22 @@ func (f *FileSize) Set(s string) error {
 				continue
 			}
 
-			*f = FileSize(v * (1 << uint(10*i)))
-			return nil
+			return FileSize(v * (1 << uint(10*i))), nil
 		}
 	}
 
 	// Assume MB
 	v, err := strconv.Atoi(s)
 	if err != nil {
-		return errors.New("invalid file size, expected value[B,KB,MB]")
+		return 0, errors.New("invalid file size, expected value[B,KB,MB]")
 	}
 
-	*f = FileSize(v * (1 << 20))
-	return nil
+	return FileSize(v * (1 << 20)), nil
+}
+
+func (f *FileSize) Set(s string) (err error) {
+	*f, err = ParseFileSize(s)
+	return
 }
 
 func (f *FileSize) String() string {

--- a/src/protonuke/http.go
+++ b/src/protonuke/http.go
@@ -38,10 +38,12 @@ var (
 	hitTLSChan       chan uint64
 	httpSiteCache    []string
 	httpTLSSiteCache []string
-	httpImage        []byte
 	httpReady        bool
 	httpLock         sync.Mutex
 	httpFS           http.Handler
+
+	httpImageMu sync.RWMutex // guards below
+	httpImages  map[FileSize][]byte
 )
 
 type HtmlContent struct {
@@ -332,7 +334,9 @@ func httpSetup() {
 	}
 
 	http.HandleFunc("/", httpHandler)
-	httpMakeImage()
+
+	httpImages = make(map[FileSize][]byte)
+	httpMakeImage(f_httpImageSize)
 
 	var err error
 	htmlTemplate, err = template.New("output").Parse(htmlsrc)
@@ -397,17 +401,14 @@ func httpTLSServer(p string) {
 	log.Fatalln(server.Serve(tlsListener))
 }
 
-func httpMakeImage() {
-	s := rand.NewSource(time.Now().UnixNano())
-	r := rand.New(s)
-
-	pixelcount := f_httpImageSize / 4
+func httpMakeImage(size FileSize) {
+	pixelcount := size / 4
 	side := int(math.Sqrt(float64(pixelcount)))
 	log.Debug("Image served will be %v by %v", side, side)
 
 	m := image.NewRGBA(image.Rect(0, 0, side, side))
 	for i := 0; i < len(m.Pix); i++ {
-		m.Pix[i] = uint8(r.Int())
+		m.Pix[i] = uint8(rand.Int())
 	}
 
 	buf := new(bytes.Buffer)
@@ -420,7 +421,10 @@ func httpMakeImage() {
 		png.Encode(buf, m)
 	}
 
-	httpImage = buf.Bytes()
+	httpImageMu.Lock()
+	defer httpImageMu.Unlock()
+
+	httpImages[size] = buf.Bytes()
 }
 
 func hitCounter() {
@@ -439,6 +443,41 @@ func hitTLSCounter() {
 	}
 }
 
+func httpImageHandler(w http.ResponseWriter, r *http.Request) {
+	size := f_httpImageSize
+
+	v := r.URL.Query()
+	if v.Get("size") != "" {
+		size2, err := ParseFileSize(v.Get("size"))
+		if err != nil {
+			http.Error(w, "invalid size", http.StatusBadRequest)
+			return
+		}
+		size = size2
+	}
+
+	var buf []byte
+	var ok bool
+
+	httpImageMu.RLock()
+	buf, ok = httpImages[size]
+	httpImageMu.RUnlock()
+
+	if !ok {
+		httpMakeImage(size)
+	}
+
+	httpImageMu.RLock()
+	buf, _ = httpImages[size]
+	httpImageMu.RUnlock()
+
+	if *f_httpGzip {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "image/png")
+	}
+	w.Write(buf)
+}
+
 func httpHandler(w http.ResponseWriter, r *http.Request) {
 	log.Debug("request: %v %v", r.RemoteAddr, r.URL.String())
 	var usingTLS bool
@@ -450,27 +489,21 @@ func httpHandler(w http.ResponseWriter, r *http.Request) {
 	start := time.Now().UnixNano()
 	if httpFS != nil {
 		httpFS.ServeHTTP(w, r)
+	} else if r.Method == http.MethodPost {
+		w.WriteHeader(http.StatusAccepted)
+	} else if strings.HasSuffix(r.URL.Path, "image.png") {
+		httpImageHandler(w, r)
 	} else {
-		if r.Method == http.MethodPost {
-			w.WriteHeader(http.StatusAccepted)
-		} else if strings.HasSuffix(r.URL.Path, "image.png") {
-			if *f_httpGzip {
-				w.Header().Set("Content-Encoding", "gzip")
-				w.Header().Set("Content-Type", "image/png")
-			}
-			w.Write(httpImage)
-		} else {
-			h := &HtmlContent{
-				URLs:   randomURLs(),
-				Hits:   hits,
-				URI:    fmt.Sprintf("%v %v", r.RemoteAddr, r.URL.String()),
-				Host:   r.Host,
-				Secure: usingTLS,
-			}
-			err := htmlTemplate.Execute(w, h)
-			if err != nil {
-				log.Errorln(err)
-			}
+		h := &HtmlContent{
+			URLs:   randomURLs(),
+			Hits:   hits,
+			URI:    fmt.Sprintf("%v %v", r.RemoteAddr, r.URL.String()),
+			Host:   r.Host,
+			Secure: usingTLS,
+		}
+		err := htmlTemplate.Execute(w, h)
+		if err != nil {
+			log.Errorln(err)
 		}
 	}
 

--- a/src/protonuke/http.go
+++ b/src/protonuke/http.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"version"
 )
 
 const (
@@ -485,6 +486,8 @@ func httpHandler(w http.ResponseWriter, r *http.Request) {
 		log.Debugln("request using tls")
 		usingTLS = true
 	}
+
+	w.Header().Set("Server", "protonuke/"+version.Revision)
 
 	start := time.Now().UnixNano()
 	if httpFS != nil {


### PR DESCRIPTION
Make the image size a query parameter:

```
http://10.0.0.1/image.png?size=1MB
http://10.0.0.1/image.png?size=16MB
```

If the size is not specified, it will use the size from the CLI flag. The image is generated on the first query for the given size and stored in memory for future requests. This could cause OOM issues if people query for many different image sizes. 

Set the `Server` HTTP header to `protonuke/$VERSON` where `$VERSION` is `version.Revision`. This makes it easier to figure out what version of protonuke you're querying.