### PR TITLE
minidoc/present: add nested bullet support with "-- "

### DIFF
--- a/doc/template/action.tmpl
+++ b/doc/template/action.tmpl
@@ -10,8 +10,14 @@ It determines how the formatting actions are rendered.
 
 {{define "list"}}
   <ul>
+  {{ if .Nested }}
+    <ul>
+  {{end}}
   {{range .Bullet}}
     <li>{{style .}}</li>
+  {{end}}
+  {{ if .Nested }}
+    </ul>
   {{end}}
   </ul>
 {{end}}

--- a/src/present/parse.go
+++ b/src/present/parse.go
@@ -172,6 +172,7 @@ func (t Text) TemplateName() string { return "text" }
 // List represents a bulleted list.
 type List struct {
 	Bullet []string
+	Nested bool
 }
 
 func (l List) TemplateName() string { return "list" }
@@ -339,6 +340,14 @@ func parseSections(ctx *Context, name string, lines *Lines, number []int, doc *D
 				}
 				lines.back()
 				e = List{Bullet: b}
+			case strings.HasPrefix(text, "-- "):
+				var b []string
+				for ok && strings.HasPrefix(text, "-- ") {
+					b = append(b, text[2:])
+					text, ok = lines.next()
+				}
+				lines.back()
+				e = List{Bullet: b, Nested: true}
 			case strings.HasPrefix(text, prefix+"* "):
 				lines.back()
 				subsecs, err := parseSections(ctx, name, lines, section.Number, doc)


### PR DESCRIPTION
Not having nested bullets in present is terrible and the golang authors have decided not to add support. It's a simple patch but maybe we want to keep this as a .patch and have the build scripts apply it instead of modifying vendorized code...

@jcrussell 