### PR TITLE
minimega: retry unmount

### DIFF
--- a/src/minimega/vms.go
+++ b/src/minimega/vms.go
@@ -354,7 +354,7 @@ func (vms *VMs) Flush(cc *ron.Server) error {
 			}
 
 			if err := vm.Flush(); err != nil {
-				log.Error("clogged VM: %v", err)
+				log.Error("clogged vm %v: %v", vm.GetID(), err)
 			}
 
 			delete(vms.m, i)


### PR DESCRIPTION
If a container filesystem is busy, retry a few times to see if we can
unmount it. Add VM ID to clogged error.

Needs testing.