### PR TITLE
ron/miniccc/minimega: improving reconnect

### DIFF
--- a/src/miniccc/main.go
+++ b/src/miniccc/main.go
@@ -8,6 +8,7 @@ import (
 	"encoding/gob"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	log "minilog"
 	"net"
@@ -156,6 +157,21 @@ func dial() error {
 			client.conn, err = net.Dial(*f_family, addr)
 		} else {
 			client.conn, err = dialSerial(*f_serial)
+		}
+
+		// write magic bytes
+		if err == nil {
+			_, err = io.WriteString(client.conn, "RON")
+		}
+
+		// read until we see the magic bytes back
+		var buf [3]byte
+		for err == nil && string(buf[:]) != "RON" {
+			// shift the buffer
+			buf[0] = buf[1]
+			buf[1] = buf[2]
+			// read the next byte
+			_, err = client.conn.Read(buf[2:])
 		}
 
 		if err == nil {

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -734,17 +734,26 @@ func (vm *KvmVM) launch() error {
 	return nil
 }
 
-func (vm *KvmVM) Connect(cc *ron.Server) error {
+func (vm *KvmVM) Connect(cc *ron.Server, reconnect bool) error {
 	if !vm.Backchannel {
 		return nil
 	}
 
-	cc.RegisterVM(vm)
+	if !reconnect {
+		cc.RegisterVM(vm)
+	}
 
-	// connect cc
-	ccPath := vm.path("cc")
+	return cc.DialSerial(vm.path("cc"))
+}
 
-	return cc.DialSerial(ccPath)
+func (vm *KvmVM) Disconnect(cc *ron.Server) error {
+	if !vm.Backchannel {
+		return nil
+	}
+
+	cc.UnregisterVM(vm)
+
+	return nil
 }
 
 func (vm *KvmVM) Hotplug(f, version, serial string) error {

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -70,7 +70,8 @@ type VM interface {
 
 	SetCCActive(bool)
 	HasCC() bool
-	Connect(*ron.Server) error
+	Connect(*ron.Server, bool) error
+	Disconnect(*ron.Server) error
 
 	UpdateNetworks()
 

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -122,9 +122,9 @@ allocate resources across the cluster.`,
 Kill one or more running virtual machines. See "vm start" for a full
 description of allowable targets.`,
 		Patterns: []string{
-			"vm kill <vm target>",
+			"vm <kill,> <vm target>",
 		},
-		Call:    wrapVMTargetCLI(cliVMKill),
+		Call:    wrapVMTargetCLI(cliVMApply),
 		Suggest: wrapVMSuggest(VM_ANY_STATE, true),
 	},
 	{ // vm start
@@ -156,9 +156,9 @@ Calling "vm start" on a specific list of VMs will cause them to be started if
 they are in the building, paused, quit, or error states. When used with the
 wildcard, only vms in the building or paused state will be started.`, Wildcard),
 		Patterns: []string{
-			"vm start <vm target>",
+			"vm <start,> <vm target>",
 		},
-		Call:    wrapVMTargetCLI(cliVMStart),
+		Call:    wrapVMTargetCLI(cliVMApply),
 		Suggest: wrapVMSuggest(^VM_RUNNING, true),
 	},
 	{ // vm stop
@@ -169,9 +169,9 @@ description of allowable targets.
 
 Calling stop will put VMs in a paused state. Use "vm start" to restart them.`,
 		Patterns: []string{
-			"vm stop <vm target>",
+			"vm <stop,> <vm target>",
 		},
-		Call:    wrapVMTargetCLI(cliVMStop),
+		Call:    wrapVMTargetCLI(cliVMApply),
 		Suggest: wrapVMSuggest(VM_RUNNING, true),
 	},
 	{ // vm flush
@@ -181,9 +181,9 @@ Discard information about VMs that have either quit or encountered an error.
 This will remove any VMs with a state of "quit" or "error" from vm info. Names
 of VMs that have been flushed may be reused.`,
 		Patterns: []string{
-			"vm flush",
+			"vm <flush,>",
 		},
-		Call: wrapBroadcastCLI(cliVMFlush),
+		Call: wrapBroadcastCLI(cliVMApply),
 	},
 	{ // vm hotplug
 		HelpShort: "add and remove USB drives",
@@ -437,37 +437,19 @@ func init() {
 	gob.Register(&ContainerVM{})
 }
 
-func cliVMStart(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	target := c.StringArgs["vm"]
+func cliVMApply(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	switch {
+	case c.BoolArgs["start"]:
+		return ns.VMs.Start(c.StringArgs["vm"], ns.ccServer)
+	case c.BoolArgs["stop"]:
+		return ns.VMs.Stop(c.StringArgs["vm"])
+	case c.BoolArgs["kill"]:
+		return ns.VMs.Kill(c.StringArgs["vm"])
+	case c.BoolArgs["flush"]:
+		return ns.VMs.Flush(ns.ccServer)
+	}
 
-	// For each VM, start it if it's in a startable state.
-	return ns.VMs.Apply(target, func(vm VM, wild bool) (bool, error) {
-		if wild && vm.GetState()&(VM_PAUSED|VM_BUILDING) != 0 {
-			// If wild, we only start VMs in the building or running state
-			return true, vm.Start()
-		} else if !wild && vm.GetState()&VM_RUNNING == 0 {
-			// If not wild, start VMs that aren't already running
-			return true, vm.Start()
-		}
-
-		return false, nil
-	})
-}
-
-func cliVMStop(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	target := c.StringArgs["vm"]
-
-	return ns.VMs.Apply(target, func(vm VM, _ bool) (bool, error) {
-		if vm.GetState()&VM_RUNNING != 0 {
-			return true, vm.Stop()
-		}
-
-		return false, nil
-	})
-}
-
-func cliVMKill(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	return makeErrSlice(ns.Kill(c.StringArgs["vm"]))
+	return unreachable()
 }
 
 func cliVMInfo(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
@@ -621,12 +603,6 @@ func cliVMLaunch(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 	}
 
 	return ns.Schedule()
-}
-
-func cliVMFlush(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	ns.Flush()
-
-	return nil
 }
 
 func cliVMQmp(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/src/ron/server.go
+++ b/src/ron/server.go
@@ -601,6 +601,24 @@ func (s *Server) serve(addr string, ln net.Listener) {
 // handshake performs a handshake with the client, returning the new client if
 // there were no errors.
 func (s *Server) handshake(conn net.Conn) (*client, error) {
+	// read until we see the magic bytes
+	var buf [3]byte
+	for string(buf[:]) != "RON" {
+		// shift the buffer
+		buf[0] = buf[1]
+		buf[1] = buf[2]
+		// read the next byte
+		_, err := conn.Read(buf[2:])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// write magic bytes back
+	if _, err := io.WriteString(conn, "RON"); err != nil {
+		return nil, err
+	}
+
 	c := &client{
 		conn:        conn,
 		enc:         gob.NewEncoder(conn),

--- a/src/ron/tunnel.go
+++ b/src/ron/tunnel.go
@@ -75,13 +75,9 @@ func Trunk(remote io.ReadCloser, uuid string, fn func(*Message) error) {
 
 			err = fn(m)
 		}
-
-		if err != nil && err != io.ErrClosedPipe {
-			log.Errorln(err)
-		}
 	}
 
-	if err != io.ErrClosedPipe {
+	if err != io.ErrClosedPipe && err != io.EOF {
 		log.Error("trunk failed for %v: %v", uuid, err)
 	}
 

--- a/tests/cc_reconnect
+++ b/tests/cc_reconnect
@@ -1,0 +1,29 @@
+# launch and start a container and kvm
+vm config filesystem $images/minicccfs
+vm config kernel $images/miniccc.kernel
+vm config initrd $images/miniccc.initrd
+vm launch container container
+vm launch kvm kvm
+vm start all
+
+# wait for cc to connect
+shell sleep 20
+cc
+
+# kill vms and make sure we're back to no clients
+vm kill all
+shell sleep 20
+cc
+
+# restart and see if they come back
+vm start kvm,container
+shell sleep 20
+cc
+
+# do again for good measure
+vm kill all
+shell sleep 20
+cc
+vm start kvm,container
+shell sleep 20
+cc

--- a/tests/cc_reconnect.want
+++ b/tests/cc_reconnect.want
@@ -1,0 +1,39 @@
+## # launch and start a container and kvm
+## vm config filesystem $images/minicccfs
+## vm config kernel $images/miniccc.kernel
+## vm config initrd $images/miniccc.initrd
+## vm launch container container
+## vm launch kvm kvm
+## vm start all
+
+## # wait for cc to connect
+## shell sleep 20
+## cc
+clients
+2
+
+## # kill vms and make sure we're back to no clients
+## vm kill all
+## shell sleep 20
+## cc
+clients
+0
+
+## # restart and see if they come back
+## vm start kvm,container
+## shell sleep 20
+## cc
+clients
+2
+
+## # do again for good measure
+## vm kill all
+## shell sleep 20
+## cc
+clients
+0
+## vm start kvm,container
+## shell sleep 20
+## cc
+clients
+2


### PR DESCRIPTION
Add synchronization bytes to hopefully allow ron and miniccc to reconnect. Write the magic bytes in both directions to flush both sides.

Add redial to the things we do when we start a VM.