### PR TITLE
minimega: support named virtio ports

### DIFF
--- a/tests/vm_config_save.want
+++ b/tests/vm_config_save.want
@@ -21,7 +21,7 @@ Kernel Append:       []
 QEMU Path:           kvm
 QEMU Append:         []
 Serial Ports:        0
-Virtio-Serial Ports: 0
+Virtio-Serial Ports: 
 Machine:             
 CPU:                 host
 Cores:               0
@@ -66,7 +66,7 @@ Kernel Append:       []
 QEMU Path:           kvm
 QEMU Append:         [-k en-us]
 Serial Ports:        0
-Virtio-Serial Ports: 0
+Virtio-Serial Ports: 
 Machine:             
 CPU:                 host
 Cores:               0
@@ -108,7 +108,7 @@ Kernel Append:       []
 QEMU Path:           kvm
 QEMU Append:         []
 Serial Ports:        0
-Virtio-Serial Ports: 0
+Virtio-Serial Ports: 
 Machine:             
 CPU:                 host
 Cores:               0
@@ -147,7 +147,7 @@ Kernel Append:       []
 QEMU Path:           kvm
 QEMU Append:         [-k en-us]
 Serial Ports:        0
-Virtio-Serial Ports: 0
+Virtio-Serial Ports: 
 Machine:             
 CPU:                 host
 Cores:               0


### PR DESCRIPTION
Users can now specify a list of named virtio ports or a number of virtio
ports to automatically generate names for (old behavior).

Fixes #1293.

TODO:

- [x] Fix minitests