### PR TITLE
misc: trim libreadline overlay

### DIFF
--- a/misc/vmbetter_configs/host_overlay/lib/x86_64-linux-gnu/libreadline.so.6
+++ b/misc/vmbetter_configs/host_overlay/lib/x86_64-linux-gnu/libreadline.so.6
@@ -1,1 +1,0 @@
-/lib/x86_64-linux-gnu/libreadline.so.6


### PR DESCRIPTION
minimega no longer needs libreadline so trim this from overlay.