### PR TITLE
minimega: fix vnc with namespaces

### DIFF
--- a/src/minimega/vnc_cli.go
+++ b/src/minimega/vnc_cli.go
@@ -61,7 +61,7 @@ below.
 			"vnc <getstep,> <vm name>",
 			"vnc <inject,> <vm name> <cmd>",
 		},
-		Call:    wrapBroadcastCLI(cliVNCPlay),
+		Call:    wrapVMTargetCLI(cliVNCPlay),
 		Suggest: wrapVMSuggest(VM_ANY_STATE, false),
 	},
 	{

--- a/src/minimega/vnc_cli.go
+++ b/src/minimega/vnc_cli.go
@@ -20,12 +20,14 @@ selected VM. Can also record the framebuffer for the specified VM so that a
 user can watch a video of interactions with the VM.
 
 If record is selected, a file will be created containing a record of mouse
-and keyboard actions by the user or of the framebuffer for the VM.`,
+and keyboard actions by the user or of the framebuffer for the VM.
+
+Note: recordings are written to the host where the VM is running.`,
 		Patterns: []string{
 			"vnc <record,> <kb,fb> <vm name> <filename>",
 			"vnc <stop,> <kb,fb> <vm name>",
 		},
-		Call:    wrapSimpleCLI(cliVNCRecord),
+		Call:    wrapVMTargetCLI(cliVNCRecord),
 		Suggest: wrapVMSuggest(VM_ANY_STATE, false),
 	},
 	{


### PR DESCRIPTION
Use `wrapVMTargetCLI` to make `vnc` work better with namespaces.