### PR TITLE
minimega: prepend namespace to read commands

### DIFF
--- a/tests/read_namespace
+++ b/tests/read_namespace
@@ -1,0 +1,7 @@
+.columns namespace,active namespace
+namespace foo
+.columns namespace,active namespace
+namespace bar
+.columns namespace,active namespace
+namespace foo namespace
+.columns namespace,active namespace

--- a/tests/read_namespace.want
+++ b/tests/read_namespace.want
@@ -1,0 +1,24 @@
+## .columns namespace,active namespace
+namespace | active
+minimega  | true
+## namespace foo
+## .columns namespace,active namespace
+namespace | active
+foo       | true
+minimega  | false
+## namespace bar
+## .columns namespace,active namespace
+namespace | active
+bar       | true
+foo       | false
+minimega  | false
+## namespace foo namespace
+namespace | vlans    | active
+bar       |          | false
+foo       |          | true
+minimega  | 101-4096 | false
+## .columns namespace,active namespace
+namespace | active
+bar       | true
+foo       | false
+minimega  | false


### PR DESCRIPTION
Prepend the original namespace to read commands so that if another
script/user changes the namespace, we still run the commands in the
intended namespace.

Fixes #968