### PR TITLE
igor: send emails, replace json with gob

### DIFF
--- a/src/igor/main.go
+++ b/src/igor/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"encoding/gob"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -336,7 +337,7 @@ func main() {
 	getReservations()
 
 	// Read in the schedule
-	path = filepath.Join(igorConfig.TFTPRoot, "/igor/schedule.json")
+	path = filepath.Join(igorConfig.TFTPRoot, "/igor/schedule.gob")
 	scheddb, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0664)
 	if err != nil {
 		log.Warn("failed to open schedule file: %v", err)
@@ -385,7 +386,7 @@ func getReservations() {
 
 // Read in the schedule from the already-open schedule file
 func getSchedule() {
-	dec := json.NewDecoder(scheddb)
+	dec := gob.NewDecoder(scheddb)
 	err := dec.Decode(&Schedule)
 	// an empty file is OK, but other errors are not
 	if err != nil && err != io.EOF {
@@ -410,7 +411,7 @@ func putSchedule() {
 	scheddb.Truncate(0)
 	scheddb.Seek(0, 0)
 	// Write out the new schedule
-	enc := json.NewEncoder(scheddb)
+	enc := gob.NewEncoder(scheddb)
 	enc.Encode(Schedule)
 	scheddb.Sync()
 }

--- a/src/igor/main.go
+++ b/src/igor/main.go
@@ -55,6 +55,7 @@ var commands = []*Command{
 	cmdShow,
 	cmdSub,
 	cmdPower,
+	cmdNotify,
 }
 
 var exitStatus = 0
@@ -111,6 +112,9 @@ type Config struct {
 	// TimeLimit: max time a non-root user can reserve
 	NodeLimit int
 	TimeLimit int
+
+	// Domain for email address
+	Domain string
 }
 
 // Represents a slice of time in the Schedule

--- a/src/igor/notify.go
+++ b/src/igor/notify.go
@@ -1,0 +1,119 @@
+// Copyright (2017) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"bytes"
+	log "minilog"
+	"os"
+	"os/exec"
+	"text/template"
+	"time"
+)
+
+var cmdNotify = &Command{
+	UsageLine: "notify",
+	Short:     "notify users of upcoming and expiring reservations",
+	Long: `
+Notify users of upcoming and expiring reservations. Intended to be run as a
+cronjob rather than by the users themselves.`,
+	Run: runNotify,
+}
+
+func runNotify(cmd *Command, args []string) {
+	log.Info("notifying users of upcoming and expiring reservations")
+
+	if os.Getuid() != 0 {
+		log.Fatalln("only root can notify users")
+	}
+
+	if igorConfig.Domain == "" {
+		log.Fatalln("must specify domain in config to notify users")
+	}
+
+	type Reservation struct {
+		Name  string
+		Start time.Time
+		End   time.Time
+	}
+	type Notification struct {
+		Upcoming []Reservation
+		Expiring []Reservation
+	}
+
+	// per-user notification
+	users := map[string]*Notification{}
+
+	now := time.Now()
+
+	for _, r := range Reservations {
+		// convert unix to time.Time
+		res := Reservation{
+			Name:  r.ResName,
+			Start: time.Unix(r.StartTime, 0),
+			End:   time.Unix(r.EndTime, 0),
+		}
+
+		// upcoming reservations start in just over an hour
+		diff := res.Start.Sub(now)
+		if diff >= 0 && diff < time.Hour {
+			if users[r.Owner] == nil {
+				users[r.Owner] = &Notification{}
+			}
+			users[r.Owner].Upcoming = append(users[r.Owner].Upcoming, res)
+		}
+
+		// expiring reservations are longer than two days and expire in just
+		// over 24 hours.
+		diff = res.End.Sub(now)
+		if res.End.Sub(res.Start) >= 48*time.Hour && diff >= 23*time.Hour && diff < 24*time.Hour {
+			if users[r.Owner] == nil {
+				users[r.Owner] = &Notification{}
+			}
+			users[r.Owner].Expiring = append(users[r.Owner].Expiring, res)
+		}
+	}
+
+	t := template.Must(template.New("notify").Parse(notifyTemplate))
+
+	for user, notification := range users {
+		var buf bytes.Buffer
+		if err := t.Execute(&buf, notification); err != nil {
+			log.Fatal("template error: %v", err)
+		}
+
+		log.Info("notifying %v of %v upcoming and %v expiring reservations", user, len(notification.Upcoming), len(notification.Expiring))
+
+		cmd := exec.Command("mail", "-s", notifySubject, user+"@"+igorConfig.Domain)
+		cmd.Stdin = &buf
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			log.Error("mail failed: %v %v", out, err)
+		}
+	}
+}
+
+const notifySubject = "igor reservations"
+
+const notifyTemplate = `
+Hello,
+{{ if .Upcoming }}
+Upcoming reservations:
+{{ range $v := .Upcoming }}
+	{{- $start := ($v.Start.Format "Mon Jan 2 15:04") }}
+	{{- $end := ($v.End.Format "Mon Jan 2 15:04") }}
+	{{ printf "%v to %v: %v" $start $end $v.Name }}
+{{ end }}
+{{ end }}
+{{ if .Expiring }}
+Expiring reservations:
+{{ range $v := .Expiring }}
+	{{- $start := ($v.Start.Format "Mon Jan 2 15:04") }}
+	{{- $end := ($v.End.Format "Mon Jan 2 15:04") }}
+	{{ printf "%v to %v: %v" $start $end $v.Name }}
+{{ end }}
+{{ end }}
+Sincerly,
+igor`


### PR DESCRIPTION
json to gob cuts down the time to load from 20s to <1s.

Add `igor notify`. Only runnable by root. Notifies user of upcoming and expiring reservations.

Fixes #958.