### PR TITLE
minimega: fix #1279

### DIFF
--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -159,6 +159,9 @@ func main() {
 			}
 
 			cmd := quoteJoin(parts, " ")
+			if len(parts) == 1 {
+				cmd = parts[0]
+			}
 			log.Info("got command: `%v`", cmd)
 
 			mm.RunAndPrint(cmd, false)


### PR DESCRIPTION
If there's only one argument, pass it directly as the command.

Tested with:

	minimega -e echo 'hello, world'
	minimega -e "echo 'hello, world'"

@mkunz7 