### PR TITLE
minidoc: show header/sidebar in articles

### DIFF
--- a/doc/content/static/article.css
+++ b/doc/content/static/article.css
@@ -1,61 +1,3 @@
-body {
-	margin: 0;
-	font-family: Helvetica, Arial, sans-serif;
-	/*font-size: 16px;*/
-}
-pre,
-code {
-	font-family: Menlo, monospace;
-	font-size: 0.8em;
-}
-pre {
-	line-height: 1.2em;
-	margin: 0;
-	padding: 0;
-}
-a {
-	color: #375EAB;
-	text-decoration: none;
-}
-a:hover {
-	text-decoration: underline;
-}
-p, ul, ol {
-	margin: 1em;
-}
-
-h1, h2, h3, h4 {
-	margin: .4em 0;
-	padding: 0;
-	color: #375EAB;
-	font-weight: bold;
-}
-h1 {
-	padding: .1em .1em;
-	font-size: 1.6em;
-	background: #E0EBF5;
-}
-h2 {
-	font-size: 1.4em;
-	padding: .1em .1em;
-}
-h3 {
-	font-size: 1.2em;
-	color: #1D435E;
-}
-h3, h4 {
-	margin: .2em .4em;
-}
-h4 {
-	font-size: 1.1em;
-	color: #111111;
-}
-
-img {
-	margin: 0.2em 1em;
-        max-width: 80%;
-}
-
 div#topbar {
 	margin: 0;
 	padding: .8em 1.2em;
@@ -65,10 +7,6 @@ div#topbar {
 	width: 100%;
 }
 
-
-body {
-	text-align: center;
-}
 div#page {
 	width: 100%;
 }
@@ -124,7 +62,7 @@ div.output .buttons {
 	float: right;
 	margin: 0px 10px;
 	padding: 10px;
-	border: 1px solid #e5ecf9; 
+	border: 1px solid #e5ecf9;
 	background-color: white;
 	max-width: 33%;
 

--- a/doc/template/article.tmpl
+++ b/doc/template/article.tmpl
@@ -1,48 +1,41 @@
 {/* This is the article template. It defines how articles are formatted. */}
 
-{{define "root"}}
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>{{.Title}}</title>
-    <link type="text/css" rel="stylesheet" href="/static/article.css">
-    <link rel="icon" href="/static/favicon.png">
-    <meta charset='utf-8'>
-  </head>
+{{define "header"}}
+<title>{{.Title}}</title>
+<link type="text/css" rel="stylesheet" href="/static/article.css">
+{{end}}
 
-  <body>
-    <div id="topbar" class="wide">
-      <div class="container">
-        <div id="heading">{{.Title}}
-          {{with .Subtitle}}{{.}}{{end}}
+{{define "content"}}
+<div id="topbar" class="wide">
+  <div class="container">
+    <div id="heading">{{.Title}}
+      {{with .Subtitle}}{{.}}{{end}}
+    </div>
+  </div>
+</div>
+<div id="page" class="wide">
+  <div class="container">
+    {{with .Sections}}
+      <div id="toc">
+        {{template "TOC" .}}
+      </div>
+    {{end}}
+
+    {{range .Sections}}
+      {{elem $.Template .}}
+    {{end}}{{/* of Section block */}}
+
+    {{if .Authors}}
+      <h2>Authors</h2>
+      {{range .Authors}}
+        <div class="author">
+          {{range .Elem}}{{elem $.Template .}}{{end}}
         </div>
-      </div>
-    </div>
-    <div id="page" class="wide">
-      <div class="container">
-        {{with .Sections}}
-          <div id="toc">
-            {{template "TOC" .}}
-          </div>
-        {{end}}
-
-        {{range .Sections}}
-          {{elem $.Template .}}
-        {{end}}{{/* of Section block */}}
-
-        {{if .Authors}}
-          <h2>Authors</h2>
-          {{range .Authors}}
-            <div class="author">
-              {{range .Elem}}{{elem $.Template .}}{{end}}
-            </div>
-          {{end}}
-        {{end}}
-      </div>
-    </div>
-    <script src='/static/mega.js'></script>
-  </body>
-</html>
+      {{end}}
+    {{end}}
+  </div>
+</div>
+<script src='/static/mega.js'></script>
 {{end}}
 
 {{define "TOC"}}

--- a/doc/template/dir.tmpl
+++ b/doc/template/dir.tmpl
@@ -1,3 +1,5 @@
+{/* Template for directory listing. */}
+
 {{ define "content" }}
 <h1>Documentation</h1>
 

--- a/doc/template/layout.tmpl
+++ b/doc/template/layout.tmpl
@@ -1,11 +1,17 @@
+{/* This is site layout. Other templates fill in the content. */}
+
+{{define "header"}}
+<title>minimega.org</title>
+{{end}}
+
+{{define "root"}}
 <!DOCTYPE html>
 <html lang="en-US">
 	<head>
-		<title>minimega.org</title>
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 		<link type="text/css" rel="stylesheet" href="/static/page.css">
 		<link rel="icon" href="/static/favicon.png">
-		<!-- handcrafted artisanal HTML !-->
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		{{ template "header" . }}
 	</head>
 
 	<body>
@@ -21,7 +27,7 @@
 			<li><a href="/articles/api.article">API Documentation</a>
 			<li><a href="/presentations/">Presentations</a>
 			<li><a href="/articles/">Documentation</a>
-            <hr />
+			<hr />
 			<li><a href="https://github.com/sandia-minimega/minimega">Github repository</a>
 			<li><a href="/articles/contributing.article">Contributing</a>
 			<li><a href="/articles/developer/">Developer Docs</a>
@@ -30,8 +36,9 @@
 			<li><a href="http://tip.minimega.org">Latest docs (unstable)</a>
 		</ul>
 
-        <div id="content" class="content">
-            {{ template "content" . }}
-        </div>
+		<div id="content" class="content">
+			{{ template "content" . }}
+		</div>
 	</body>
 </html>
+{{end}}


### PR DESCRIPTION
Tweak templates so that we embed the article within the standard layout
template. Muck around with CSS a bit since pages and articles conflict.

Fixes #1219