### PR TITLE
Igor notify conf

### DIFF
--- a/src/igor/config.go
+++ b/src/igor/config.go
@@ -78,7 +78,7 @@ type Config struct {
 	// Domain for email address
 	Domain string
 
-	//Igor Notify Notice time (in hours) is the amount of time before reservation expires users are notified
+	//Igor Notify Notice time (in minutes) is the amount of time before reservation expires users are notified
 	ExpirationLeadTime int
 }
 

--- a/src/igor/config.go
+++ b/src/igor/config.go
@@ -77,6 +77,9 @@ type Config struct {
 
 	// Domain for email address
 	Domain string
+
+	//Igor Notify Notice time (in hours) is the amount of time before reservation expires users are notified
+	ExpirationLeadTime int
 }
 
 // Read in the configuration from the specified path.
@@ -90,5 +93,6 @@ func readConfig(path string) (c Config) {
 	if err != nil {
 		log.Fatal("Couldn't parse json: %v", err)
 	}
+
 	return
 }

--- a/src/igor/notify.go
+++ b/src/igor/notify.go
@@ -78,8 +78,8 @@ func runNotify(cmd *Command, args []string) {
 			lowerwindow = time.Duration(23)
 			upperwindow = time.Duration(24)
 		} else {
-			lowerwindow = time.Duration(igorConfig.ExpirationLeadTime - 1)
-			upperwindow = time.Duration(igorConfig.ExpirationLeadTime)
+			lowerwindow = time.Duration((igorConfig.ExpirationLeadTime / 60) - 1)
+			upperwindow = time.Duration(igorConfig.ExpirationLeadTime / 60)
 		}
 		if res.End.Sub(res.Start) >= 48*time.Hour && diff >= lowerwindow*time.Hour && diff < upperwindow*time.Hour {
 			if users[r.Owner] == nil {

--- a/src/igor/notify.go
+++ b/src/igor/notify.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	log "minilog"
 	"os/exec"
 	"text/template"
@@ -72,10 +73,21 @@ func runNotify(cmd *Command, args []string) {
 		// expiring reservations are longer than two days and expire in just
 		// over 24 hours.
 		diff = res.End.Sub(now)
-		if res.End.Sub(res.Start) >= 48*time.Hour && diff >= 23*time.Hour && diff < 24*time.Hour {
+		var lowerwindow, upperwindow time.Duration
+
+		if igorConfig.ExpirationLeadTime < 24 { //check if there is a leadtime configured if not assign default value
+			lowerwindow = time.Duration(23)
+			upperwindow = time.Duration(24)
+		} else {
+			lowerwindow = time.Duration(igorConfig.ExpirationLeadTime - 1)
+			upperwindow = time.Duration(igorConfig.ExpirationLeadTime)
+		}
+		if res.End.Sub(res.Start) >= 48*time.Hour && diff >= lowerwindow*time.Hour && diff < upperwindow*time.Hour {
 			if users[r.Owner] == nil {
 				users[r.Owner] = &Notification{}
 			}
+			fmt.Println(r.Owner)
+			fmt.Println(users[r.Owner].Expiring)
 			users[r.Owner].Expiring = append(users[r.Owner].Expiring, res)
 		}
 	}

--- a/src/igor/notify.go
+++ b/src/igor/notify.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	log "minilog"
 	"os/exec"
 	"text/template"
@@ -86,8 +85,6 @@ func runNotify(cmd *Command, args []string) {
 			if users[r.Owner] == nil {
 				users[r.Owner] = &Notification{}
 			}
-			fmt.Println(r.Owner)
-			fmt.Println(users[r.Owner].Expiring)
 			users[r.Owner].Expiring = append(users[r.Owner].Expiring, res)
 		}
 	}

--- a/src/igor/notify.go
+++ b/src/igor/notify.go
@@ -74,7 +74,7 @@ func runNotify(cmd *Command, args []string) {
 		diff = res.End.Sub(now)
 		var lowerwindow, upperwindow time.Duration
 
-		if igorConfig.ExpirationLeadTime < 24 { //check if there is a leadtime configured if not assign default value
+		if igorConfig.ExpirationLeadTime < 24*60 { //check if there is a leadtime configured if not assign default value
 			lowerwindow = time.Duration(23)
 			upperwindow = time.Duration(24)
 		} else {


### PR DESCRIPTION
Added a new field for the config file called expirationleadtime. It allows admins to set how much lead time in hours to notify users about pending reservation expiration . if no value is specified a default lead time of 24 hours is in effect