### PR TITLE
vmbetter: even better

### DIFF
--- a/misc/vmbetter_configs/minimal_ubuntu.conf
+++ b/misc/vmbetter_configs/minimal_ubuntu.conf
@@ -1,5 +1,5 @@
 // Example usage:
-// vmbetter -mbr /usr/lib/syslinux/mbr/mbr.bin -level debug -qcow -qcowsize 5G -branch bionic -mirror http://us.archive.ubuntu.com/ubuntu/ -debootstrap-append "--components=main,universe,restricted,multiverse" minimal_ubuntu.conf
+// vmbetter -level debug -disk -size 5G -branch bionic -mirror http://us.archive.ubuntu.com/ubuntu/ -debootstrap-append "--components=main,universe,restricted,multiverse" minimal_ubuntu.conf
 
 packages = "linux-image-generic linux-headers-generic initramfs-tools net-tools isc-dhcp-client openssh-server init iputils-ping vim less netbase curl ethtool rsync ifupdown dbus"
 

--- a/src/vmbetter/main.go
+++ b/src/vmbetter/main.go
@@ -25,9 +25,10 @@ var (
 	f_stage1        = flag.Bool("1", false, "stop after stage one, and copy build files to <config>_stage1")
 	f_stage2        = flag.String("2", "", "complete stage 2 from an existing stage 1 directory")
 	f_branch        = flag.String("branch", "testing", "debian branch to use")
-	f_qcow          = flag.Bool("qcow", false, "generate a qcow2 image instead of a kernel/initrd pair")
-	f_qcowsize      = flag.String("qcowsize", "1G", "qcow2 image size (eg 1G, 1024M)")
-	f_mbr           = flag.String("mbr", "/usr/lib/syslinux/mbr.bin", "path to mbr.bin if building qcow2 images")
+	f_disk          = flag.Bool("disk", false, "generate a disk image, use -format to set format")
+	f_diskSize      = flag.String("size", "1G", "disk image size (e.g. 1G, 1024M)")
+	f_format        = flag.String("format", "qcow2", "disk format to use when -disk is set")
+	f_mbr           = flag.String("mbr", "/usr/lib/syslinux/mbr/mbr.bin", "path to mbr.bin if building disk images")
 	f_iso           = flag.Bool("iso", false, "generate an ISO")
 	f_isolinux      = flag.String("isolinux", "misc/isolinux/", "path to a directory containing isolinux.bin, ldlinux.c32, and isolinux.cfg")
 	f_rootfs        = flag.Bool("rootfs", false, "generate a simple rootfs")
@@ -157,8 +158,8 @@ func main() {
 
 		// build the image file
 		fmt.Println("building target files")
-		if *f_qcow {
-			err = Buildqcow2(buildPath, config)
+		if *f_disk {
+			err = BuildDisk(buildPath, config)
 		} else if *f_iso {
 			err = BuildISO(buildPath, config)
 		} else if *f_rootfs {


### PR DESCRIPTION
Change -qcow to -disk and add the option to specify the disk format
(currently allows qcow, qcow2, raw, and vmdk). Rename -qcowsize to
-size. Change the default mbr location so that it matches debian.

Needs more testing.