### PR TITLE
minimega: add RESTful command interface

### DIFF
--- a/src/minimega/command_http.go
+++ b/src/minimega/command_http.go
@@ -1,0 +1,82 @@
+// Copyright (2018) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"minicli"
+	log "minilog"
+	"net/http"
+)
+
+var httpServer *http.Server
+
+func commandHttpStart() {
+	if *f_httpAddr == "" {
+		return
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/command", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var request struct {
+			Command string `json:"command"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, "Failed to decode request body", http.StatusBadRequest)
+			log.Error("unable to decode request: %v", err)
+			return
+		}
+
+		var res []minicli.Responses
+
+		cmd, err := minicli.Compile(request.Command)
+		if err != nil {
+			// invalid command
+			resp := &minicli.Response{
+				Host:  hostname,
+				Error: err.Error(),
+			}
+
+			res = append(res, minicli.Responses{resp})
+		} else if cmd != nil {
+			for resps := range RunCommands(cmd) {
+				res = append(res, resps)
+			}
+		}
+
+		w.Header().Add("content-type", "application/json")
+		if err := json.NewEncoder(w).Encode(res); err != nil {
+			// shoot
+			return
+		}
+	})
+
+	httpServer = &http.Server{
+		Addr:    *f_httpAddr,
+		Handler: mux,
+	}
+
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil {
+			if err != http.ErrServerClosed {
+				log.Error("http server exited: %v", err)
+			}
+		}
+	}()
+}
+
+func commandHttpStop() {
+	if httpServer != nil {
+		httpServer.Shutdown(context.Background())
+	}
+}

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -50,6 +50,7 @@ var (
 	f_panic      = flag.Bool("panic", false, "panic on quit, producing stack traces for debugging")
 	f_cgroup     = flag.String("cgroup", "/sys/fs/cgroup", "path to cgroup mount")
 	f_pipe       = flag.String("pipe", "", "read/write to or from a named pipe")
+	f_httpAddr   = flag.String("http", ":9006", "address to listen on for HTTP requests, empty string disables")
 
 	hostname string
 	reserved = []string{Wildcard}
@@ -222,6 +223,7 @@ func main() {
 	SetNamespace(DefaultNamespace)
 
 	commandSocketStart()
+	commandHttpStart()
 
 	// set up signal handling
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
@@ -287,6 +289,7 @@ func teardown() {
 	}
 
 	commandSocketRemove()
+	commandHttpStop()
 
 	if err := os.Remove(filepath.Join(*f_base, "minimega.pid")); err != nil {
 		log.Errorln(err)


### PR DESCRIPTION
_Please wait for 2.5 to merge._

POST JSON to :9006/command to run a minimega command. For example:
```
curl 'http://localhost:9006/command' -d '{"command": "vm info" }'
```
Should this be enabled by default or enabled via option?