### PR TITLE
igor: minor tweaks

### DIFF
--- a/src/igor/show.go
+++ b/src/igor/show.go
@@ -89,9 +89,8 @@ func runShow(_ *Command, _ []string) {
 	args = append(args,
 		"-sn",
 		"-PS22",
-		"--max-retries=1",
 		"--unprivileged",
-		"--host-timeout=300ms",
+		"-T5",
 		"-oG",
 		"-",
 	)

--- a/src/igor/sub.go
+++ b/src/igor/sub.go
@@ -288,10 +288,10 @@ VlanLoop:
 	Schedule = newSched
 
 	// update the network config
-	//err = networkSet(reservation.Hosts, vlan)
-	//if err != nil {
-	//	log.Fatal("error setting network isolation: %v", err)
-	//}
+	err = networkSet(reservation.Hosts, vlan)
+	if err != nil {
+		log.Fatal("error setting network isolation: %v", err)
+	}
 
 	putReservations()
 	putSchedule()


### PR DESCRIPTION
Uncomment the network isolation code. Will only be used if enabled in
config. Change nmap args so that `igor show` works when most of the
cluster is off.