### PR TITLE
minimega/ron: cc filter using vm info columns

### DIFF
--- a/src/minimega/cc_cli.go
+++ b/src/minimega/cc_cli.go
@@ -71,6 +71,13 @@ treated as tags:
 
 	cc filter foo=bar
 
+Users can also filter by any column in "vm info" using a similar syntax:
+
+	cc filter name=server
+	cc filter vlan=DMZ
+
+"vm info" columns take precedance over tags when both define the same key.
+
 "cc mount" allows direct access to a guest's filesystem over the command and
 control connection. When given a VM uuid or name and a path, the VM's
 filesystem is mounted to the local machine at the provided path. "cc mount"
@@ -295,7 +302,7 @@ func cliCCFilter(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 				parts = parts[1:]
 				fallthrough
 			default:
-				// Implicit filter on a tag
+				// Implicit filter on a tag or `vm info` field
 				if filter.Tags == nil {
 					filter.Tags = make(map[string]string)
 				}

--- a/src/ron/ron.go
+++ b/src/ron/ron.go
@@ -28,6 +28,7 @@ type VM interface {
 	SetCCActive(bool)
 	GetTags() map[string]string
 	SetTag(string, string)
+	Info(string) (string, error)
 }
 
 func unmangle(uuid string) string {

--- a/src/ron/server.go
+++ b/src/ron/server.go
@@ -915,6 +915,13 @@ func (s *Server) route(m *Message) {
 				}
 				// update client's tags in case we're matching based on them
 				c.Tags = vm.GetTags()
+
+				// load the relevant info fields, overriding any tag values
+				for _, cmd := range m.Commands {
+					for k := range cmd.Filter.Tags {
+						c.Tags[k], _ = vm.Info(k)
+					}
+				}
 			}
 
 			// create a copy of the Message


### PR DESCRIPTION
Make it so that you can use any "vm info" column in "cc filter".

Needs testing.