### PR TITLE
igor: add detail to log

### DIFF
--- a/src/igor/power.go
+++ b/src/igor/power.go
@@ -95,8 +95,11 @@ func runPower(cmd *Command, args []string) {
 			log.Fatal("insufficient privileges to power %v reservation: %v", action, powerR)
 		}
 
+		// Detailed logging is happening in runner
 		fmt.Printf("Powering %s reservation %s\n", action, powerR)
-		doPower(r.Hosts, action)
+		if err := doPower(r.Hosts, action); err != nil {
+			log.Error("Error running power command: %v", err)
+		}
 		return
 	}
 
@@ -118,6 +121,9 @@ func runPower(cmd *Command, args []string) {
 		}
 	}
 
+	// Detailed logging is happening in runner
 	fmt.Printf("Powering %s nodes %s\n", action, powerN)
-	doPower(nodes, action)
+	if err := doPower(nodes, action); err != nil {
+		log.Error("Error running power command: %v", err)
+	}
 }

--- a/src/igor/power.go
+++ b/src/igor/power.go
@@ -95,7 +95,7 @@ func runPower(cmd *Command, args []string) {
 			log.Fatal("insufficient privileges to power %v reservation: %v", action, powerR)
 		}
 
-		// Detailed logging is happening in runner
+		// Detailed logging is happening in external
 		fmt.Printf("Powering %s reservation %s\n", action, powerR)
 		if err := doPower(r.Hosts, action); err != nil {
 			log.Error("Error running power command: %v", err)
@@ -121,7 +121,7 @@ func runPower(cmd *Command, args []string) {
 		}
 	}
 
-	// Detailed logging is happening in runner
+	// Detailed logging is happening in external
 	fmt.Printf("Powering %s nodes %s\n", action, powerN)
 	if err := doPower(nodes, action); err != nil {
 		log.Error("Error running power command: %v", err)


### PR DESCRIPTION
We were dropping the error that comes back from doPower without logging. I suspect this is because any errors that may have come back from the external run of the executed power command would be handled and logged by external.go. However, out of an abundance of caution, I'm logging those errors and noting where we log upstream.