### PR TITLE
igor: extend clarification

### DIFF
--- a/src/igor/config.go
+++ b/src/igor/config.go
@@ -171,7 +171,7 @@ func (c Config) checkTimeLimit(nodes int, d time.Duration) error {
 	}
 
 	if d > max {
-		return fmt.Errorf("max allowable duration for %v nodes is %v (you requested %v)", nodes, max, d)
+		return fmt.Errorf("max allowable duration for %v nodes is %v, you requested %v", nodes, max, d)
 	}
 
 	return nil

--- a/src/igor/config_test.go
+++ b/src/igor/config_test.go
@@ -23,19 +23,17 @@ func TestCheckTimeLimit(t *testing.T) {
 		t.Errorf("err != nil: %v", err)
 	}
 
-	c.TimeLimit = 100
-	if err := c.checkTimeLimit(10, 10*time.Minute); err != nil {
-		t.Errorf("err != nil: %v", err)
-	}
-
-	c.TimeLimit = 10
 	if err := c.checkTimeLimit(10, 10*time.Minute); err == nil {
 		t.Errorf("err == nil: %v", err)
 	}
 
-	c.TimeLimit = 10
 	if err := c.checkTimeLimit(100, 10*time.Minute); err == nil {
 		t.Errorf("err == nil: %v", err)
+	}
+
+	c.TimeLimit = 100
+	if err := c.checkTimeLimit(10, 10*time.Minute); err != nil {
+		t.Errorf("err != nil: %v", err)
 	}
 }
 

--- a/src/igor/extend.go
+++ b/src/igor/extend.go
@@ -63,8 +63,9 @@ func runExtend(cmd *Command, args []string) {
 
 	if igor.Username != "root" {
 		// Make sure the reservation doesn't exceed any limits
-		if err := igor.checkTimeLimit(len(r.Hosts), r.Remaining(igor.Now)+duration); err != nil {
-			log.Fatalln(err)
+		remainingResDuration := r.Remaining(igor.Now)
+		if err := igor.checkTimeLimit(len(r.Hosts), remainingResDuration+duration); err != nil {
+			log.Fatalln(err, " (%v + %v minutes remaining in your reservation.)", duration, remainingResDuration)
 		}
 
 		// Make sure that the user is extending a reservation that is near its


### PR DESCRIPTION
Clarifying logs for extend when duration exceeds limits. Before, the message indicated that the user request more time than specified in their command because we were adding it to the time remaining in their reservation.

Now, we specify that the requested time, plus the time remaining, is what exceeds the limit.