### PR TITLE
minitest: distributed tests for plumbing

### DIFF
--- a/src/minitest/main.go
+++ b/src/minitest/main.go
@@ -26,8 +26,8 @@ the U.S. Government retains certain rights in this software.`
 )
 
 var skippedExtensions = []string{
-	"got",
-	"want",
+	".got",
+	".want",
 }
 
 var (

--- a/tests/distributed/plumbing_basic
+++ b/tests/distributed/plumbing_basic
@@ -1,0 +1,19 @@
+###
+### Explicit pipelines (created through plumb/pipe)
+###
+
+# Set up a pipeline from foo->bar->baz->qux across mm1->mm2->mm3
+mesh send mm1 plumb foo "sed -u s/cc/mm1/" bar
+mesh send mm2 plumb bar "sed -u s/mm1/mm2/" baz
+mesh send mm3 plumb baz "sed -u s/mm2/mm3/" qux
+
+# Send a message through foo (created on mm1)
+mesh send mm1 pipe foo "hello from cc!"
+
+# Give the message time to go through the pipeline
+shell sleep 5
+
+.annotate true
+# Emit 'pipe' responses from all nodes
+mesh send all .columns name,readers,writers,count,previous pipe
+

--- a/tests/distributed/plumbing_basic.want
+++ b/tests/distributed/plumbing_basic.want
@@ -1,0 +1,26 @@
+## ###
+## ### Explicit pipelines (created through plumb/pipe)
+## ###
+
+## # Set up a pipeline from foo->bar->baz->qux across mm1->mm2->mm3
+## mesh send mm1 plumb foo "sed -u s/cc/mm1/" bar
+## mesh send mm2 plumb bar "sed -u s/mm1/mm2/" baz
+## mesh send mm3 plumb baz "sed -u s/mm2/mm3/" qux
+
+## # Send a message through foo (created on mm1)
+## mesh send mm1 pipe foo "hello from cc!"
+
+## # Give the message time to go through the pipeline
+## shell sleep 5
+
+## .annotate true
+## # Emit 'pipe' responses from all nodes
+## mesh send all .columns name,readers,writers,count,previous pipe
+host | name | readers | writers | count | previous
+mm1  | bar  | 0       | 1       | 1     | hello from mm1!
+mm1  | foo  | 1       | 0       | 1     | hello from cc!
+mm2  | bar  | 1       | 0       | 1     | hello from mm1!
+mm2  | baz  | 0       | 1       | 1     | hello from mm2!
+mm3  | baz  | 1       | 0       | 1     | hello from mm2!
+mm3  | qux  | 0       | 1       | 1     | hello from mm3!
+

--- a/tests/distributed/plumbing_miniccc
+++ b/tests/distributed/plumbing_miniccc
@@ -1,0 +1,36 @@
+###
+### Implicit pipelines (created through 'cc')
+###
+
+## Stand up two VMs, foo (on host mm1) and bar (on host mm2)
+vm config filesystem /root/uminicccfs
+vm config schedule mm1 
+vm config uuid 00000000-0000-0000-0000-000000000000
+vm config hostname foo
+vm launch container foo
+vm config schedule mm2
+vm config uuid 11111111-1111-1111-1111-111111111111
+vm config hostname bar
+vm launch container bar
+.annotate true .columns name vm info
+vm start foo
+vm start bar
+
+# Give sufficient build time
+shell sleep 10s
+
+# Set up a cat pipeline on bar from foopipe
+# TODO: Use pipe.out to test in-order delivery of meshage-based pipe communication
+cc filter hostname=bar
+cc background stdin=foopipe sh -c "cat > pipe.out"
+
+shell sleep 5s
+
+# Send a message from foo through foopipe
+cc filter hostname=foo
+cc exec stdout=foopipe seq 1000
+
+shell sleep 60s
+
+# Verify that all messages were received on bar through foopipe
+pipe

--- a/tests/distributed/plumbing_miniccc.want
+++ b/tests/distributed/plumbing_miniccc.want
@@ -1,0 +1,42 @@
+## ###
+## ### Implicit pipelines (created through 'cc')
+## ###
+
+## ## Stand up two VMs, foo (on host mm1) and bar (on host mm2)
+## vm config filesystem /root/uminicccfs
+## vm config schedule mm1 
+## vm config uuid 00000000-0000-0000-0000-000000000000
+## vm config hostname foo
+## vm launch container foo
+## vm config schedule mm2
+## vm config uuid 11111111-1111-1111-1111-111111111111
+## vm config hostname bar
+## vm launch container bar
+## .annotate true .columns name vm info
+host | name
+mm1  | foo
+mm2  | bar
+## vm start foo
+## vm start bar
+
+## # Give sufficient build time
+## shell sleep 10s
+
+## # Set up a cat pipeline on bar from foopipe
+## # TODO: Use pipe.out to test in-order delivery of meshage-based pipe communication
+## cc filter hostname=bar
+## cc background stdin=foopipe sh -c "cat > pipe.out"
+
+## shell sleep 5s
+
+## # Send a message from foo through foopipe
+## cc filter hostname=foo
+## cc exec stdout=foopipe seq 1000
+
+## shell sleep 60s
+
+## # Verify that all messages were received on bar through foopipe
+## pipe
+name    | mode | readers | writers | count | via | previous
+foopipe | all  | 0       | 0       | 1000  |     | 1000
+foopipe | all  | 1       | 0       | 1000  |     | 1000

--- a/tests/distributed/prolog
+++ b/tests/distributed/prolog
@@ -1,4 +1,5 @@
 .annotate false
 clear history
+clear cc responses
 
 namespace distributed


### PR DESCRIPTION
Added distributed tests for VM-to-VM communications between hosts over miniplumber pipelines. Diagrammatically, this looks like:
 
               vm1 -> mm1 -> mm2 -> vm2
 
where the vm <-> mm communications are through cc and the mm->mm communications are through meshage.