### PR TITLE
igor: change time limits

### DIFF
--- a/src/igor/config.go
+++ b/src/igor/config.go
@@ -62,6 +62,11 @@ type Config struct {
 	NodeLimit int
 	TimeLimit int
 
+	// ExtendWithin is the number of minutes before the end of a reservation
+	// that it can be extended. For example, 24*60 would mean that the
+	// reservation can be extended within 24 hours of its expiration.
+	ExtendWithin int
+
 	// ConcurrencyLimit is the maximum number of parallel commands igor
 	// executes for cobbler and power management.
 	ConcurrencyLimit uint

--- a/src/igor/extend.go
+++ b/src/igor/extend.go
@@ -72,9 +72,18 @@ func runExtend(cmd *Command, args []string) {
 		}
 
 		// Make sure the reservation doesn't exceed any limits
-		if user.Username != "root" && igorConfig.TimeLimit > 0 {
-			if float64(duration)+r.Duration > float64(igorConfig.TimeLimit) {
-				log.Fatal("Only root can extend a reservation longer than %v minutes. The maximum allowable time you may extend is %v minutes.", igorConfig.TimeLimit, float64(igorConfig.TimeLimit)-r.Duration)
+		if user.Username != "root" {
+			if err := checkTimeLimit(len(r.Hosts), duration); err != nil {
+				log.Fatalln(err)
+			}
+		}
+
+		// Make sure that the user is extending a reservation that is near its
+		// completion based on the ExtendWithin config.
+		if igorConfig.ExtendWithin > 0 {
+			remaining := time.Unix(r.EndTime, 0).Sub(time.Now())
+			if remaining.Minutes() > igorConfig.ExtendWithin {
+				log.Fatal("reservations can only be extended if they are within %v minutes of ending", igorConfig.ExtendWithin)
 			}
 		}
 

--- a/src/igor/extend.go
+++ b/src/igor/extend.go
@@ -82,7 +82,7 @@ func runExtend(cmd *Command, args []string) {
 		// completion based on the ExtendWithin config.
 		if igorConfig.ExtendWithin > 0 {
 			remaining := time.Unix(r.EndTime, 0).Sub(time.Now())
-			if remaining.Minutes() > igorConfig.ExtendWithin {
+			if int(remaining.Minutes()) > igorConfig.ExtendWithin {
 				log.Fatal("reservations can only be extended if they are within %v minutes of ending", igorConfig.ExtendWithin)
 			}
 		}

--- a/src/igor/schedule.go
+++ b/src/igor/schedule.go
@@ -1,8 +1,13 @@
+// Copyright (2013) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
 package main
 
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	log "minilog"
 	"net"
@@ -24,6 +29,26 @@ func checkValidNodeRange(nodes []string) bool {
 		return true
 	}
 	return !(indexes[len(indexes)-1] > igorConfig.End-1 || indexes[0] < igorConfig.Start-1)
+}
+
+func checkTimeLimit(nodes, duration int) error {
+	// no time limit in the config
+	if igorConfig.TimeLimit <= 0 {
+		return nil
+	}
+
+	max := igorConfig.TimeLimit
+	if nodes > 1 {
+		// compute the max reservation length for this many nodes, rounding up
+		// to the nearest minute.
+		max = int(float64(max)/math.Log2(float64(nodes)) + 0.5)
+	}
+
+	if duration > max {
+		return fmt.Errorf("max allowable duration for %v nodes is %v minutes", nodes, max)
+	}
+
+	return nil
 }
 
 // Returns the node numbers within the given array of nodes of all contiguous sets of '0' entries

--- a/src/igor/schedule_test.go
+++ b/src/igor/schedule_test.go
@@ -1,0 +1,39 @@
+// Copyright (2013) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import "testing"
+
+func TestCheckTimeLimit(t *testing.T) {
+	old := igorConfig.TimeLimit
+	defer func() {
+		igorConfig.TimeLimit = old
+	}()
+
+	igorConfig.TimeLimit = 0
+	if err := checkTimeLimit(100, 100); err != nil {
+		t.Errorf("err != nil: %v", err)
+	}
+
+	igorConfig.TimeLimit = 10
+	if err := checkTimeLimit(1, 10); err != nil {
+		t.Errorf("err != nil: %v", err)
+	}
+
+	igorConfig.TimeLimit = 100
+	if err := checkTimeLimit(10, 10); err != nil {
+		t.Errorf("err != nil: %v", err)
+	}
+
+	igorConfig.TimeLimit = 10
+	if err := checkTimeLimit(10, 10); err == nil {
+		t.Errorf("err == nil: %v", err)
+	}
+
+	igorConfig.TimeLimit = 10
+	if err := checkTimeLimit(100, 10); err == nil {
+		t.Errorf("err == nil: %v", err)
+	}
+}

--- a/src/igor/sub.go
+++ b/src/igor/sub.go
@@ -202,7 +202,13 @@ func runSub(cmd *Command, args []string) {
 		}
 	}
 	if user.Username != "root" {
-		if err := checkTimeLimit(len(nodes), duration); err != nil {
+		// nodes is only set if using subW
+		n := len(nodes)
+		if subN > 0 {
+			// must be using subN
+			n = subN
+		}
+		if err := checkTimeLimit(n, duration); err != nil {
 			log.Fatalln(err)
 		}
 	}

--- a/src/igor/sub.go
+++ b/src/igor/sub.go
@@ -201,9 +201,9 @@ func runSub(cmd *Command, args []string) {
 			log.Fatal("Only root can make a reservation of more than %v nodes", igorConfig.NodeLimit)
 		}
 	}
-	if user.Username != "root" && igorConfig.TimeLimit > 0 {
-		if duration > igorConfig.TimeLimit {
-			log.Fatal("Only root can make a reservation longer than %v minutes", igorConfig.TimeLimit)
+	if user.Username != "root" {
+		if err := checkTimeLimit(len(nodes), duration); err != nil {
+			log.Fatalln(err)
 		}
 	}
 


### PR DESCRIPTION
Time limits are now based on the number of nodes (well log of the number
of nodes). Extensions can be made as long as the reservation is near the
end (config-defined) and can be performed indefinitely.