### PR TITLE
minimega: remove namespace from default vm name

### DIFF
--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -358,7 +358,7 @@ func (n *Namespace) Schedule() error {
 				// get names that are unique across the namespace
 				for i, name := range q.Names {
 					if name == "" {
-						q.Names[i] = fmt.Sprintf("vm-%v-%v", n.Name, n.vmID.Next())
+						q.Names[i] = fmt.Sprintf("vm-%v", n.vmID.Next())
 					}
 				}
 

--- a/tests/distributed/vm_names.want
+++ b/tests/distributed/vm_names.want
@@ -4,9 +4,9 @@
 ## # should all have a unique name
 ## .column name vm info
 name
-vm-distributed-0
-vm-distributed-1
-vm-distributed-2
-vm-distributed-3
-vm-distributed-4
-vm-distributed-5
+vm-0
+vm-1
+vm-2
+vm-3
+vm-4
+vm-5


### PR DESCRIPTION
Each namespace has its own counter and names don't have to be unique
across namespaces so remove the namespace from the default vm name.