### PR TITLE
minimega: add `tar:` prefix

### DIFF
--- a/src/minimega/external.go
+++ b/src/minimega/external.go
@@ -42,6 +42,7 @@ var externalDependencies = map[string]bool{
 	"blockdev":  true, // used in disk.go
 	"ovs-vsctl": true, // used in external.go
 	"taskset":   true, // used in optimize.go
+	"tar":       true, // used in cli.go
 }
 
 func init() {


### PR DESCRIPTION
Fetches and untars tarballs via meshage. Current only untars if there is
a single top-level directory. It untars to the same directory that
contains the tarball... we probably don't want that when the tarball is
in the iomBase. Maybe it would be better to always untar to
/tmp/minimega/???.

Thoughts? @djfritz 