### PR TITLE
vmconfig: more magic

### DIFF
--- a/misc/vmbetter_configs/carnac_host.conf
+++ b/misc/vmbetter_configs/carnac_host.conf
@@ -3,7 +3,7 @@ parents = "host.conf"
 
 packages = "libmlx5-1"
 
-overlay = "misc/vmbetter_configs/carnac_host_overlay"
+overlay = "carnac_host_overlay"
 
 postbuild = `
 	echo "carnac_host built with vmbetter on $(date)" > /etc/motd

--- a/misc/vmbetter_configs/ccc_host.conf
+++ b/misc/vmbetter_configs/ccc_host.conf
@@ -1,8 +1,8 @@
 // ccc host
 parents = "host.conf"
 
-overlay = "misc/vmbetter_configs/ccc_host_overlay"
+overlay = "ccc_host_overlay"
 
 postbuild = `
-	echo "ccc_host_ovs built with vmbetter on $(date)" > /etc/motd
+	echo "ccc_host built with vmbetter on $(date)" > /etc/motd
 `

--- a/misc/vmbetter_configs/default_amd64.conf
+++ b/misc/vmbetter_configs/default_amd64.conf
@@ -1,33 +1,37 @@
 // example config
+//
 // comments begin with // and may appear anywhere
 
 // the generated image will be named after the config file, without the .conf
 
 // parents
-// list parent configs to read in relative or absolute paths.
-// you may include multiple parents in list order seperated by spaces
+//
+// List parent configs to read in relative or absolute paths. You may include
+// multiple parents in list order seperated by spaces
 
 // packages
-// list packages available via apt-get to install
-// you may list multiple packages seperated by spaces
+//
+// List packages available via apt-get to install. You may list multiple
+// packages seperated by spaces.
 packages = "linux-headers-amd64 linux-image-amd64 isc-dhcp-client openssh-server netbase ntp vim less"
 
 // network utils
 packages = "net-tools telnet netcat-openbsd iputils-ping curl wget ethtool traceroute dnsutils tcpdump"
 
 // overlay
-// specify an overlay directory to copy onto the image
-// the overlay will be copied into the root of the image, so
-// <your overlay path>/etc will go into /etc on the image
-// the overlay path can be relative or absolute
-overlay = "misc/vmbetter_configs/default_overlay"
+//
+// Specify an overlay directory to copy onto the image the overlay will be
+// copied into the root of the image, so <your overlay path>/etc will go into
+// /etc on the image the overlay path can be relative or absolute. Relative
+// paths are interpretted relative to the config file.
+overlay = "default_overlay"
 
 // postbuild
-// a newline seperated list of post-build commands to execute in a chroot
-// environment.
-// commands are run with bash, so all bash syntax should work.
-// the postbuild script is run as a whole, so local variables and other
-// bash-isms work.
+//
+// A newline seperated list of post-build commands to execute in a chroot
+// environment. Commands are run with bash, so all bash syntax should work. The
+// postbuild script is run as a whole, so local variables and other bash-isms
+// work.
 postbuild = `
 	# by default, allow passwordless root log in
 	sed -i 's/nullok_secure/nullok/' /etc/pam.d/common-auth

--- a/misc/vmbetter_configs/host.conf
+++ b/misc/vmbetter_configs/host.conf
@@ -12,7 +12,7 @@ packages = "strace gdb"
 // misc
 packages = "tmux locales"
 
-overlay = "misc/vmbetter_configs/host_overlay"
+overlay = "host_overlay"
 
 postbuild = `
 	echo "root soft nofile 999999" >> /etc/security/limits.conf

--- a/misc/vmbetter_configs/miniccc.conf
+++ b/misc/vmbetter_configs/miniccc.conf
@@ -3,8 +3,8 @@
 
 parents = "default_amd64.conf"
 
-overlay = "misc/vmbetter_configs/miniccc_overlay"
+overlay = "miniccc_overlay"
 
 postbuild = `
-	echo "miniccc_virtio built with vmbetter on $(date)" > /etc/motd
+	echo "miniccc built with vmbetter on $(date)" > /etc/motd
 `

--- a/misc/vmbetter_configs/miniccc_container.conf
+++ b/misc/vmbetter_configs/miniccc_container.conf
@@ -3,7 +3,7 @@
 
 parents = "default_amd64.conf"
 
-overlay = "misc/vmbetter_configs/miniccc_container_overlay"
+overlay = "miniccc_container_overlay"
 
 postbuild = `
 	echo "miniccc_container built with vmbetter on $(date)" > /etc/motd

