### PR TITLE
minimega: add container-specific network functions

### DIFF
--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -815,7 +815,7 @@ func cliVMNetMod(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 			return true, vm.NetworkDisconnect(pos)
 		}
 
-		return true, vm.NetworkConnect(pos, bridge, vlan)
+		return true, vm.NetworkConnect(pos, vlan, bridge)
 	})
 }
 


### PR DESCRIPTION
Containers only have interfaces when they are running so check the state
before trying to interact with OVS. Otherwise, update the NetConfig and
return.