### PR TITLE
Make pages work

### DIFF
--- a/misc/web/js/glue.js
+++ b/misc/web/js/glue.js
@@ -576,7 +576,7 @@ function updateScreenshotTable(vmsData) {
                 { "title": "Model", "data": "model", "searchable": false },
                 { "title": "VM", "data": "vm", "visible": false, "searchable": false },
             ],
-            "createdRow": loadOrRestoreImage,
+            "fnRowCallback": loadOrRestoreImage,
             "stateSave": true,
             "stateDuration": 0
         });


### PR DESCRIPTION
:%s/createdRow/fnRowCallback/g
http://legacy.datatables.net/usage/callbacks
https://stackoverflow.com/questions/28816318/jquery-lazyload-images-in-jquery-databables
fixes #1310

someone take a look
@jcrussell @djfritz 