--- a/misc/vmbetter_configs/miniception.conf
+++ b/misc/vmbetter_configs/miniception.conf
@@ -2,4 +2,4 @@
 
 parents = "host.conf"
 
-overlay = "misc/vmbetter_configs/miniception_overlay"
+overlay = "miniception_overlay"

--- a/misc/vmbetter_configs/minirouter.conf
+++ b/misc/vmbetter_configs/minirouter.conf
@@ -4,7 +4,7 @@ parents = "default_amd64.conf"
 // minirouter needs
 packages = "dnsmasq bird"
 
-overlay = "misc/vmbetter_configs/minirouter_overlay"
+overlay = "minirouter_overlay"
 
 postbuild = `
 	echo "minirouter built with vmbetter on $(date)" > /etc/motd

--- a/misc/vmbetter_configs/minirouter_container.conf
+++ b/misc/vmbetter_configs/minirouter_container.conf
@@ -4,7 +4,7 @@ parents = "default_amd64.conf"
 // minirouter needs
 packages = "dnsmasq bird"
 
-overlay = "misc/vmbetter_configs/minirouter_container_overlay"
+overlay = "minirouter_container_overlay"
 
 postbuild = `
 	echo "minirouter_container built with vmbetter on $(date)" > /etc/motd

--- a/src/vmconfig/vmconfig.go
+++ b/src/vmconfig/vmconfig.go
@@ -33,26 +33,26 @@ type Config struct {
 // any parents. Config is invalid on any non-nil error.
 func ReadConfig(path string) (c Config, err error) {
 	c.Path = path
-	err = read(path, &c)
+	err = read(path, "", &c)
 	return
 }
 
 // reentrant read routine. Will be called recursively if a 'parents' key exists in the config file
-func read(path string, c *Config) error {
+func read(path, prev string, c *Config) error {
 	f, err := os.Open(path)
 	if err != nil {
-		if strings.Contains(err.Error(), "no such file") { // file doesn't exist, let's try some path magic
-			if path == c.Path {
-				return err
-			}
-			newpath := filepath.Join(filepath.Dir(c.Path), filepath.Base(path))
-			f, err = os.Open(newpath)
+		// file doesn't exist, let's try some path magic
+		if strings.Contains(err.Error(), "no such file") && prev != "" {
+			// maybe the parent is relative to the prev file
+			path2 := filepath.Join(filepath.Dir(prev), path)
+
+			f, err = os.Open(path2)
 			if err != nil {
 				return err
 			}
-			log.Warn("could not find %v, but found a similar one at %v, using that instead", path, newpath)
-		} else {
-			return err
+
+			log.Warn("could not find %v, but found %v, using that instead", path, path2)
+			path = path2
 		}
 	}
 	defer f.Close()
@@ -84,7 +84,7 @@ func read(path string, c *Config) error {
 		case "parents":
 			for _, i := range d {
 				log.Infoln("reading config:", i)
-				err = read(i, c)
+				err = read(i, path, c)
 				c.Parents = append(c.Parents, i)
 				if err != nil {
 					return err

--- a/src/vmconfig/vmconfig.go
+++ b/src/vmconfig/vmconfig.go
@@ -96,6 +96,12 @@ func read(path, prev string, c *Config) error {
 			// trim any trailing "/"
 			for i, j := range d {
 				d[i] = strings.TrimRight(j, "/")
+
+				// if not absolute, the overlay should be a relative path from
+				// the directory containing this config
+				if !filepath.IsAbs(d[i]) {
+					d[i] = filepath.Join(filepath.Dir(path), d[i])
+				}
 			}
 			c.Overlays = append(c.Overlays, d...)
 		case "postbuild":


### PR DESCRIPTION
vmconfig had magic to find parent config files based on the root config.
Improve the magic so that instead of looking in the dir of the root
config, vmconfig looks in the dir of the current config.

Change the overlay directories to be a path relative to the config file
so that we can run vmbetter from anywhere.

Update all the configs to use this paradigm.