### PR TITLE
minimega: specify `flush` target

### DIFF
--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -209,7 +209,7 @@ func (n *Namespace) Destroy() error {
 
 	// Kill and flush all the VMs
 	n.Kill(Wildcard)
-	n.Flush(n.ccServer)
+	n.FlushAll(n.ccServer)
 
 	// Stop ron server
 	n.ccServer.Destroy()

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -185,7 +185,7 @@ Calling stop will put VMs in a paused state. Use "vm start" to restart them.`,
 	{ // vm flush
 		HelpShort: "discard information about quit or failed VMs",
 		HelpLong: `
-Flush one or more running virtual machines. Discard information about VMs that
+Flush one or more virtual machines. Discard information about VMs that
 have either quit or encountered an error. This will remove VMs with a state of
 "quit" or "error" from vm info. Names of VMs that have been flushed may be
 reused.
@@ -196,8 +196,8 @@ target. See "vm start" for a full description of allowable targets.`,
 			"vm <flush,>",
 			"vm <flush,> <vm target>",
 		},
-		Call: wrapBroadcastCLI(cliVMApply),
-		Suggest: wrapVMSuggest((VM_QUIT|VM_ERROR), true),
+		Call:    wrapBroadcastCLI(cliVMApply),
+		Suggest: wrapVMSuggest((VM_QUIT | VM_ERROR), true),
 	},
 	{ // vm hotplug
 		HelpShort: "add and remove USB drives",
@@ -464,7 +464,7 @@ func cliVMApply(ns *Namespace, c *minicli.Command, resp *minicli.Response) error
 	case c.BoolArgs["kill"]:
 		return ns.VMs.Kill(c.StringArgs["vm"])
 	case c.BoolArgs["flush"]:
-		if (len(c.StringArgs["vm"]) == 0) {
+		if len(c.StringArgs["vm"]) == 0 {
 			return ns.VMs.FlushAll(ns.ccServer)
 		} else {
 			return ns.VMs.Flush(c.StringArgs["vm"], ns.ccServer)

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -185,13 +185,19 @@ Calling stop will put VMs in a paused state. Use "vm start" to restart them.`,
 	{ // vm flush
 		HelpShort: "discard information about quit or failed VMs",
 		HelpLong: `
-Discard information about VMs that have either quit or encountered an error.
-This will remove any VMs with a state of "quit" or "error" from vm info. Names
-of VMs that have been flushed may be reused.`,
+Flush one or more running virtual machines. Discard information about VMs that
+have either quit or encountered an error. This will remove VMs with a state of
+"quit" or "error" from vm info. Names of VMs that have been flushed may be
+reused.
+
+Note running without arguments results in the same behavior as using the "all"
+target. See "vm start" for a full description of allowable targets.`,
 		Patterns: []string{
 			"vm <flush,>",
+			"vm <flush,> <vm target>",
 		},
 		Call: wrapBroadcastCLI(cliVMApply),
+		Suggest: wrapVMSuggest((VM_QUIT|VM_ERROR), true),
 	},
 	{ // vm hotplug
 		HelpShort: "add and remove USB drives",
@@ -458,7 +464,11 @@ func cliVMApply(ns *Namespace, c *minicli.Command, resp *minicli.Response) error
 	case c.BoolArgs["kill"]:
 		return ns.VMs.Kill(c.StringArgs["vm"])
 	case c.BoolArgs["flush"]:
-		return ns.VMs.Flush(ns.ccServer)
+		if (len(c.StringArgs["vm"]) == 0) {
+			return ns.VMs.FlushAll(ns.ccServer)
+		} else {
+			return ns.VMs.Flush(c.StringArgs["vm"], ns.ccServer)
+		}
 	}
 
 	return unreachable()

--- a/tests/vm_lifecycle
+++ b/tests/vm_lifecycle
@@ -22,3 +22,11 @@ vm flush
 vm kill all
 vm flush
 .columns name,state vm info
+vm launch kvm foo[0-2]
+.columns name,state vm info
+vm kill foo0
+vm flush foo0
+.columns name,state vm info
+vm kill all
+vm flush all
+.columns name,state vm info

--- a/tests/vm_lifecycle.want
+++ b/tests/vm_lifecycle.want
@@ -61,3 +61,18 @@ foo2 | RUNNING
 ## vm kill all
 ## vm flush
 ## .columns name,state vm info
+## vm launch kvm foo[0-2]
+## .columns name,state vm info
+name | state
+foo0 | BUILDING
+foo1 | BUILDING
+foo2 | BUILDING
+## vm kill foo0
+## vm flush foo0
+## .columns name,state vm info
+name | state
+foo1 | BUILDING
+foo2 | BUILDING
+## vm kill all
+## vm flush all
+## .columns name,state vm info


### PR DESCRIPTION
- Changed 'all' VM flush method to 'FlushAll()'.
- Created new 'Flush()' method that uses the 'Apply' method to flush a specified target.
- Updated help strings to reflect enhancement.
- Backwards compatible with old `vm flush` behavior

Resolves https://github.com/sandia-minimega/minimega/issues/1392