### PR TITLE
igor: Add -json flag to 'igor show'

### DIFF
--- a/src/igor/show.go
+++ b/src/igor/show.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	log "minilog"
 	"os"
@@ -69,6 +70,8 @@ var showOpts struct {
 	sortName  bool
 	reverse   bool
 
+	asJSON bool
+
 	filterOwner     string
 	filterName      string
 	filterGroup     string
@@ -90,6 +93,8 @@ func init() {
 	cmdShow.Flag.BoolVar(&showOpts.sortOwner, "o", false, "sort by owner")
 	cmdShow.Flag.BoolVar(&showOpts.sortName, "n", false, "sort by reservation name")
 	cmdShow.Flag.BoolVar(&showOpts.reverse, "r", false, "reverse order while sorting")
+
+	cmdShow.Flag.BoolVar(&showOpts.asJSON, "json", false, "return JSON-encoded reservations")
 
 	cmdShow.Flag.StringVar(&showOpts.filterOwner, "owner", "", "filter by owner")
 	cmdShow.Flag.StringVar(&showOpts.filterGroup, "group", "", "filter by group")
@@ -188,6 +193,32 @@ func runShow(_ *Command, _ []string) {
 		}
 	}
 
+	// if printing as JSON, write out info and bail...
+	if showOpts.asJSON {
+		data, err := json.Marshal(struct {
+			Prefix                                      string
+			RangeStart, RangeEnd, RackWidth, RackHeight int
+			Available, Down                             []string
+			Reservations                                []*Reservation
+		}{
+			Prefix:       igor.Config.Prefix,
+			RangeStart:   igor.Config.Start,
+			RangeEnd:     igor.Config.End,
+			RackWidth:    igor.Config.Rackwidth,
+			RackHeight:   igor.Config.Rackheight,
+			Available:    unreservedNodes,
+			Down:         downNodes,
+			Reservations: resarray,
+		})
+		if err != nil {
+			log.Fatal("unable to marshal reservations: %v", err)
+		}
+
+		fmt.Printf("%s\n", data)
+		return
+	}
+
+	// ... if not printing as json
 	// sort according to options
 	sortReservations(resarray)
 

--- a/src/igor/show.go
+++ b/src/igor/show.go
@@ -193,6 +193,9 @@ func runShow(_ *Command, _ []string) {
 		}
 	}
 
+	// sort according to options
+	sortReservations(resarray)
+
 	// if printing as JSON, write out info and bail...
 	if showOpts.asJSON {
 		data, err := json.Marshal(struct {
@@ -219,9 +222,6 @@ func runShow(_ *Command, _ []string) {
 	}
 
 	// ... if not printing as json
-	// sort according to options
-	sortReservations(resarray)
-
 	if showOpts.showTable {
 		p := tablePrinter{
 			filter:     isFiltered,


### PR DESCRIPTION
Add option for JSON encoded output to `igor show`

This helps igor web get a list of reservations without worrying about file locking.  Let igor handle that.