### PR TITLE
minimega: fix `vm config clone`

### DIFF
--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -465,6 +465,25 @@ func (n Namespace) hostSlice() []string {
 	return hosts
 }
 
+// processVMNets parses a list of netspecs using processVMNet and updates the
+// active vmConfig.
+func (n *Namespace) processVMNets(vals []string) error {
+	n.vmConfig.Networks = nil
+
+	for _, spec := range vals {
+		nic, err := processVMNet(n.Name, spec)
+		if err != nil {
+			n.vmConfig.Networks = nil
+			return err
+		}
+		nic.Raw = spec
+
+		n.vmConfig.Networks = append(n.vmConfig.Networks, nic)
+	}
+
+	return nil
+}
+
 // GetNamespace returns the active namespace.
 func GetNamespace() *Namespace {
 	namespaceLock.Lock()

--- a/src/minimega/vmconfig.go
+++ b/src/minimega/vmconfig.go
@@ -86,6 +86,10 @@ type NetConfig struct {
 	IP6    string
 
 	RxRate, TxRate float64 // Most recent bandwidth measurements for Tap
+
+	// Raw string that we used when creating this network config will be
+	// reparsed if we ever clone the VM that has this config.
+	Raw string
 }
 
 func NewVMConfig() VMConfig {

--- a/src/minimega/vmconfig_cli.go
+++ b/src/minimega/vmconfig_cli.go
@@ -37,6 +37,10 @@ To clone the configuration of an existing VM:
 
 	vm config clone <vm name>
 
+Clone reparses the original network "vm config net". If the cloned VM was
+configured with a static MAC, the VM config will not be launchable. Clone also
+clears the UUID.
+
 Calling clear vm config will clear all VM configuration options, but will not
 remove saved configurations.`,
 		Patterns: []string{
@@ -45,7 +49,8 @@ remove saved configurations.`,
 			"vm config <restore,> [name]",
 			"vm config <clone,> <vm name>",
 		},
-		Call: wrapSimpleCLI(cliVMConfig),
+		Suggest: wrapVMSuggest(VM_ANY_STATE, false),
+		Call:    wrapSimpleCLI(cliVMConfig),
 	},
 	{ // vm config net
 		HelpShort: "specify network interfaces for VM",
@@ -188,7 +193,16 @@ func cliVMConfig(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 			ns.vmConfig.ContainerConfig = vm.ContainerConfig.Copy()
 		}
 
-		return nil
+		// clear UUID since we can't launch VMs with the same UUID
+		ns.vmConfig.UUID = ""
+
+		// reprocess the network configs from their original input
+		vals := []string{}
+		for _, nic := range ns.vmConfig.Networks {
+			vals = append(vals, nic.Raw)
+		}
+
+		return ns.processVMNets(vals)
 	}
 
 	// Print the config
@@ -202,19 +216,7 @@ func cliVMConfigNet(ns *Namespace, c *minicli.Command, resp *minicli.Response) e
 		return nil
 	}
 
-	ns.vmConfig.Networks = nil
-
-	for _, spec := range c.ListArgs["netspec"] {
-		net, err := processVMNet(ns.Name, spec)
-		if err != nil {
-			ns.vmConfig.Networks = nil
-			return err
-		}
-
-		ns.vmConfig.Networks = append(ns.vmConfig.Networks, net)
-	}
-
-	return nil
+	return ns.processVMNets(c.ListArgs["netspec"])
 }
 
 func cliVMConfigQemuOverride(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {


### PR DESCRIPTION
Reprocess the original `vm config net` so that we generate new tap
names, if unspecified. Clear `vm config uuid` because we can't boot VMs
with the same UUID.

Updates #1072.

@mkunz7 