### PR TITLE
miniweb: change -console to string

### DIFF
--- a/doc/content/articles/miniweb.article
+++ b/doc/content/articles/miniweb.article
@@ -29,8 +29,8 @@ preferably the head node. It has many flags, seen here:
 			create password file for auth
 	  -cert string
 			cert file for TLS in PEM format
-	  -console
-			enable console
+	  -console string
+			path to minimega to enable console (e.g. bin/minimega)
 	  -key string
 			key file for TLS in PEM format
 	  -level value
@@ -184,7 +184,7 @@ Each KVM VM can returns its current screenshot to `miniweb` via the
 
 * Console
 
-`miniweb` includes a minimega console via `/console`. It is disabled by default but
-can be enabled with the `-console` flag:
+`miniweb` includes a minimega console via `/console`. It is disabled by default
+but can be enabled with the `-console` flag:
 
-	$ miniweb -console
+	$ miniweb -console bin/minimega

--- a/src/miniweb/handlers.go
+++ b/src/miniweb/handlers.go
@@ -418,7 +418,7 @@ func tabularHandler(w http.ResponseWriter, r *http.Request) {
 func consoleHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/console" {
 		// create a new console
-		cmd := exec.Command("bin/minimega", "-attach")
+		cmd := exec.Command(*f_console, "-attach")
 
 		tty, err := pty.Start(cmd)
 		if err != nil {

--- a/src/miniweb/main.go
+++ b/src/miniweb/main.go
@@ -29,7 +29,7 @@ var (
 	f_base      = flag.String("base", defaultBase, "base path for minimega")
 	f_passwords = flag.String("passwords", "", "password file for auth")
 	f_bootstrap = flag.Bool("bootstrap", false, "create password file for auth")
-	f_console   = flag.Bool("console", false, "enable console and commands")
+	f_console   = flag.String("console", "", "path to minimega to enable console (e.g. bin/minimega)")
 	f_key       = flag.String("key", "", "key file for TLS in PEM format")
 	f_cert      = flag.String("cert", "", "cert file for TLS in PEM format")
 	f_namespace = flag.String("namespace", "", "limit miniweb to a namespace")
@@ -111,7 +111,7 @@ func main() {
 		})
 	}
 
-	if *f_console {
+	if *f_console != "" {
 		mux.HandleFunc("/console", mustAuth(consoleHandler))
 		mux.HandleFunc("/console/", mustAuth(consoleHandler))
 		mux.HandleFunc("/command", mustAuth(commandHandler))


### PR DESCRIPTION
Specify the path to minimega with -console to enable.

Fixes #1301