### PR TITLE
minimega: use "actual path" from qemu-img for backing image if present

### DIFF
--- a/src/minimega/disk.go
+++ b/src/minimega/disk.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -113,6 +114,8 @@ func diskInfo(image string) (DiskInfo, error) {
 		return info, fmt.Errorf("%v: %v", out, err)
 	}
 
+	regex := regexp.MustCompile(`.*\(actual path: (.*)\)`)
+
 	for _, line := range strings.Split(out, "\n") {
 		parts := strings.SplitN(line, ": ", 2)
 		if len(parts) != 2 {
@@ -127,7 +130,13 @@ func diskInfo(image string) (DiskInfo, error) {
 		case "disk size":
 			info.DiskSize = parts[1]
 		case "backing file":
-			info.BackingFile = parts[1]
+			// In come cases, `qemu-img info` includes the actual absolute path for
+			// the backing image. We want to use that, if present.
+			if match := regex.FindStringSubmatch(parts[1]); match != nil {
+				info.BackingFile = match[1]
+			} else {
+				info.BackingFile = parts[1]
+			}
 		}
 	}
 


### PR DESCRIPTION
If you run `qemu-img info` in the same directory as the image your passing to it, then the `(actual path: ...)` stuff isn't included in the output. However, if you run `qemu-img info` from a different directory, or you pass the absolute path of the image to `qemu-img info`, then the `(actual path: ...)` stuff is present. Minimega always passes the full path of a disk image to `qemu-img info`.

As an aside, I'm not sure if this is new functionality in a more recent version of `qemu-img` (I have the following version of `qemu-utils` installed: `focal-updates,focal-security,now 1:4.2-3ubuntu6.10`).