### PR TITLE
igor: fix corner cases in scheduler

### DIFF
--- a/src/igor/.gitignore
+++ b/src/igor/.gitignore
@@ -1,0 +1,1 @@
+/igor.log

--- a/src/igor/reservation.go
+++ b/src/igor/reservation.go
@@ -53,6 +53,11 @@ func (r Reservation) IsActive(t time.Time) bool {
 	return r.Start.Before(t) && r.End.After(t)
 }
 
+// IsOverlap tests whether the reservation overlaps with a given time range
+func (r Reservation) IsOverlap(start, end time.Time) bool {
+	return r.End.Sub(start) > 0 && r.Start.Sub(end) < 0
+}
+
 // Remaining returns how long the reservation has remaining at the given time
 // if the reservation is active. If the reservation is not active, it returns
 // how long the reservation will be active for.

--- a/src/igor/reservation_test.go
+++ b/src/igor/reservation_test.go
@@ -23,3 +23,38 @@ func TestIsActive(t *testing.T) {
 		t.Errorf("now-2h should not be active")
 	}
 }
+
+func TestIsOverlap(t *testing.T) {
+	now, _ := time.Parse(time.RFC3339, "2006-01-02T15:00:00Z")
+
+	r := &Reservation{
+		Start: now.Add(-60 * time.Minute),
+		End:   now.Add(60 * time.Minute),
+	}
+
+	// before/after reservation
+	if r.IsOverlap(now.Add(-90*time.Minute), now.Add(-60*time.Minute)) {
+		t.Errorf("[-90m, -60m] should not overlap")
+	}
+	if r.IsOverlap(now.Add(60*time.Minute), now.Add(90*time.Minute)) {
+		t.Errorf("[60m, 90m] should not overlap")
+	}
+
+	// contains whole reservation
+	if !r.IsOverlap(now.Add(-90*time.Minute), now.Add(90*time.Minute)) {
+		t.Errorf("[-90m, 90m] should overlap")
+	}
+
+	// contained within reservation
+	if !r.IsOverlap(now.Add(-30*time.Minute), now.Add(30*time.Minute)) {
+		t.Errorf("[-30m, 30m] should overlap")
+	}
+
+	// overlap start/end
+	if !r.IsOverlap(now.Add(-90*time.Minute), now.Add(-30*time.Minute)) {
+		t.Errorf("[-90m, -30m] should overlap")
+	}
+	if !r.IsOverlap(now.Add(30*time.Minute), now.Add(90*time.Minute)) {
+		t.Errorf("[30m, 90m] should overlap")
+	}
+}


### PR DESCRIPTION
Two issues: reservations that spanned other reservations and using the
start time of the first host in a block rather than the max.