### PR TITLE
various: fix .alias

### DIFF
--- a/src/miniclient/client.go
+++ b/src/miniclient/client.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -302,6 +303,8 @@ func (mm *Conn) Attach(namespace string) {
 		} else if err == io.EOF {
 			break
 		}
+
+		line = strings.TrimSpace(line)
 
 		log.Debug("got line from stdin: `%s`", line)
 

--- a/src/minimega/cli.go
+++ b/src/minimega/cli.go
@@ -442,6 +442,8 @@ func cliLocal(input *liner.State) {
 			break
 		}
 
+		line = strings.TrimSpace(line)
+
 		log.Debug("got line from stdin: `%v`", line)
 
 		// skip blank lines
@@ -450,6 +452,9 @@ func cliLocal(input *liner.State) {
 		}
 
 		input.AppendHistory(line)
+
+		// expand aliases
+		line = minicli.ExpandAliases(line)
 
 		cmd, err := minicli.Compile(line)
 		if err != nil {

--- a/src/minimega/command_socket.go
+++ b/src/minimega/command_socket.go
@@ -118,6 +118,8 @@ func commandSocketHandle(c net.Conn) {
 			continue
 		}
 
+		r.Command = minicli.ExpandAliases(r.Command)
+
 		// client specified a command
 		cmd, err = minicli.Compile(r.Command)
 		if err != nil {


### PR DESCRIPTION
Fix double expansion and only replace the first full word on a line.

Fixes #1360