### PR TITLE
Fix #1373 broken containers on newer distros.

### DIFF
--- a/src/bridge/container.go
+++ b/src/bridge/container.go
@@ -37,7 +37,7 @@ func (b *Bridge) CreateContainerTap(tap, ns, mac string, vlan, index int) (strin
 
 	var created bool
 
-	err := createVeth(tap, ns)
+	err := createVeth(tap, iface, ns)
 	if err == nil {
 		created = true
 		err = upInterface(tap, false)

--- a/src/bridge/ip.go
+++ b/src/bridge/ip.go
@@ -55,18 +55,18 @@ func createTap(name string) error {
 }
 
 // createVeth creates a veth of the specified name using the `ip` command.
-func createVeth(name, netnsname string) error {
-	log.Debug("creating veth: %v %v", name, netnsname)
+func createVeth(tap, name, netnsname string) error {
+	log.Debug("creating veth: %v on %v in netns %v", name, tap, netnsname)
 
 	args := []string{
 		"ip",
 		"link",
 		"add",
-		name,
+		tap,
 		"type",
 		"veth",
 		"peer",
-		"mega", // does the namespace ignore this?
+		name,
 		"netns",
 		netnsname,
 	}

--- a/src/bridge/process.go
+++ b/src/bridge/process.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	log "minilog"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -28,7 +29,7 @@ func processWrapper(args ...string) (string, error) {
 	start := time.Now()
 	out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
 	stop := time.Now()
-	log.Debug("cmd %v completed in %v", args[0], stop.Sub(start))
+	log.Debug("cmd \"%v\" completed in %v, output below:\n %v", strings.Join(args, " "), stop.Sub(start), string(out))
 
 	return string(out), err
 }


### PR DESCRIPTION
On newer distros, `ip link add` actually respects the iface name given within the container netns now, whereas it didn't before and just gave the vethX as expected.

