### PR TITLE
minimega/miniclient: add -namespace flag

### DIFF
--- a/src/miniclient/client.go
+++ b/src/miniclient/client.go
@@ -256,7 +256,7 @@ func (mm *Conn) Error() error {
 }
 
 // Attach creates a CLI interface to the dialed minimega instance
-func (mm *Conn) Attach() {
+func (mm *Conn) Attach(namespace string) {
 	fmt.Println("CAUTION: calling 'quit' will cause the minimega daemon to exit")
 	fmt.Println("use 'disconnect' or ^d to exit just the minimega command line")
 	fmt.Println()
@@ -269,6 +269,10 @@ func (mm *Conn) Attach() {
 	input.SetCompleter(mm.Suggest)
 
 	prompt := fmt.Sprintf("minimega:%v$ ", mm.url)
+
+	if namespace != "" {
+		prompt = fmt.Sprintf("minimega:%v[%v]$ ", mm.url, namespace)
+	}
 
 	var quit bool
 	for {
@@ -300,6 +304,10 @@ func (mm *Conn) Attach() {
 		}
 
 		quit = false
+
+		if namespace != "" {
+			line = fmt.Sprintf("namespace %q %v", namespace, line)
+		}
 
 		mm.RunAndPrint(line, true)
 

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -36,7 +36,6 @@ const (
 
 var (
 	f_base       = flag.String("base", BASE_PATH, "base path for minimega data")
-	f_e          = flag.Bool("e", false, "execute command on running minimega")
 	f_degree     = flag.Uint("degree", 0, "meshage starting degree")
 	f_msaTimeout = flag.Uint("msa", 10, "meshage MSA timeout")
 	f_port       = flag.Int("port", 9000, "meshage port to listen on")
@@ -45,11 +44,14 @@ var (
 	f_version    = flag.Bool("version", false, "print the version and copyright notices")
 	f_context    = flag.String("context", "minimega", "meshage context for discovery")
 	f_iomBase    = flag.String("filepath", IOM_PATH, "directory to serve files from")
-	f_attach     = flag.Bool("attach", false, "attach the minimega command line to a running instance of minimega")
 	f_cli        = flag.Bool("cli", false, "validate and print the minimega cli, in JSON, to stdout and exit")
 	f_panic      = flag.Bool("panic", false, "panic on quit, producing stack traces for debugging")
 	f_cgroup     = flag.String("cgroup", "/sys/fs/cgroup", "path to cgroup mount")
 	f_pipe       = flag.String("pipe", "", "read/write to or from a named pipe")
+
+	f_e         = flag.Bool("e", false, "execute command on running minimega")
+	f_attach    = flag.Bool("attach", false, "attach the minimega command line to a running instance of minimega")
+	f_namespace = flag.String("namespace", "", "prepend namespace to all -attach and -e commands")
 
 	hostname string
 	reserved = []string{Wildcard}
@@ -148,17 +150,22 @@ func main() {
 		mm.Pager = minipager.DefaultPager
 
 		if *f_e {
-			a := flag.Args()
-			log.Debugln("got args:", a)
+			parts := []string{}
+			if *f_namespace != "" {
+				parts = append(parts, "namespace", quoteIfSpace(*f_namespace))
+			}
 
-			// TODO: Need to escape?
-			cmd := strings.Join(a, " ")
+			for _, arg := range flag.Args() {
+				parts = append(parts, quoteIfSpace(arg))
+			}
+
+			cmd := strings.Join(parts, " ")
 			log.Infoln("got command: `%v`", cmd)
 
 			mm.RunAndPrint(cmd, false)
 		} else {
 			attached = mm
-			mm.Attach()
+			mm.Attach(*f_namespace)
 		}
 
 		return

--- a/src/minimega/misc.go
+++ b/src/minimega/misc.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -181,6 +182,14 @@ func unescapeString(input []string) string {
 	}
 	log.Debug("unescapeString generated: %v", ret)
 	return strings.TrimSpace(ret)
+}
+
+func quoteIfSpace(s string) string {
+	if strings.IndexFunc(s, unicode.IsSpace) > -1 {
+		return strconv.Quote(s)
+	}
+
+	return s
 }
 
 // convert a src ppm image to a dst png image, resizing to a largest dimension

--- a/src/minimega/netconfig.go
+++ b/src/minimega/netconfig.go
@@ -11,9 +11,7 @@ import (
 	log "minilog"
 	"net"
 	"sort"
-	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/google/gopacket/macs"
 )
@@ -153,27 +151,19 @@ func ParseNetConfig(spec string, nics map[string]bool) (*NetConfig, error) {
 func (c NetConfig) String() string {
 	parts := []string{}
 
-	prep := func(s string) string {
-		if strings.IndexFunc(s, unicode.IsSpace) > -1 {
-			return strconv.Quote(s)
-		}
-
-		return s
-	}
-
 	if c.Bridge != "" && c.Bridge != DefaultBridge {
-		parts = append(parts, prep(c.Bridge))
+		parts = append(parts, quoteIfSpace(c.Bridge))
 	}
 
-	parts = append(parts, prep(c.Alias))
+	parts = append(parts, quoteIfSpace(c.Alias))
 
 	if c.MAC != "" {
-		// shouldn't need to prep MAC since it is a valid MAC
+		// shouldn't need to quote MAC since it is a valid MAC
 		parts = append(parts, c.MAC)
 	}
 
 	if c.Driver != "" && c.Driver != DefaultKVMDriver {
-		parts = append(parts, prep(c.Driver))
+		parts = append(parts, quoteIfSpace(c.Driver))
 	}
 
 	return strings.Join(parts, ",")


### PR DESCRIPTION
Prepends the specified namespace to all -e and -attach commands. Because
of how it's implemented, it prevents the -e or -attach command from
changing the active namespace for more than the current command. Example
usage:

        root# bin/minimega -namespace foo -e namespace
        namespace | vlans    | active
        foo       |          | true
        minimega  | 101-4096 | false
        root# bin/minimega -e namespace
        namespace | vlans    | active
        foo       |          | false
        minimega  | 101-4096 | true

Also changes how we build commands from args to avoid errors when args
have spaces.

Fixes #970