### PR TITLE
miniccc: move code out of init

### DIFF
--- a/src/miniccc/client.go
+++ b/src/miniccc/client.go
@@ -41,8 +41,7 @@ type Process struct {
 	process *os.Process
 }
 
-// init client fields
-func init() {
+func NewClient() {
 	client.UUID = getUUID()
 	client.Arch = runtime.GOARCH
 	client.OS = runtime.GOOS

--- a/src/miniccc/main.go
+++ b/src/miniccc/main.go
@@ -59,6 +59,9 @@ func main() {
 
 	log.Init()
 
+	// init client
+	NewClient()
+
 	if *f_pipe != "" {
 		pipeHandler(*f_pipe)
 		return


### PR DESCRIPTION
So that we can run -h without a uuid.