### PR TITLE
Usb serial number

### DIFF
--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -717,7 +717,7 @@ func (vm *KvmVM) Connect(cc *ron.Server) error {
 	return cc.DialSerial(ccPath)
 }
 
-func (vm *KvmVM) Hotplug(f, version string) error {
+func (vm *KvmVM) Hotplug(f, version, serial string) error {
 	var bus string
 	switch version {
 	case "", "1.1":
@@ -750,7 +750,7 @@ func (vm *KvmVM) Hotplug(f, version string) error {
 	}
 	log.Debugln("hotplug drive_add response:", r)
 
-	r, err = vm.q.USBDeviceAdd(hid, bus)
+	r, err = vm.q.USBDeviceAdd(hid, bus, serial)
 	if err != nil {
 		return err
 	}

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -216,6 +216,7 @@ See "vm start" for a full description of allowable targets.`,
 		Patterns: []string{
 			"vm hotplug",
 			"vm hotplug <add,> <vm target> <filename> [version]",
+			"vm hotplug <add,> <vm target> <filename> serial <serial> [version]",
 			"vm hotplug <remove,> <vm target> <disk id or all>",
 		},
 		Call:    wrapVMTargetCLI(cliVMHotplug),
@@ -722,10 +723,11 @@ func cliVMHotplug(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 		}
 
 		version := c.StringArgs["version"]
+		serial := c.StringArgs["serial"]
 
 		return ns.VMs.Apply(target, func(vm VM, wild bool) (bool, error) {
 			if kvm, ok := vm.(*KvmVM); ok {
-				return true, kvm.Hotplug(f, version)
+				return true, kvm.Hotplug(f, version, serial)
 			}
 
 			return false, nil

--- a/src/qmp/qmp.go
+++ b/src/qmp/qmp.go
@@ -382,11 +382,14 @@ func (q *Conn) DriveAdd(id, file string) (string, error) {
 	return resp, err
 }
 
-func (q *Conn) USBDeviceAdd(id, bus string) (string, error) {
+func (q *Conn) USBDeviceAdd(id, bus, serial string) (string, error) {
 	if !q.ready {
 		return "", ERR_READY
 	}
 	arg := fmt.Sprintf("device_add usb-storage,id=%v,drive=%v,bus=%v", id, id, bus)
+	if serial != "" {
+		arg = fmt.Sprintf("device_add usb-storage,id=%v,drive=%v,bus=%v,serial=%v", id, id, bus, serial)
+	}
 	resp, err := q.HumanMonitorCommand(arg)
 	return resp, err
 }


### PR DESCRIPTION
Allow the user to give a USB disk a serial number. Implemented this to track USB devices across a virtual enterprise.