### PR TITLE
miniplumber: Added "message count" column to output from 'pipe' command.

### DIFF
--- a/src/minimega/plumber.go
+++ b/src/minimega/plumber.go
@@ -188,7 +188,7 @@ func cliPipeBroadcast(ns *Namespace, c *minicli.Command, resp *minicli.Response)
 		}
 	} else {
 		// get info on all named pipes
-		resp.Header = []string{"name", "mode", "readers", "writers", "via", "last message"}
+		resp.Header = []string{"name", "mode", "readers", "writers", "via", "last message", "message count"}
 		resp.Tabular = [][]string{}
 
 		for _, v := range plumber.Pipes() {
@@ -199,7 +199,7 @@ func cliPipeBroadcast(ns *Namespace, c *minicli.Command, resp *minicli.Response)
 				}
 				name = strings.Replace(name, fmt.Sprintf("%v//", ns), "", -1)
 			}
-			resp.Tabular = append(resp.Tabular, []string{name, v.Mode(), fmt.Sprintf("%v", v.NumReaders()), fmt.Sprintf("%v", v.NumWriters()), v.GetVia(), strings.TrimSpace(v.Last())})
+			resp.Tabular = append(resp.Tabular, []string{name, v.Mode(), fmt.Sprintf("%v", v.NumReaders()), fmt.Sprintf("%v", v.NumWriters()), v.GetVia(), strings.TrimSpace(v.Last()), fmt.Sprintf("%v", v.NumMessages())})
 		}
 	}
 

--- a/src/miniplumber/miniplumber.go
+++ b/src/miniplumber/miniplumber.go
@@ -74,6 +74,7 @@ type Pipe struct {
 	viaCommand    []string
 	viaHost       string
 	readerCache   []int64
+	numMessages   int64
 }
 
 type Reader struct {
@@ -966,6 +967,13 @@ func (p *Pipe) GetVia() string {
 	return strings.Join(p.viaCommand, " ")
 }
 
+func (p *Pipe) NumMessages() int64 {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return p.numMessages
+}
+
 // pipe lock is already held
 func (p *Pipe) via(value string) (string, error) {
 	if len(p.viaCommand) == 0 {
@@ -1040,6 +1048,9 @@ func (p *Pipe) write(value string, r int64) {
 			}
 		}
 	}
+
+	// tally the messages
+	p.numMessages += 1
 }
 
 // Return a slice of strings, split on whitespace, not unlike strings.Fields(),


### PR DESCRIPTION
Counts the total number of messages received on each pipe.