### PR TITLE
minimega: include image name partition not found error for disk injections

### DIFF
--- a/src/minimega/disk.go
+++ b/src/minimega/disk.go
@@ -228,9 +228,9 @@ func diskInject(dst, partition string, pairs map[string]string, options []string
 		// check desired partition exists
 		_, err = os.Stat(path)
 		if err != nil {
-			return fmt.Errorf("desired partition %s not found", partition)
+			return fmt.Errorf("desired partition %s not found in image %s", partition, dst)
 		} else {
-			log.Info("desired partition %s found", partition)
+			log.Info("desired partition %s found in image %s", partition, dst)
 		}
 	}
 


### PR DESCRIPTION
Many times, reading in a large script file will result in an error similar to the following:

```
desired partition 1 not found
```

Debugging this is difficult since no additional details are reported. This PR includes the name of the disk image being operated on.