### PR TITLE
minimega: name sanitization

### DIFF
--- a/src/minimega/minimega.go
+++ b/src/minimega/minimega.go
@@ -1,0 +1,16 @@
+// Copyright (2019) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"errors"
+	"regexp"
+)
+
+// validName is used by VMs and namespaces to exclude weird characters
+var validName = regexp.MustCompile(`^[a-zA-Z0-9-_]+$`)
+
+// validNameErr can be returned when validName is not met
+var validNameErr = errors.New("invalid name; must only include letters, numbers, hyphens and underscores")

--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -267,6 +267,10 @@ func (n *Namespace) Queue(arg string, vmType VMType, vmConfig VMConfig) error {
 		if takenName[name] {
 			return fmt.Errorf("vm already exists with name `%s`", name)
 		}
+
+		if !validName.MatchString(name) {
+			return fmt.Errorf("%v: `%v`", validNameErr, name)
+		}
 	}
 
 	if takenUUID[vmConfig.UUID] && vmConfig.UUID != "" {

--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -268,7 +268,7 @@ func (n *Namespace) Queue(arg string, vmType VMType, vmConfig VMConfig) error {
 			return fmt.Errorf("vm already exists with name `%s`", name)
 		}
 
-		if !validName.MatchString(name) {
+		if name != "" && !validName.MatchString(name) {
 			return fmt.Errorf("%v: `%v`", validNameErr, name)
 		}
 	}

--- a/src/minimega/namespace_cli.go
+++ b/src/minimega/namespace_cli.go
@@ -128,6 +128,13 @@ func cliNamespace(c *minicli.Command, respChan chan<- minicli.Responses) {
 	ns := GetNamespace()
 
 	if name, ok := c.StringArgs["name"]; ok {
+		// check the name is sane
+		if !validName.MatchString(name) {
+			resp.Error = validNameErr.Error()
+			respChan <- minicli.Responses{resp}
+			return
+		}
+
 		ns2 := GetOrCreateNamespace(name)
 
 		if c.Subcommand != nil {


### PR DESCRIPTION
Make sure namespace and VM names are sanitized since we create
directories and argument strings based on them.

Fixes #1288.