### PR TITLE
minimega: add vm->vm tap mirror

### DIFF
--- a/src/bridge/mirror.go
+++ b/src/bridge/mirror.go
@@ -22,6 +22,9 @@ func (b *Bridge) CreateMirror(src, dst string) error {
 
 func (b *Bridge) createMirror(src, dst string) error {
 	log.Info("adding mirror on bridge: %v:%v to %v", b.Name, src, dst)
+	if src == dst {
+		return errors.New("cannot mirror tap to itself")
+	}
 
 	// check source tap exists, if it is set
 	if _, ok := b.taps[src]; src != "" && !ok {

--- a/src/minimega/bridge.go
+++ b/src/minimega/bridge.go
@@ -224,7 +224,7 @@ func mirrorDeleteVM(ns *Namespace, svm, si string) error {
 	}
 
 	// delete all mirrors for all interfaces
-	if si == "" {
+	if si == Wildcard {
 		networks := vm.GetNetworks()
 
 		for _, nic := range networks {

--- a/src/minimega/bridge_cli.go
+++ b/src/minimega/bridge_cli.go
@@ -102,7 +102,7 @@ mirrors. "clear tap" also deletes all mirrors.`,
 		Patterns: []string{
 			"clear tap",
 			"clear tap <mirror,> [name]",
-			"clear tap <mirror,> <vm name> [interface index]",
+			"clear tap <mirror,> <vm name> <interface index or all>",
 		},
 		Call: wrapSimpleCLI(cliTapClear),
 	},

--- a/src/minimega/capture.go
+++ b/src/minimega/capture.go
@@ -113,14 +113,13 @@ func (c *netflowCapture) Stop() error {
 // CaptureVM starts a new capture for a specified interface on a VM, writing
 // the packets to the specified file in PCAP format.
 func (c *captures) CaptureVM(vm VM, iface int, fname string) error {
-	networks := vm.GetNetworks()
-
-	if len(networks) <= iface {
-		return fmt.Errorf("no such interface %v", iface)
+	nic, err := vm.GetNetwork(iface)
+	if err != nil {
+		return err
 	}
 
-	bridge := networks[iface].Bridge
-	tap := networks[iface].Tap
+	bridge := nic.Bridge
+	tap := nic.Tap
 
 	br, err := getBridge(bridge)
 	if err != nil {

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -33,12 +33,11 @@ const (
 )
 
 type VM interface {
-	GetID() int               // GetID returns the VM's per-host unique ID
-	GetPID() int              // GetPID returns the VM's PID
-	GetName() string          // GetName returns the VM's per-host unique name
-	GetNamespace() string     // GetNamespace returns the VM's namespace name
-	GetNetworks() []NetConfig // GetNetworks returns an ordered, deep copy of the NetConfigs associated with the vm.
-	GetHost() string          // GetHost returns the hostname that the VM is running on
+	GetID() int           // GetID returns the VM's per-host unique ID
+	GetPID() int          // GetPID returns the VM's PID
+	GetName() string      // GetName returns the VM's per-host unique name
+	GetNamespace() string // GetNamespace returns the VM's namespace name
+	GetHost() string      // GetHost returns the hostname that the VM is running on
 	GetState() VMState
 	GetLaunchTime() time.Time // GetLaunchTime returns the time when the VM was launched
 	GetType() VMType
@@ -47,6 +46,9 @@ type VM interface {
 	GetCPUs() uint64
 	GetMem() uint64
 	GetCoschedule() int
+
+	GetNetwork(i int) (NetConfig, error) // GetNetwork returns the ith NetConfigs associated with the vm.
+	GetNetworks() []NetConfig            // GetNetworks returns an ordered, deep copy of the NetConfigs associated with the vm.
 
 	// Lifecycle functions
 	Launch() error
@@ -286,6 +288,17 @@ func (vm *BaseVM) GetName() string {
 
 func (vm *BaseVM) GetNamespace() string {
 	return vm.Namespace
+}
+
+func (vm *BaseVM) GetNetwork(i int) (NetConfig, error) {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	if len(vm.Networks) < i {
+		return NetConfig{}, fmt.Errorf("no such interface %v for %v", i, vm.Name)
+	}
+
+	return vm.Networks[i], nil
 }
 
 func (vm *BaseVM) GetNetworks() []NetConfig {

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -294,7 +294,7 @@ func (vm *BaseVM) GetNetwork(i int) (NetConfig, error) {
 	vm.lock.Lock()
 	defer vm.lock.Unlock()
 
-	if len(vm.Networks) < i {
+	if len(vm.Networks) <= i {
 		return NetConfig{}, fmt.Errorf("no such interface %v for %v", i, vm.Name)
 	}
 

--- a/tests/capture.want
+++ b/tests/capture.want
@@ -55,7 +55,7 @@ mega_bridge | pcap | car:0     |      |          | /dev/null
 
 ## # Try some things that shouldn't work
 ## namespace foo capture pcap vm car 1 /dev/null
-E: no such interface 1
+E: no such interface 1 for car
 ## namespace foo capture pcap vm bar 0 /dev/null
 E: vm not found: bar
 ## namespace foo capture pcap delete vm bar

--- a/tests/distributed/tap_mirror_vm
+++ b/tests/distributed/tap_mirror_vm
@@ -1,0 +1,24 @@
+# three VMs, two of which are on the same node
+vm config filesystem /root/uminicccfs
+vm config net LAN
+vm config schedule mm1
+vm launch container a
+vm config schedule mm1
+vm launch container b
+vm config schedule mm2
+vm launch container c
+vm start all
+
+.annotate true .column name vm info
+
+# should not work
+tap mirror a 0 c 0
+
+# should work
+tap mirror a 0 b 0
+
+# clear by destination
+clear tap mirror b 0
+
+# already cleared, should have error
+clear tap mirror b 0

--- a/tests/distributed/tap_mirror_vm.want
+++ b/tests/distributed/tap_mirror_vm.want
@@ -1,0 +1,31 @@
+## # three VMs, two of which are on the same node
+## vm config filesystem /root/uminicccfs
+## vm config net LAN
+## vm config schedule mm1
+## vm launch container a
+## vm config schedule mm1
+## vm launch container b
+## vm config schedule mm2
+## vm launch container c
+## vm start all
+
+## .annotate true .column name vm info
+host | name
+mm1  | a
+mm1  | b
+mm2  | c
+
+## # should not work
+## tap mirror a 0 c 0
+E: vms are not colocated or invalid vm name: a
+E: vms are not colocated or invalid vm name: c
+
+## # should work
+## tap mirror a 0 b 0
+
+## # clear by destination
+## clear tap mirror b 0
+
+## # already cleared, should have error
+## clear tap mirror b 0
+E: not a valid mirror

--- a/tests/tap_mirror_vm
+++ b/tests/tap_mirror_vm
@@ -1,0 +1,16 @@
+vm config net LAN
+vm launch kvm a,b
+
+# do some obviously wrong things
+tap mirror a 1 b 0
+tap mirror a 0 b 1
+tap mirror a 0 c 0
+
+# should work
+tap mirror a 0 b 0
+
+# clear by destination
+clear tap mirror b 0
+
+# already cleared, should have error
+clear tap mirror b 0

--- a/tests/tap_mirror_vm.want
+++ b/tests/tap_mirror_vm.want
@@ -1,0 +1,20 @@
+## vm config net LAN
+## vm launch kvm a,b
+
+## # do some obviously wrong things
+## tap mirror a 1 b 0
+E: no such interface 1 for a
+## tap mirror a 0 b 1
+E: no such interface 1 for b
+## tap mirror a 0 c 0
+E: vms are not colocated or invalid vm name: c
+
+## # should work
+## tap mirror a 0 b 0
+
+## # clear by destination
+## clear tap mirror b 0
+
+## # already cleared, should have error
+## clear tap mirror b 0
+E: not a valid mirror


### PR DESCRIPTION
Allows you to specify tap mirrors by VM names and interface indices.
Needs testing.

Updates #1217