### PR TITLE
igor: Don't uninstall / clear network settings when deleting future reservation

### DIFF
--- a/src/igor/reservations.go
+++ b/src/igor/reservations.go
@@ -142,14 +142,17 @@ func (r *Reservations) Delete(id uint64) error {
 		return errors.New("invalid reservation ID")
 	}
 
-	// clean up the network config
-	if err := networkClear(res.Hosts); err != nil {
-		return fmt.Errorf("error clearing network isolation: %v", err)
-	}
+	// Only clear network and uninstall if this is an active, installed reservation
+	if res.IsActive(igor.Now) && res.Installed {
+		// clean up the network config
+		if err := networkClear(res.Hosts); err != nil {
+			return fmt.Errorf("error clearing network isolation: %v", err)
+		}
 
-	// unset cobbler or TFTP configuration
-	if err := igor.Uninstall(res); err != nil {
-		return fmt.Errorf("unable to uninstall reservation: %v", err)
+		// unset cobbler or TFTP configuration
+		if err := igor.Uninstall(res); err != nil {
+			return fmt.Errorf("unable to uninstall reservation: %v", err)
+		}
 	}
 
 	// We use this to indicate if a reservation has been created or not


### PR DESCRIPTION
Fixes an issue where deleting future reservations clobbers network settings for active reservations.