### PR TITLE
minicli/minimega: fix read when there are comments

### DIFF
--- a/src/minicli/command.go
+++ b/src/minicli/command.go
@@ -29,10 +29,10 @@ type Command struct {
 	// not. Must be set before the Command is executed.
 	Preprocess bool
 
-	// Set when the command is intentionally a NoOp (the original string
+	// Set when the command is intentionally a No-op (the original string
 	// contains just a comment). This was added to ensure that lines containing
 	// only a comment are recorded in the history.
-	noOp bool
+	Nop bool
 
 	// Source allows developers to keep track of where the command originated
 	// from. Setting and using this is entirely up to developers using minicli.

--- a/src/minicli/minicli.go
+++ b/src/minicli/minicli.go
@@ -142,7 +142,7 @@ func ProcessString(input string, record bool) (<-chan Responses, error) {
 
 // Process a prepopulated Command
 func ProcessCommand(c *Command) <-chan Responses {
-	if !c.noOp && c.Call == nil {
+	if !c.Nop && c.Call == nil {
 		log.Fatal("command %v has no callback!", c)
 	}
 
@@ -160,7 +160,7 @@ func ProcessCommand(c *Command) <-chan Responses {
 			}
 		}
 
-		if !c.noOp {
+		if !c.Nop {
 			c.Call(c, respChan)
 		}
 
@@ -215,7 +215,7 @@ func Compile(input string) (*Command, error) {
 	}
 
 	if strings.HasPrefix(input, CommentLeader) {
-		cmd := &Command{Original: input, noOp: true}
+		cmd := &Command{Original: input, Nop: true}
 		return cmd, nil
 	}
 


### PR DESCRIPTION
Fix bug where we would return already in namespace errors if there were
comments in the read file.