### PR TITLE
minimega: add `vm config colocate`

### DIFF
--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -164,7 +164,7 @@ type KVMConfig struct {
 	QemuOverride QemuOverrides
 
 	// hugepagesMountPath is copied from ns.hugepagesMountPath when the VM is
-	// launched. Not set by `vm config` APIs.
+	// launched. Not set by "vm config" APIs.
 	hugepagesMountPath string
 }
 

--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -344,6 +344,15 @@ func (n *Namespace) Schedule() error {
 		}
 	}
 
+	// resolve any "colocated" VMs for VMs that are already launched
+	for _, vm := range globalVMs(n) {
+		for _, q := range n.queue {
+			if q.Colocate == vm.GetName() {
+				q.Schedule = vm.GetHost()
+			}
+		}
+	}
+
 	// Create the host -> VMs assignment
 	assignment, err := schedule(n.queue, hostStats, hostSorter)
 	if err != nil {

--- a/src/minimega/scheduler.go
+++ b/src/minimega/scheduler.go
@@ -5,22 +5,204 @@ import (
 	"fmt"
 	log "minilog"
 	"sort"
+	"strings"
 )
+
+type Scheduler struct {
+	queue      []*QueuedVMs
+	hosts      []*HostStats
+	hostSortBy // embed
+
+	// output from scheduler map of queued vms, indexed by host that they
+	// should be scheduled on
+	res map[string][]*QueuedVMs
+
+	// colocated are VMs that need to be scheduled with another VM, indexed by
+	// the name of the VM to be colocated with
+	colocated map[string][]*QueuedVMs
+}
 
 // hostSortBy defines the ordering of hosts based on some notion of load
 type hostSortBy func(h1, h2 *HostStats) bool
 
+// hostSorter acts a minheap so that the least-loaded host is in position 0.
 type hostSorter struct {
 	hosts []*HostStats
 	by    hostSortBy
 }
 
-type ByPriority []*QueuedVMs
-
 var hostSortByFns = map[string]hostSortBy{
 	"netcommit": networkCommit,
 	"cpucommit": cpuCommit,
 	"memcommit": memoryCommit,
+}
+
+func (s *Scheduler) Schedule() (map[string][]*QueuedVMs, error) {
+	if len(s.hosts) == 0 {
+		return nil, errors.New("no hosts to schedule VMs on")
+	}
+
+	if len(s.hosts) == 1 {
+		log.Warn("only one host in namespace, scheduling all VMs on it")
+		res := map[string][]*QueuedVMs{
+			s.hosts[0].Name: s.queue,
+		}
+		return res, nil
+	}
+
+	s.res = map[string][]*QueuedVMs{}
+	s.colocated = map[string][]*QueuedVMs{}
+
+	for _, q := range s.queue {
+		// resolve `localhost` to actual hostname
+		if q.Schedule == Localhost {
+			q.Schedule = hostname
+		}
+
+		// ensure we can get host stats to simplify scheduling loop
+		if host := q.Schedule; host != "" {
+			// host should exist
+			if s.findHostStats(host) == nil {
+				return nil, fmt.Errorf("VM scheduled on unknown host: `%v`", host)
+			}
+		}
+
+		// found "floating" VM
+		if q.Colocate != "" && q.Schedule == "" {
+			s.colocated[q.Colocate] = append(s.colocated[q.Colocate], q)
+		}
+	}
+
+	// update colocatedCounts so that we can include it in the sorting
+	for _, q := range s.queue {
+		q.colocatedCounts = map[string]int{}
+		q.colocatedCount = 0
+
+		for _, name := range q.Names {
+			if _, ok := s.colocated[name]; !ok {
+				continue
+			}
+
+			v := len(s.colocated[name])
+			q.colocatedCounts[name] = v
+			q.colocatedCount += v
+		}
+	}
+
+	// perform initial sort of queued VMs and hosts
+	sort.Slice(s.queue, func(i, j int) bool {
+		return s.queue[i].Less(s.queue[j])
+	})
+	s.hostSortBy.Sort(s.hosts)
+
+	for _, q := range s.queue {
+		if q.Colocate != "" && q.Schedule == "" {
+			// floating, ignore
+			continue
+		}
+
+		for _, name := range q.Names {
+			// least loaded host is at position zero
+			host := s.hosts[0]
+
+			if v := q.Schedule; v != "" {
+				// find the specified host
+				host = s.findHostStats(v)
+			}
+
+			if err := s.add(host, name, q); err != nil {
+				s.dumpSchedule()
+				return nil, err
+			}
+
+			s.hostSortBy.Update(s.hosts, host.Name)
+		}
+	}
+
+	// floating VMs never found a home... should probably be an error, right?
+	if len(s.colocated) != 0 {
+		names := []string{}
+		for k := range s.colocated {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		return nil, fmt.Errorf("nonexistent colocate VMs: [%v]", strings.Join(names, ", "))
+	}
+
+	return s.res, nil
+}
+
+// helper to write schedule to log
+func (s *Scheduler) dumpSchedule() {
+	log.Info("partial schedule:")
+	for host := range s.res {
+		names := []string{}
+		for _, q := range s.res[host] {
+			names = append(names, q.Names...)
+		}
+
+		log.Info("VMs scheduled on %v: %v", host, names)
+	}
+}
+
+// helper to find host stats by name
+func (s *Scheduler) findHostStats(host string) *HostStats {
+	for _, v := range s.hosts {
+		if v.Name == host {
+			return v
+		}
+	}
+
+	return nil
+}
+
+// add a VM to the given host, checking and adjusting limits if necessary
+func (s *Scheduler) add(host *HostStats, name string, q *QueuedVMs) error {
+	limit := int(q.Coschedule)
+
+	if limit != -1 {
+		// number of peers is one less than the number of VMs that we
+		// should launch on the node
+		limit := limit + 1
+		if host.Limit == -1 {
+			// set initial limit
+			log.Debug("set initial limit on %v to %v", host.Name, limit)
+			host.Limit = limit
+		} else if limit < host.Limit {
+			// lower the limit for the host
+			log.Debug("lower limit on %v from %v to %v", host.Name, host.Limit, limit)
+			host.Limit = limit
+		}
+	}
+
+	// update commit based on this VM's specs
+	host.increment(q.VMConfig)
+
+	// schedule all floating VMs on this host as well
+	for _, q := range s.colocated[name] {
+		for _, name2 := range q.Names {
+			log.Debug("colocating %v with %v", name2, name)
+			if err := s.add(host, name2, q); err != nil {
+				return err
+			}
+		}
+	}
+
+	// we no longer need to track these floating VMs
+	delete(s.colocated, name)
+
+	if host.Limit != -1 && host.VMs > host.Limit {
+		return fmt.Errorf("too many VMs scheduled on %v for coschedule requirement of %v", host.Name, host.Limit)
+	}
+
+	// create copy of q
+	q2 := *q
+	q2.Names = []string{name}
+
+	//log.Debug("scheduling VM on %v: %v", host.Name, name)
+	s.res[host.Name] = append(s.res[host.Name], &q2)
+
+	return nil
 }
 
 func (by hostSortBy) Sort(hosts []*HostStats) {
@@ -88,22 +270,12 @@ func (h *hostSorter) Swap(i, j int) {
 func (h *hostSorter) Less(i, j int) bool {
 	return h.by(h.hosts[i], h.hosts[j])
 }
-func (q ByPriority) Less(i, j int) bool {
-	return q[i].Less(q[j])
-}
-
-func (q ByPriority) Len() int {
-	return len(q)
-}
-
-func (q ByPriority) Swap(i, j int) {
-	q[i], q[j] = q[j], q[i]
-}
 
 // Less function for sorting QueuedVMs such that:
 //  * host and a coschedule limit come first
 //  * then those that specify a host
 //  * then those that specify a coschedule limit
+//  * then those that have more colocated VMs
 //  * then those that specify neither
 func (q *QueuedVMs) Less(q2 *QueuedVMs) bool {
 	host, host2 := q.Schedule, q2.Schedule
@@ -130,9 +302,21 @@ func (q *QueuedVMs) Less(q2 *QueuedVMs) bool {
 		return q.Coschedule < q2.Coschedule
 	}
 
+	// VMs with more colocated VMs are next
+	if q.colocatedCount != q2.colocatedCount {
+		return q.colocatedCount > q2.colocatedCount
+	}
+
 	// We don't really care about the ordering of the rest but we should
 	// probably schedule larger groups first.
 	return len(q.Names) > len(q2.Names)
+}
+
+func (s *HostStats) increment(config VMConfig) {
+	s.VMs += 1
+	s.CPUCommit += config.VCPUs
+	s.MemCommit += config.Memory
+	s.NetworkCommit += len(config.Networks)
 }
 
 // cpuCommit tests whether h1 < h2.
@@ -171,118 +355,12 @@ func networkCommit(h1, h2 *HostStats) bool {
 	return h1.NetworkCommit < h2.NetworkCommit
 }
 
-func incHostStats(stats *HostStats, config VMConfig) {
-	stats.VMs += 1
-	stats.CPUCommit += config.VCPUs
-	stats.MemCommit += config.Memory
-	stats.NetworkCommit += len(config.Networks)
-}
-
-func schedule(queue []*QueuedVMs, hosts []*HostStats, hostSorter hostSortBy) (map[string][]*QueuedVMs, error) {
-	res := map[string][]*QueuedVMs{}
-
-	if len(hosts) == 0 {
-		return nil, errors.New("no hosts to schedule VMs on")
+func schedule(q []*QueuedVMs, hosts []*HostStats, by hostSortBy) (map[string][]*QueuedVMs, error) {
+	s := &Scheduler{
+		queue:      q,
+		hosts:      hosts,
+		hostSortBy: by,
 	}
 
-	if len(hosts) == 1 {
-		log.Warn("only one host in namespace, scheduling all VMs on it")
-		res[hosts[0].Name] = queue
-		return res, nil
-	}
-
-	// helper to find HostStats by host's name
-	findHostStats := func(host string) *HostStats {
-		for _, v := range hosts {
-			if v.Name == host {
-				return v
-			}
-		}
-
-		return nil
-	}
-
-	// helper to write schedule to log
-	dumpSchedule := func() {
-		log.Info("partial schedule:")
-		for host := range res {
-			names := []string{}
-			for _, q := range res[host] {
-				names = append(names, q.Names...)
-			}
-
-			log.Info("VMs scheduled on %v: %v", host, names)
-		}
-	}
-
-	for _, q := range queue {
-		// resolve `localhost` to actual hostname
-		if q.Schedule == Localhost {
-			q.Schedule = hostname
-		}
-
-		// ensure we can get host stats to simplify scheduling loop
-		if host := q.Schedule; host != "" {
-			// host should exist
-			if findHostStats(host) == nil {
-				return nil, fmt.Errorf("VM scheduled on unknown host: `%v`", host)
-			}
-		}
-	}
-
-	// perform initial sort of queued VMs and hosts
-	sort.Sort(ByPriority(queue))
-	hostSorter.Sort(hosts)
-
-	for _, q := range queue {
-		// no error checking required, see above
-		limit := int(q.Coschedule)
-
-		for _, name := range q.Names {
-			var stats *HostStats
-
-			if host := q.Schedule; host != "" {
-				// find the specified host
-				stats = findHostStats(host)
-			} else {
-				// least loaded host is at position zero
-				stats = hosts[0]
-			}
-
-			host := stats.Name
-
-			if limit != -1 {
-				// number of peers is one less than the number of VMs that we
-				// should launch on the node
-				limit := limit + 1
-				if stats.Limit == -1 {
-					// set initial limit
-					log.Debug("set initial limit on %v to %v", stats.Name, limit)
-					stats.Limit = limit
-				} else if limit < stats.Limit {
-					// lower the limit for the host
-					log.Debug("lower limit on %v from %v to %v", stats.Name, stats.Limit, limit)
-					stats.Limit = limit
-				}
-			}
-
-			// schedule the VMs on the host, update commit accordingly
-			incHostStats(stats, q.VMConfig)
-
-			if stats.Limit != -1 && stats.VMs > stats.Limit {
-				dumpSchedule()
-				return nil, fmt.Errorf("too many VMs scheduled on %v for coschedule requirement of %v", host, stats.Limit)
-			}
-
-			hostSorter.Update(hosts, host)
-
-			q2 := *q
-			q2.Names = []string{name}
-
-			//log.Debug("scheduling VM on %v: %v", host, name)
-			res[host] = append(res[host], &q2)
-		}
-	}
-
-	return res, nil
+	return s.Schedule()
 }

--- a/src/minimega/vmconfig.go
+++ b/src/minimega/vmconfig.go
@@ -9,6 +9,7 @@ package main
 import (
 	"bridge"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -52,9 +53,16 @@ type BaseConfig struct {
 	// Default: true
 	Snapshot bool
 
-	// Set a host where the VM should be scheduled. This is only used when
-	// launching VMs in a namespace.
-	Schedule string
+	// Set a host where the VM should be scheduled.
+	//
+	// Note: Cannot specify Schedule and Colocate in the same config.
+	Schedule string `validate:"validSchedule"`
+
+	// Colocate this VM with another VM that has already been launched or is
+	// queued for launching.
+	//
+	// Note: Cannot specify Colocate and Schedule in the same
+	Colocate string `validate:"validColocate"`
 
 	// Set a limit on the number of VMs that should be scheduled on the same
 	// host as the VM. A limit of zero means that the VM should be scheduled by
@@ -63,11 +71,6 @@ type BaseConfig struct {
 	//
 	// Default: -1
 	Coschedule int64
-
-	// Colocate this VM with another VM that has already been launched or is
-	// queued for launching. Conflicting Schedule or Coschedule values may
-	// cause errors during scheduling.
-	Colocate string
 
 	// Enable/disable serial command and control layer for this VM.
 	//
@@ -148,6 +151,7 @@ func (vm *BaseConfig) String(namespace string) string {
 	fmt.Fprintf(w, "UUID:\t%v\n", vm.UUID)
 	fmt.Fprintf(w, "Schedule host:\t%v\n", vm.Schedule)
 	fmt.Fprintf(w, "Coschedule limit:\t%v\n", vm.Coschedule)
+	fmt.Fprintf(w, "Colocate:\t%v\n", vm.Colocate)
 	fmt.Fprintf(w, "Backchannel:\t%v\n", vm.Backchannel)
 	if vm.Tags != nil {
 		fmt.Fprintf(w, "Tags:\t%v\n", marshal(vm.Tags))
@@ -188,4 +192,22 @@ func (vm *BaseConfig) QosString(b, t, i string) string {
 		}
 	}
 	return strings.Trim(val, " ")
+}
+
+func validSchedule(vmConfig VMConfig, s string) error {
+	if vmConfig.Colocate != "" && s != "" {
+		return errors.New("cannot specify schedule and colocate in the same config")
+	}
+
+	// TODO: could check if s is a host in the mesh
+	return nil
+}
+
+func validColocate(vmConfig VMConfig, s string) error {
+	if vmConfig.Schedule != "" && s != "" {
+		return errors.New("cannot specify colocate and schedule in the same config")
+	}
+
+	// TODO: could check if s is a known VM
+	return nil
 }

--- a/src/minimega/vmconfig.go
+++ b/src/minimega/vmconfig.go
@@ -64,6 +64,11 @@ type BaseConfig struct {
 	// Default: -1
 	Coschedule int64
 
+	// Colocate this VM with another VM that has already been launched or is
+	// queued for launching. Conflicting Schedule or Coschedule values may
+	// cause errors during scheduling.
+	Colocate string
+
 	// Enable/disable serial command and control layer for this VM.
 	//
 	// Default: true

--- a/src/minimega/vmconfiger_cli.go
+++ b/src/minimega/vmconfiger_cli.go
@@ -738,6 +738,27 @@ Default: -1
 		}),
 	},
 	{
+		HelpShort: "configures colocate",
+		HelpLong: `Colocate this VM with another VM that has already been launched or is
+queued for launching. Conflicting Schedule or Coschedule values may
+cause errors during scheduling.
+`,
+		Patterns: []string{
+			"vm config colocate [value]",
+		},
+
+		Call: wrapSimpleCLI(func(ns *Namespace, c *minicli.Command, r *minicli.Response) error {
+			if len(c.StringArgs) == 0 {
+				r.Response = ns.vmConfig.Colocate
+				return nil
+			}
+
+			ns.vmConfig.Colocate = c.StringArgs["value"]
+
+			return nil
+		}),
+	},
+	{
 		HelpShort: "configures backchannel",
 		HelpLong: `Enable/disable serial command and control layer for this VM.
 
@@ -803,6 +824,7 @@ newly launched VMs.
 			"clear vm config <backchannel,>",
 			"clear vm config <cpu,>",
 			"clear vm config <cdrom,>",
+			"clear vm config <colocate,>",
 			"clear vm config <cores,>",
 			"clear vm config <coschedule,>",
 			"clear vm config <disk,>",
@@ -864,6 +886,9 @@ func (v *BaseConfig) Info(field string) (string, error) {
 	if field == "coschedule" {
 		return fmt.Sprintf("%v", v.Coschedule), nil
 	}
+	if field == "colocate" {
+		return v.Colocate, nil
+	}
 	if field == "backchannel" {
 		return strconv.FormatBool(v.Backchannel), nil
 	}
@@ -896,6 +921,9 @@ func (v *BaseConfig) Clear(mask string) {
 	if mask == Wildcard || mask == "coschedule" {
 		v.Coschedule = -1
 	}
+	if mask == Wildcard || mask == "colocate" {
+		v.Colocate = ""
+	}
 	if mask == Wildcard || mask == "backchannel" {
 		v.Backchannel = true
 	}
@@ -925,6 +953,9 @@ func (v *BaseConfig) WriteConfig(w io.Writer) error {
 	}
 	if v.Coschedule != -1 {
 		fmt.Fprintf(w, "vm config coschedule %v\n", v.Coschedule)
+	}
+	if v.Colocate != "" {
+		fmt.Fprintf(w, "vm config colocate %v\n", v.Colocate)
 	}
 	if v.Backchannel != true {
 		fmt.Fprintf(w, "vm config backchannel %t\n", v.Backchannel)

--- a/src/minimega/vms.go
+++ b/src/minimega/vms.go
@@ -38,6 +38,13 @@ type QueuedVMs struct {
 	Names    []string
 	VMType   // embed
 	VMConfig // embed
+
+	// book keeping for scheduler
+
+	// counts for colocated VMs, indexed by name
+	colocatedCounts map[string]int
+	// sum of colocatedCounts, used for sorting
+	colocatedCount int
 }
 
 // GetFiles looks through the VMConfig for files in the IOMESHAGE directory and

--- a/src/vmconfiger/generator.go
+++ b/src/vmconfiger/generator.go
@@ -182,6 +182,9 @@ func (g *Generator) handleNode(node ast.Node) bool {
 		for _, field := range strct.Fields.List {
 			log.Info("%#v", field)
 			name := field.Names[0].Name
+			if !ast.IsExported(name) {
+				continue
+			}
 			doc := field.Doc.Text()
 			var tag reflect.StructTag
 			if field.Tag != nil {

--- a/tests/distributed/vm_colocate
+++ b/tests/distributed/vm_colocate
@@ -1,0 +1,12 @@
+# test that all VMs end up on mm1 with queueing disabled
+ns queueing false
+vm config schedule mm1
+vm launch kvm a
+clear vm config schedule
+vm config colocate a
+vm launch kvm b
+vm config colocate b
+vm launch kvm c
+
+# check where VMs ended up
+.annotate true .columns name vm info

--- a/tests/distributed/vm_colocate.want
+++ b/tests/distributed/vm_colocate.want
@@ -1,0 +1,16 @@
+## # test that all VMs end up on mm1 with queueing disabled
+## ns queueing false
+## vm config schedule mm1
+## vm launch kvm a
+## clear vm config schedule
+## vm config colocate a
+## vm launch kvm b
+## vm config colocate b
+## vm launch kvm c
+
+## # check where VMs ended up
+## .annotate true .columns name vm info
+host | name
+mm1  | a
+mm1  | b
+mm1  | c

--- a/tests/distributed/vm_colocate_errors
+++ b/tests/distributed/vm_colocate_errors
@@ -1,0 +1,24 @@
+# both schedule and colocate
+vm config schedule mm1
+vm config colocate a
+clear vm config
+
+# both colocate and schedule
+vm config colocate a
+vm config schedule mm1
+clear vm config
+
+# schedule with non-existent VM with queueing disabled
+ns queueing false
+vm config colocate foo
+vm launch kvm a
+ns flush
+clear vm config
+
+# schedule with non-existent VM with queueing enabled
+ns queueing true
+vm config colocate foo
+vm launch kvm a
+vm launch
+ns flush
+clear vm config

--- a/tests/distributed/vm_colocate_errors.want
+++ b/tests/distributed/vm_colocate_errors.want
@@ -1,0 +1,28 @@
+## # both schedule and colocate
+## vm config schedule mm1
+## vm config colocate a
+E: cannot specify colocate and schedule in the same config
+## clear vm config
+
+## # both colocate and schedule
+## vm config colocate a
+## vm config schedule mm1
+E: cannot specify schedule and colocate in the same config
+## clear vm config
+
+## # schedule with non-existent VM with queueing disabled
+## ns queueing false
+## vm config colocate foo
+## vm launch kvm a
+E: nonexistent colocate VMs: [foo]
+## ns flush
+## clear vm config
+
+## # schedule with non-existent VM with queueing enabled
+## ns queueing true
+## vm config colocate foo
+## vm launch kvm a
+## vm launch
+E: nonexistent colocate VMs: [foo]
+## ns flush
+## clear vm config

--- a/tests/distributed/vm_colocate_queueing
+++ b/tests/distributed/vm_colocate_queueing
@@ -1,0 +1,16 @@
+# test that all VMs end up on mm1 with queueing enabled
+ns queueing true
+vm config schedule mm1
+vm launch kvm a
+clear vm config schedule
+vm config colocate a
+vm launch kvm b
+vm config colocate b
+vm launch kvm c
+vm launch
+
+# wait for scheduler to run
+shell sleep 5s
+
+# check where VMs ended up
+.annotate true .columns name vm info

--- a/tests/distributed/vm_colocate_queueing.want
+++ b/tests/distributed/vm_colocate_queueing.want
@@ -1,0 +1,20 @@
+## # test that all VMs end up on mm1 with queueing enabled
+## ns queueing true
+## vm config schedule mm1
+## vm launch kvm a
+## clear vm config schedule
+## vm config colocate a
+## vm launch kvm b
+## vm config colocate b
+## vm launch kvm c
+## vm launch
+
+## # wait for scheduler to run
+## shell sleep 5s
+
+## # check where VMs ended up
+## .annotate true .columns name vm info
+host | name
+mm1  | a
+mm1  | b
+mm1  | c

--- a/tests/distributed/vm_colocated_errors
+++ b/tests/distributed/vm_colocated_errors
@@ -1,0 +1,23 @@
+# both schedule and colocate
+vm config schedule mm1
+vm config colocate a
+clear vm config
+
+# both colocate and schedule
+vm config colocate a
+vm config schedule mm1
+clear vm config
+
+# schedule with non-existent VM with queueing enabled
+ns queueing false
+vm config coschedule foo
+vm launch kvm a
+ns flush
+clear vm config
+
+# schedule with non-existent VM with queueing disabled
+ns queueing true
+vm config coschedule foo
+vm launch kvm a
+ns flush
+clear vm config

--- a/tests/vm_config_save.want
+++ b/tests/vm_config_save.want
@@ -7,6 +7,7 @@ Snapshot:         true
 UUID:             
 Schedule host:    
 Coschedule limit: -1
+Colocate:         
 Backchannel:      true
 Tags:             {}
 
@@ -48,6 +49,7 @@ Snapshot:         true
 UUID:             9131e2a3-ad6b-4f38-b5ba-5ff2b19e32dc
 Schedule host:    
 Coschedule limit: -1
+Colocate:         
 Backchannel:      true
 Tags:             {}
 
@@ -86,6 +88,7 @@ Snapshot:         true
 UUID:             
 Schedule host:    
 Coschedule limit: -1
+Colocate:         
 Backchannel:      true
 Tags:             {}
 
@@ -121,6 +124,7 @@ Snapshot:         true
 UUID:             9131e2a3-ad6b-4f38-b5ba-5ff2b19e32dc
 Schedule host:    
 Coschedule limit: -1
+Colocate:         
 Backchannel:      true
 Tags:             {}
 


### PR DESCRIPTION
Allow users to schedule VMs on the same host via `vm config colocate`.

 * Supports chaining -- a with b, b with c, c with d.
 * Cannot specify `vm config schedule` with `vm config colocate` to simplify the code.
 * Can specify `vm config schedule` on "root VM" and then colocate VMs with it.
 * Minor fix to `vmconfiger`.

Has some unit testing, need to do some more testing.