### PR TITLE
minimega: add dry-run to scheduler

### DIFF
--- a/doc/content/articles/namespaces.article
+++ b/doc/content/articles/namespaces.article
@@ -148,7 +148,7 @@ Calling `vm`launch` with no additional arguments flushes the queue and invokes
 the scheduler:
 
 	minimega[foo]$ vm launch
-	minimega[foo]$ ns schedules
+	minimega[foo]$ ns schedule status
 	start               | end                 | state     | launched | failures | total | hosts
 	02 Jan 06 15:04 MST | 02 Jan 06 15:04 MST | completed | 1        | 0        | 1     | 1
 

--- a/doc/content/articles/namespaces.article
+++ b/doc/content/articles/namespaces.article
@@ -202,6 +202,41 @@ to schedule at most four other VMs on those nodes. Note: because of the way the
 least loaded scheduler works, quad[0-3] will most likely not be scheduled on the
 same node.
 
+*** Dry-run
+
+The `ns` API also allows users to perform dry runs with the scheduler. This
+will determine VM placement but stop before launching any VMs. The VM placement
+is displayed back to the user for editing with the `ns`schedule`mv` API. For
+example, if we launched four VMs with queueing enabled:
+
+    minimega$ ns queueing true
+    minimega$ vm launch kvm vm[0-3]
+    minimega$ ns schedule dry-run
+    vm   | dst
+    vm0  | mm0
+    vm1  | mm1
+    vm2  | mm2
+    vm3  | mm3
+
+We can then move one or more VMs:
+
+    minimega$ ns schedule mv vm0 mm1
+    minimega$ ns schedule mv vm[1-2] mm0
+    minimega$ ns schedule dump
+    vm   | dst
+    vm0  | mm1
+    vm1  | mm0
+    vm2  | mm0
+    vm3  | mm3
+
+To launch the VMs based on the edited VM placement, simply run `ns`schedule`:
+
+    minimega$ ns schedule dump
+
+Note that only named VMs can be manipulated in this manner. If you launch VMs
+with a number (i.e. `vm`launch`kvm`4`), the VMs do not have names until they
+are launched.
+
 ** vm API
 
 Besides the changes noted above to `vm`launch`, all of the `vm` APIs are

--- a/src/minimega/meshage.go
+++ b/src/minimega/meshage.go
@@ -16,6 +16,7 @@ import (
 	"miniplumber"
 	"ranges"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 	"version"
@@ -221,8 +222,9 @@ func meshageLaunch(host, namespace string, queued *QueuedVMs) <-chan minicli.Res
 				} else {
 					// wrap response up into a minicli.Response
 					resp := &minicli.Response{
-						Host:  host,
-						Error: strings.Join(body.Errors, "\n"),
+						Host:     host,
+						Response: strconv.Itoa(len(body.Errors)),
+						Error:    strings.Join(body.Errors, "\n"),
 					}
 
 					out <- minicli.Responses{resp}

--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"qemu"
+	"ranges"
 	"ron"
 	"runtime"
 	"sort"
@@ -43,6 +44,10 @@ type Namespace struct {
 
 	// Queued VMs to launch
 	queue []*QueuedVMs
+
+	// Assignment created by dry-run that the user can tinker with. Used on the
+	// next call to Schedule() unless invalidated.
+	assignment map[string][]*QueuedVMs
 
 	// Status of launching things
 	scheduleStats []*scheduleStat
@@ -238,6 +243,9 @@ func (n *Namespace) Destroy() error {
 // Queue handles storing the current VM config to the namespace's queued VMs so
 // that we can launch it in the future.
 func (n *Namespace) Queue(arg string, vmType VMType, vmConfig VMConfig) error {
+	// invalidate assignment
+	n.assignment = nil
+
 	names, err := expandLaunchNames(arg)
 	if err != nil {
 		return err
@@ -325,8 +333,11 @@ func (n *Namespace) hostStats() []*HostStats {
 // Schedule runs the scheduler, launching VMs across the cluster. Blocks until
 // all the `vm launch ...` commands are in-flight.
 //
+// If dryRun is true, the scheduler will determine VM placement but not
+// actually launch any VMs so that the user can tinker with the schedule.
+//
 // LOCK: Assumes cmdLock is held.
-func (n *Namespace) Schedule() error {
+func (n *Namespace) Schedule(dryRun bool) error {
 	if len(n.Hosts) == 0 {
 		return errors.New("namespace must contain at least one host to launch VMs")
 	}
@@ -334,6 +345,18 @@ func (n *Namespace) Schedule() error {
 	if len(n.queue) == 0 {
 		return errors.New("namespace must contain at least one queued VM to launch VMs")
 	}
+
+	// already have assignment so if we're not doing a dry run, run it
+	if n.assignment != nil && !dryRun {
+		if err := n.schedule(n.assignment); err != nil {
+			return err
+		}
+
+		n.assignment = nil
+		return nil
+	}
+
+	// otherwise, generate a fresh assignment
 
 	hostStats := n.hostStats()
 
@@ -359,6 +382,15 @@ func (n *Namespace) Schedule() error {
 		return err
 	}
 
+	if dryRun {
+		n.assignment = assignment
+		return nil
+	}
+
+	return n.schedule(assignment)
+}
+
+func (n *Namespace) schedule(assignment map[string][]*QueuedVMs) error {
 	total := 0
 	for _, q := range n.queue {
 		total += len(q.Names)
@@ -369,7 +401,7 @@ func (n *Namespace) Schedule() error {
 
 	stats := &scheduleStat{
 		total: total,
-		hosts: len(hostStats),
+		hosts: len(n.Hosts),
 		start: time.Now(),
 		state: SchedulerRunning,
 	}
@@ -423,6 +455,58 @@ func (n *Namespace) Schedule() error {
 
 	stats.end = time.Now()
 	stats.state = SchedulerCompleted
+
+	return nil
+}
+
+// Reschedule
+func (n *Namespace) Reschedule(target, dst string) error {
+	if n.assignment == nil {
+		return errors.New("must run dry-run first")
+	}
+
+	if !n.Hosts[dst] {
+		return errors.New("new dst host is not in namespace")
+	}
+
+	vals, err := ranges.SplitList(target)
+	if err != nil {
+		return err
+	}
+
+Outer:
+	for _, v := range vals {
+		// find each VM
+		for src, qs := range n.assignment {
+			for i, q := range qs {
+				for j, v2 := range q.Names {
+					// no match
+					if v != v2 {
+						continue
+					}
+
+					if len(q.Names) == 1 {
+						// only a single name, simply relocate whole QueuedVMs
+						n.assignment[src] = append(n.assignment[src][:i], n.assignment[src][i+1:]...)
+						n.assignment[dst] = append(n.assignment[dst], q)
+
+						continue Outer
+					}
+
+					// more than one name, need to split QueuedVMs
+					q2 := *q
+					q2.Names = []string{v2}
+					q.Names = append(q.Names[:j], q.Names[j+1:]...)
+
+					n.assignment[dst] = append(n.assignment[dst], &q2)
+					continue Outer
+				}
+			}
+		}
+
+		// didn't find vm -- strange
+		return fmt.Errorf("reassign %v: vm not found", v)
+	}
 
 	return nil
 }

--- a/src/minimega/namespace_cli.go
+++ b/src/minimega/namespace_cli.go
@@ -55,11 +55,11 @@ Display or modify the active namespace.
 - queue     : display VM queue
 - flush     : clear the VM queue
 - queueing  : toggle VMs queueing when launching (default false)
-- schedules : display scheduling stats
 - schedule  : run scheduler (same as "vm launch")
   - dry-run : determine VM placement and print out VM -> host assignments
   - dump    : print out VM -> host assignments (after dry-run)
   - mv      : manually edit VM placement in schedule (after dry-run)
+  - status  : display scheduling status
 - snapshot  : take a snapshot of namespace or print snapshot progress
 - run       : run a command on all nodes in the namespace
 `,
@@ -74,11 +74,11 @@ Display or modify the active namespace.
 			"ns <queue,>",
 			"ns <flush,>",
 			"ns <queueing,> [true,false]",
-			"ns <schedules,>",
 			"ns <schedule,>",
 			"ns <schedule,> <dry-run,>",
 			"ns <schedule,> <dump,>",
 			"ns <schedule,> <mv,> <vm target> <dst>",
+			"ns <schedule,> <status,>",
 			"ns <snapshot,> [name]",
 			"ns <run,> (command)",
 		},
@@ -116,7 +116,6 @@ var nsCliHandlers = map[string]minicli.CLIFunc{
 	"queue":     wrapSimpleCLI(cliNamespaceQueue),
 	"queueing":  wrapSimpleCLI(cliNamespaceQueueing),
 	"flush":     wrapSimpleCLI(cliNamespaceFlush),
-	"schedules": wrapSimpleCLI(cliNamespaceSchedules),
 	"schedule":  wrapSimpleCLI(cliNamespaceSchedule),
 	"snapshot":  cliNamespaceSnapshot,
 	"run":       cliNamespaceRun,
@@ -323,33 +322,6 @@ func cliNamespaceFlush(ns *Namespace, c *minicli.Command, resp *minicli.Response
 	return nil
 }
 
-func cliNamespaceSchedules(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	resp.Header = []string{
-		"start", "end", "state", "launched", "failures", "total", "hosts",
-	}
-
-	for _, stats := range ns.scheduleStats {
-		var end string
-		if !stats.end.IsZero() {
-			end = stats.end.Format(time.RFC822)
-		}
-
-		row := []string{
-			stats.start.Format(time.RFC822),
-			end,
-			stats.state,
-			strconv.Itoa(stats.launched),
-			strconv.Itoa(stats.failures),
-			strconv.Itoa(stats.total),
-			strconv.Itoa(stats.hosts),
-		}
-
-		resp.Tabular = append(resp.Tabular, row)
-	}
-
-	return nil
-}
-
 func cliNamespaceSchedule(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 	switch {
 	case c.BoolArgs["dry-run"]:
@@ -378,6 +350,31 @@ func cliNamespaceSchedule(ns *Namespace, c *minicli.Command, resp *minicli.Respo
 		return nil
 	case c.BoolArgs["mv"]:
 		return ns.Reschedule(c.StringArgs["vm"], c.StringArgs["dst"])
+	case c.BoolArgs["status"]:
+		resp.Header = []string{
+			"start", "end", "state", "launched", "failures", "total", "hosts",
+		}
+
+		for _, stats := range ns.scheduleStats {
+			var end string
+			if !stats.end.IsZero() {
+				end = stats.end.Format(time.RFC822)
+			}
+
+			row := []string{
+				stats.start.Format(time.RFC822),
+				end,
+				stats.state,
+				strconv.Itoa(stats.launched),
+				strconv.Itoa(stats.failures),
+				strconv.Itoa(stats.total),
+				strconv.Itoa(stats.hosts),
+			}
+
+			resp.Tabular = append(resp.Tabular, row)
+		}
+
+		return nil
 	default:
 		return ns.Schedule(false)
 	}

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -106,9 +106,9 @@ naming scheme:
 
 Note: VM names cannot be integers or reserved words (e.g. "all").
 
-If enabled (see "ns"), VMs will be queued for launching until "vm launch" is
-called with no additional arguments. This allows the scheduler to better
-allocate resources across the cluster.`,
+If queueing is enabled (see "ns"), VMs will be queued for launching until "vm
+launch" is called with no additional arguments. This allows the scheduler to
+better allocate resources across the cluster.`,
 		Patterns: []string{
 			"vm launch",
 			"vm launch <kvm,> <name or count>",
@@ -596,13 +596,13 @@ func cliVMLaunch(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 
 		if err == nil && !ns.QueueVMs {
 			// no error queueing and user has disabled queueing -- launch now!
-			return ns.Schedule()
+			return ns.Schedule(false)
 		}
 
 		return err
 	}
 
-	return ns.Schedule()
+	return ns.Schedule(false)
 }
 
 func cliVMQmp(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/tests/distributed/ns_schedule
+++ b/tests/distributed/ns_schedule
@@ -1,0 +1,35 @@
+ns queueing true
+
+# schedule one container per host
+vm config filesystem /root/uminicccfs
+vm config schedule mm1
+vm launch container vm1
+vm config schedule mm2
+vm launch container vm2
+vm config schedule mm3
+vm launch container vm3
+
+# dry run, dump schedule
+ns schedule dry-run
+
+# try invalid moves
+ns schedule mv vm4 mm1
+ns schedule mv vm1 mm4
+
+# no changes, hopefully
+ns schedule dump
+
+# try valid moves
+ns schedule mv vm1 mm2
+ns schedule dump
+ns schedule mv vm[1-3] mm3
+ns schedule dump
+
+# run scheduler
+ns schedule
+
+# wait for scheduler to run
+shell sleep 5s
+
+# check where VMs ended up
+.annotate true .columns name vm info

--- a/tests/distributed/ns_schedule.want
+++ b/tests/distributed/ns_schedule.want
@@ -1,0 +1,57 @@
+## ns queueing true
+
+## # schedule one container per host
+## vm config filesystem /root/uminicccfs
+## vm config schedule mm1
+## vm launch container vm1
+## vm config schedule mm2
+## vm launch container vm2
+## vm config schedule mm3
+## vm launch container vm3
+
+## # dry run, dump schedule
+## ns schedule dry-run
+vm   | dst
+vm1  | mm1
+vm2  | mm2
+vm3  | mm3
+
+## # try invalid moves
+## ns schedule mv vm4 mm1
+E: reassign vm4: vm not found
+## ns schedule mv vm1 mm4
+E: new dst host is not in namespace
+
+## # no changes, hopefully
+## ns schedule dump
+vm   | dst
+vm1  | mm1
+vm2  | mm2
+vm3  | mm3
+
+## # try valid moves
+## ns schedule mv vm1 mm2
+## ns schedule dump
+vm   | dst
+vm1  | mm2
+vm2  | mm2
+vm3  | mm3
+## ns schedule mv vm[1-3] mm3
+## ns schedule dump
+vm   | dst
+vm1  | mm3
+vm2  | mm3
+vm3  | mm3
+
+## # run scheduler
+## ns schedule
+
+## # wait for scheduler to run
+## shell sleep 5s
+
+## # check where VMs ended up
+## .annotate true .columns name vm info
+host | name
+mm3  | vm1
+mm3  | vm2
+mm3  | vm3


### PR DESCRIPTION
Dry run of the scheduler that prints out VM placement. User can then edit the placement as needed before running it. Rename `ns schedules` to `ns schedule status`. Fix bug in schedule status where launched VMs weren't being counted properly.

Fixes #1229.
