### PR TITLE
minimega: nix second -enable-kvm

### DIFF
--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -879,8 +879,6 @@ func (vm *KvmVM) ProcStats() (map[int]*ProcStats, error) {
 func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 	var args []string
 
-	args = append(args, "-enable-kvm")
-
 	args = append(args, "-name")
 	args = append(args, strconv.Itoa(id))
 


### PR DESCRIPTION
minimega uses `kvm` by default which typically runs `qemu-system-x86_64`
with `-enable-kvm` so it is redundant to include the flag. This makes it
simpler to run different architectures since you can change the qemu
path and don't need to add a qemu override to remove the `-enable-kvm`
flag.

Fixes #1076