### PR TITLE
miniclient: add redial on temporary error

### DIFF
--- a/src/miniclient/client.go
+++ b/src/miniclient/client.go
@@ -78,7 +78,6 @@ func Dial(base string) (*Conn, error) {
 			time.Sleep(backoff)
 			backoff *= 2
 		} else {
-			log.Error("%#v", err)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Too many minimega -e's can cause minimega's listen queue to fill up and
start rejecting new miniclients. Add redial/backoff when we detect a
temporary error.