### PR TITLE
Add -vlan flag to sub and edit

### DIFF
--- a/src/igor/edit.go
+++ b/src/igor/edit.go
@@ -18,8 +18,8 @@ The -r flag specifies the name of the reservation to edit.
 
 OPTIONAL FLAGS:
 
-See "igor sub" for the meanings of the -k, -i, -profile, and -c flags. As with
-"igor sub", the -profile flag takes precedence over the other flags.
+See "igor sub" for the meanings of the -k, -i, -profile, -vlan, and -c flags.
+As with "igor sub", the -profile flag takes precedence over the other flags.
 
 The -owner flag can be used to modify the reservation owner (admin only). If
 -owner is specified, all other edits are ignored.
@@ -39,6 +39,7 @@ func init() {
 	cmdEdit.Flag.StringVar(&subI, "i", "", "")
 	cmdEdit.Flag.StringVar(&subC, "c", "", "")
 	cmdEdit.Flag.StringVar(&subProfile, "profile", "", "")
+	cmdEdit.Flag.StringVar(&subVlan, "vlan", "", "")
 	cmdEdit.Flag.StringVar(&subOwner, "owner", "", "")
 	cmdEdit.Flag.StringVar(&subG, "g", "", "")
 }
@@ -149,6 +150,14 @@ func runEdit(cmd *Command, args []string) {
 		if r.KernelArgs != subC {
 			r2.KernelArgs = subC
 		}
+	}
+
+	if subVlan != "" {
+		vlanID, err := parseVLAN(subVlan)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		r2.Vlan = vlanID
 	}
 
 	// replace reservation with modified version

--- a/src/igor/reservations.go
+++ b/src/igor/reservations.go
@@ -93,11 +93,14 @@ func (r *Reservations) Install(res *Reservation) error {
 		return nil
 	}
 
-	// pick a network segment
-	if v, err := r.NextVLAN(); err != nil {
-		return fmt.Errorf("error setting network isolation: %v", err)
-	} else {
-		res.Vlan = v
+	// Vlan wasn't specified by flag
+	if res.Vlan == 0 {
+		// pick a network segment
+		if v, err := r.NextVLAN(); err != nil {
+			return fmt.Errorf("error setting network isolation: %v", err)
+		} else {
+			res.Vlan = v
+		}
 	}
 
 	// update network config
@@ -274,6 +277,16 @@ func (r *Reservations) Extend(res *Reservation, d time.Duration) error {
 
 	r.dirty = true
 	return nil
+}
+
+func (r *Reservations) UsingVLAN(vlan int) []*Reservation {
+	rs := []*Reservation{}
+	for _, res := range r.M {
+		if vlan == res.Vlan {
+			rs = append(rs, res)
+		}
+	}
+	return rs
 }
 
 func (r *Reservations) NextVLAN() (int, error) {

--- a/src/igor/sub.go
+++ b/src/igor/sub.go
@@ -57,7 +57,7 @@ The -a flag indicates that the reservation should take place on or after the
 specified time, given in the format "2017-Jan-2-15:04". Especially useful in
 conjunction with the -s flag.
 
-The -vlan flag gives the name of an existing reservation or a VLAN number.
+The -vlan flag specifies the name of an existing reservation or a VLAN number.
 If a reservation name is provided, the VLAN of the new reservation is set to
 the same VLAN as the specified reservation. If a VLAN number is provided, the
 new reservation is set to use the specified VLAN.`,

--- a/src/igor/sub.go
+++ b/src/igor/sub.go
@@ -55,7 +55,12 @@ slot.
 
 The -a flag indicates that the reservation should take place on or after the
 specified time, given in the format "2017-Jan-2-15:04". Especially useful in
-conjunction with the -s flag.`,
+conjunction with the -s flag.
+
+The -vlan flag gives the name of an existing reservation or a VLAN number.
+If a reservation name is provided, the VLAN of the new reservation is set to
+the same VLAN as the specified reservation. If a VLAN number is provided, the
+new reservation is set to use the specified VLAN.`,
 }
 
 var subR string       // -r flag
@@ -69,6 +74,7 @@ var subA string       // -a
 var subW string       // -w
 var subG string       // -g
 var subProfile string // -profile
+var subVlan string    // -vlan
 
 func init() {
 	// break init cycle
@@ -85,6 +91,7 @@ func init() {
 	cmdSub.Flag.StringVar(&subW, "w", "", "")
 	cmdSub.Flag.StringVar(&subG, "g", "", "")
 	cmdSub.Flag.StringVar(&subProfile, "profile", "", "")
+	cmdSub.Flag.StringVar(&subVlan, "vlan", "", "")
 }
 
 func runSub(cmd *Command, args []string) {
@@ -136,6 +143,16 @@ func runSub(cmd *Command, args []string) {
 		if !cobblerProfiles[subProfile] {
 			log.Fatal("Cobbler profile does not exist: %v", subProfile)
 		}
+	}
+
+	// Check VLAN Availablility
+	if subVlan != "" {
+		vlan, err := parseVLAN(subVlan)
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		r.Vlan = vlan
 	}
 
 	// Make sure there's not already a reservation with this name


### PR DESCRIPTION
Allows users to specify which VLAN they'd like a reservation to connect to. The value of `-vlan` can be:

- the name of another reservation (`string`)
    - The specified reservation must be writable by the current user
    -  The new reservation uses the same VLAN as the existing one
-  a VLAN ID (`int`)
    - ... As long as the specified VLAN ID is not in use by any other reservation, or the VLAN ID is used by at least one existing reservation that is writable for the current user.
    - The VLAN ID must be in the range specified by igor's config

If `-vlan` is not provided, igor determines a VLAN ID as usual.

`-vlan` can be specified for `sub` and `edit`