### PR TITLE
minimega.namespace_cli: don't use loopback addresses for GRE tunnels

### DIFF
--- a/src/minimega/namespace_cli.go
+++ b/src/minimega/namespace_cli.go
@@ -429,12 +429,17 @@ func cliNamespaceBridge(ns *Namespace, c *minicli.Command, resp *minicli.Respons
 		if err != nil {
 			return fmt.Errorf("failure looking up %v: %v", host, err)
 		}
-
-		if len(res) >= 1 {
-			// probably fine to use the first?
-			ips[host] = res[0].String()
-		} else if len(res) == 0 {
-			return errors.New("host has no IP")
+		// track whether we found a non-loopback IP address
+		foundIP := false
+		for _, element := range res {
+			if !element.IsLoopback() {
+				foundIP = true
+				ips[host] = element.String()
+				break
+			}
+		}
+		if !foundIP {
+			return errors.New("host has no non-loopback IP")
 		}
 	}
 


### PR DESCRIPTION
This prohibits loopback addresses from being used as endpoints in bridges in cliNamespaceBridge in minimega.namespace_cli.go.