### PR TITLE
minimega: Enhance ns snapshot

### DIFF
--- a/doc/content/articles/namespaces.article
+++ b/doc/content/articles/namespaces.article
@@ -287,14 +287,36 @@ namespace.
 
 ** Snapshot
 
-Namespaces are working towards a full snapshot of a running experiment. This
-capability is partially implemented in the `ns`snapshot` API. This API records
-a minimega script to relaunch the running VMs and calls `vm`migrate` on each VM
-to capture its memory. The resulting migration files are added to the minimega
-script using the `vm`config`migrate` API. This snapshot capability should work
-for VMs with a kernel/initrd but not for VMs with a disk.
+The `ns`snapshot` API can be used to take a full snapshot of a running
+experiment. This API first pauses all VMs in the experiment and then calls
+`vm`snapshot` on each VM to capture both its memory and disk state as separate
+files. In addition, the command records a minimega script to relaunch the
+running VMs using the saved disk and memory files via the `vm`config`migrate`
+and `vm`config`disk` APIs. This snapshot capability will work for both KVM and
+container type VMs. For KVMs without a disk (kernel/initrd), only the memory
+state is saved. For containers, no state is saved -- the vm config is simply
+copied to the relaunch script.
 
-In future releases, we plan to expand upon this capability.
+The state files and relaunch script are saved in a user-specified subdirectory:
+
+    <minimega filepath>/snapshots/<name>/vm1.hdd
+    <minimega filepath>/snapshots/<name>/vm1.migrate
+    <minimega filepath>/snapshots/<name>/vm2.hdd
+    <minimega filepath>/snapshots/<name>/vm2.migrate
+    ...
+    <minimega filepath>/snapshots/<name>/launch.mm
+
+Notes: This command will block until VMs have completed the disk save portion
+of the snapshot. After that, the memory save portion will continue to run in
+the background until finished. Progress can be monitored by running
+`ns`snapshot` or `vm`snapshot` without arguments. This command does not
+restart any VMs after the snapshot, so they will be left in a paused state. The
+snapshotted experiment can be restarted using the `read` command and passing it
+the generated minimega script.
+
+Warning: The process of saving both disk and memory state for an entire
+experiment can result in large files created on the host filesystem. Before
+running, verify there is enough storage available.
 
 ** vm API
 

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -472,6 +472,12 @@ func (vm *KvmVM) QMPRaw(input string) (string, error) {
 }
 
 func (vm *KvmVM) Save(filename string) error {
+	// skip save if using kernel/initrd or cdrom as boot device
+	if len(vm.KVMConfig.Disks) == 0 {
+		log.Warn("Skipping kvm disk save for non-disk VM: %v", vm.Name)
+		return nil
+	}
+
 	if !filepath.IsAbs(filename) {
 		filename = filepath.Join(*f_iomBase, filename)
 	}

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bridge"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -219,6 +220,20 @@ type KvmVM struct {
 	// the virtual serial port was opened client-side, and `false` if it was
 	// closed client-side. Used to handle miniccc restarts in the client.
 	vSerPortOpenEvent chan bool
+}
+
+type BlockDevice struct {
+	Device   string `json:"device"`
+	Inserted *struct {
+		File string `json:"file"`
+	} `json:"inserted"`
+}
+
+type BlockDeviceJobs struct {
+	Device string `json:"device"`
+	Status int    `json:"io-status"`
+	Length int    `json:"len"`
+	Offset int    `json:"offset"`
 }
 
 // Ensure that KvmVM implements the VM interface
@@ -454,6 +469,52 @@ func (vm *KVMConfig) DiskString(namespace string) string {
 
 func (vm *KvmVM) QMPRaw(input string) (string, error) {
 	return vm.q.Raw(input)
+}
+
+func (vm *KvmVM) Save(filename string) error {
+	if !filepath.IsAbs(filename) {
+		filename = filepath.Join(*f_iomBase, filename)
+	}
+
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	fp := fmt.Sprintf("%s/%s", *f_base, strconv.Itoa(vm.ID))
+
+	r, err := vm.q.QueryBlock()
+	if err != nil {
+		return err
+	}
+
+	rString, err := json.Marshal(r)
+	var v []BlockDevice
+	json.Unmarshal(rString, &v)
+
+	// find the device name
+	var device string
+	for _, dev := range v {
+		if dev.Inserted != nil {
+			if strings.HasPrefix(dev.Inserted.File, fp) {
+				device = dev.Device
+				break
+			}
+		}
+	}
+
+	err = vm.q.SaveDisk(filename, device)
+	if err != nil {
+		return err
+	}
+
+	// wait for drive-backup to finish
+	for {
+		if r, _ := vm.q.QueryBlockJobs(); len(r) == 0 {
+			break
+		}
+		time.Sleep(time.Second * 1)
+	}
+
+	return err
 }
 
 func (vm *KvmVM) Migrate(filename string) error {

--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -733,15 +733,21 @@ func (n *Namespace) Snapshot(dir string) error {
 			return err
 		}
 
-		// override the migrate and disk paths
+		// override the migrate and disk paths;
+		// skip disk if using kernel/initrd or cdrom as boot device
+		disks, _ := vm.Info("disks")
 		if useIOM {
 			rel, _ := filepath.Rel(*f_iomBase, stateDst)
 			fmt.Fprintf(f, "vm config migrate file:%v\n", rel)
-			rel, _ = filepath.Rel(*f_iomBase, diskDst)
-			fmt.Fprintf(f, "vm config disk file:%v\n", rel)
+			if disks != "" {
+				rel, _ = filepath.Rel(*f_iomBase, diskDst)
+				fmt.Fprintf(f, "vm config disk file:%v\n", rel)
+			}
 		} else {
 			fmt.Fprintf(f, "vm config migrate %v\n", stateDst)
-			fmt.Fprintf(f, "vm config disk %v\n", diskDst)
+			if disks != "" {
+				fmt.Fprintf(f, "vm config disk %v\n", diskDst)
+			}
 		}
 
 		fmt.Fprintf(f, "vm launch %v %q\n\n", vm.GetType(), vm.GetName())

--- a/src/minimega/namespace.go
+++ b/src/minimega/namespace.go
@@ -761,7 +761,7 @@ func (n *Namespace) Snapshot(dir string) error {
 				}
 			}
 		} else if vm.GetType() == CONTAINER {
-			log.Warn("Skipping snapshot for container: %q\n", vm.GetName(), err)
+			log.Warn("Skipping snapshot for container: %q\n", vm.GetName())
 			fmt.Fprintf(f, "clear vm config\n")
 
 			if err := vm.WriteConfig(f); err != nil {

--- a/src/minimega/vmconfiger_cli.go
+++ b/src/minimega/vmconfiger_cli.go
@@ -990,15 +990,9 @@ func (v *BaseConfig) WriteConfig(w io.Writer) error {
 	if v.UUID != "" {
 		fmt.Fprintf(w, "vm config uuid %v\n", v.UUID)
 	}
-	if v.VCPUs != 1 {
-		fmt.Fprintf(w, "vm config vcpus %v\n", v.VCPUs)
-	}
-	if v.Memory != 2048 {
-		fmt.Fprintf(w, "vm config memory %v\n", v.Memory)
-	}
-	if v.Snapshot != true {
+	fmt.Fprintf(w, "vm config vcpus %v\n", v.VCPUs)
+	fmt.Fprintf(w, "vm config memory %v\n", v.Memory)
 		fmt.Fprintf(w, "vm config snapshot %t\n", v.Snapshot)
-	}
 	if v.Schedule != "" {
 		fmt.Fprintf(w, "vm config schedule %v\n", v.Schedule)
 	}

--- a/src/minimega/vmconfiger_cli.go
+++ b/src/minimega/vmconfiger_cli.go
@@ -992,7 +992,7 @@ func (v *BaseConfig) WriteConfig(w io.Writer) error {
 	}
 	fmt.Fprintf(w, "vm config vcpus %v\n", v.VCPUs)
 	fmt.Fprintf(w, "vm config memory %v\n", v.Memory)
-		fmt.Fprintf(w, "vm config snapshot %t\n", v.Snapshot)
+	fmt.Fprintf(w, "vm config snapshot %t\n", v.Snapshot)
 	if v.Schedule != "" {
 		fmt.Fprintf(w, "vm config schedule %v\n", v.Schedule)
 	}

--- a/src/qmp/qmp.go
+++ b/src/qmp/qmp.go
@@ -329,7 +329,7 @@ func (q *Conn) SaveDisk(path, device string) error {
 	}
 	v := <-q.messageSync
 	if !success(v) {
-		return errors.New("save")
+		return errors.New("error in qmp SaveDisk")
 	}
 	return nil
 }

--- a/src/qmp/qmp.go
+++ b/src/qmp/qmp.go
@@ -311,6 +311,29 @@ func (q *Conn) Screendump(path string) error {
 	return nil
 }
 
+func (q *Conn) SaveDisk(path, device string) error {
+	if !q.ready {
+		return ERR_READY
+	}
+	s := map[string]interface{}{
+		"execute": "drive-backup",
+		"arguments": map[string]interface{}{
+			"device": device,
+			"sync":   "top",
+			"target": path,
+		},
+	}
+	err := q.write(s)
+	if err != nil {
+		return err
+	}
+	v := <-q.messageSync
+	if !success(v) {
+		return errors.New("save")
+	}
+	return nil
+}
+
 func (q *Conn) MigrateDisk(path string) error {
 	if !q.ready {
 		return ERR_READY
@@ -350,6 +373,45 @@ func (q *Conn) QueryMigrate() (map[string]interface{}, error) {
 		return nil, errors.New("received nil status")
 	}
 	return status.(map[string]interface{}), nil
+}
+
+func (q *Conn) QueryBlock() ([]interface{}, error) {
+	if !q.ready {
+		return nil, ERR_READY
+	}
+	s := map[string]interface{}{
+		"execute": "query-block",
+	}
+	err := q.write(s)
+	if err != nil {
+		return nil, err
+	}
+	v := <-q.messageSync
+	status := v["return"]
+	if status == nil {
+		return nil, errors.New("received nil status")
+	}
+	return status.([]interface{}), nil
+}
+
+func (q *Conn) QueryBlockJobs() ([]interface{}, error) {
+	if !q.ready {
+		return nil, ERR_READY
+	}
+	s := map[string]interface{}{
+		"execute": "query-block-jobs",
+	}
+	err := q.write(s)
+	if err != nil {
+		return nil, err
+	}
+	v := <-q.messageSync
+
+	status := v["return"]
+	if status == nil {
+		return nil, errors.New("received nil status")
+	}
+	return status.([]interface{}), nil
 }
 
 func (q *Conn) HumanMonitorCommand(command string) (string, error) {

--- a/tests/ns_snapshot
+++ b/tests/ns_snapshot
@@ -1,0 +1,44 @@
+# Enter the matrix
+namespace matrix
+
+# Create disk image
+disk create qcow2 morpheus.qcow2 512M
+
+# Launch some VMs to snapshot
+vm config disk morpheus.qcow2
+vm launch kvm neo[1-2]
+vm config vcpus 2
+vm config memory 2048
+vm launch kvm trinity
+clear vm config
+# Launch a VM without a disk
+vm launch kvm mouse
+
+# Copy the matrix
+ns snapshot matrix
+
+# Check that the snapshots completed after a quick nap
+shell sleep 1
+.column name,status vm snapshot
+
+# Check for the files on disk
+.filter name=snapshots/matrix/launch.mm .column dir,name file list snapshots/matrix/
+.filter name=snapshots/matrix/neo1.migrate .column dir,name file list snapshots/matrix/
+.filter name=snapshots/matrix/neo1.hdd .column dir,name file list snapshots/matrix/
+.filter name=snapshots/matrix/neo2.migrate .column dir,name file list snapshots/matrix/
+.filter name=snapshots/matrix/neo2.hdd .column dir,name file list snapshots/matrix/
+.filter name=snapshots/matrix/trinity.migrate .column dir,name file list snapshots/matrix/
+.filter name=snapshots/matrix/trinity.hdd .column dir,name file list snapshots/matrix/
+.filter name=snapshots/matrix/mouse.migrate .column dir,name file list snapshots/matrix/
+# mouse died :(
+.filter name=snapshots/matrix/mouse.hdd .column dir,name file list snapshots/matrix/
+
+# Check for VM state
+.column name,state vm info
+
+# Clean up
+file delete morpheus.qcow2
+file delete snapshots/matrix/
+
+# Escape the matrix
+clear namespace matrix

--- a/tests/ns_snapshot.want
+++ b/tests/ns_snapshot.want
@@ -1,0 +1,70 @@
+## # Enter the matrix
+## namespace matrix
+
+## # Create disk image
+## disk create qcow2 morpheus.qcow2 512M
+
+## # Launch some VMs to snapshot
+## vm config disk morpheus.qcow2
+## vm launch kvm neo[1-2]
+## vm config vcpus 2
+## vm config memory 2048
+## vm launch kvm trinity
+## clear vm config
+## # Launch a VM without a disk
+## vm launch kvm mouse
+
+## # Copy the matrix
+## ns snapshot matrix
+
+## # Check that the snapshots completed after a quick nap
+## shell sleep 1
+## .column name,status vm snapshot
+name    | status
+mouse   | completed
+neo1    | completed
+neo2    | completed
+trinity | completed
+
+## # Check for the files on disk
+## .filter name=snapshots/matrix/launch.mm .column dir,name file list snapshots/matrix/
+dir  | name
+     | snapshots/matrix/launch.mm
+## .filter name=snapshots/matrix/neo1.migrate .column dir,name file list snapshots/matrix/
+dir  | name
+     | snapshots/matrix/neo1.migrate
+## .filter name=snapshots/matrix/neo1.hdd .column dir,name file list snapshots/matrix/
+dir  | name
+     | snapshots/matrix/neo1.hdd
+## .filter name=snapshots/matrix/neo2.migrate .column dir,name file list snapshots/matrix/
+dir  | name
+     | snapshots/matrix/neo2.migrate
+## .filter name=snapshots/matrix/neo2.hdd .column dir,name file list snapshots/matrix/
+dir  | name
+     | snapshots/matrix/neo2.hdd
+## .filter name=snapshots/matrix/trinity.migrate .column dir,name file list snapshots/matrix/
+dir  | name
+     | snapshots/matrix/trinity.migrate
+## .filter name=snapshots/matrix/trinity.hdd .column dir,name file list snapshots/matrix/
+dir  | name
+     | snapshots/matrix/trinity.hdd
+## .filter name=snapshots/matrix/mouse.migrate .column dir,name file list snapshots/matrix/
+dir  | name
+     | snapshots/matrix/mouse.migrate
+## # mouse died :(
+## .filter name=snapshots/matrix/mouse.hdd .column dir,name file list snapshots/matrix/
+
+## # Check for VM state
+## .column name,state vm info
+name    | state
+mouse   | PAUSED
+neo1    | PAUSED
+neo2    | PAUSED
+trinity | PAUSED
+
+## # Clean up
+## file delete morpheus.qcow2
+## file delete snapshots/matrix/
+
+## # Escape the matrix
+## clear namespace matrix

--- a/tests/vm_snapshot
+++ b/tests/vm_snapshot
@@ -1,0 +1,32 @@
+# Create disk image
+disk create qcow2 foo.qcow2 512M
+
+# Launch a couple VMs to snapshot
+vm config disk foo.qcow2
+vm launch kvm foo
+clear vm config
+vm launch kvm foo-no-disk
+
+# Dump migration and disk state files
+vm snapshot foo foo.migrate foo.hdd
+vm snapshot foo-no-disk foo-nd.migrate foo-nd.hdd
+
+# Check that the snapshots completed after a quick nap
+shell sleep 1
+.column name,status vm snapshot
+
+# Check for the files on disk
+.filter name=foo.migrate .column dir,name file list
+.filter name=foo.hdd .column dir,name file list
+.filter name=foo-nd.migrate .column dir,name file list
+# This one shouldn't exist
+.filter name=foo-nd.hdd .column dir,name file list
+
+# Check for VM state
+.column name,state vm info
+
+# Clean up
+file delete foo.migrate
+file delete foo.hdd
+file delete foo-nd.migrate
+file delete foo.qcow2

--- a/tests/vm_snapshot.want
+++ b/tests/vm_snapshot.want
@@ -1,0 +1,44 @@
+## # Create disk image
+## disk create qcow2 foo.qcow2 512M
+
+## # Launch a couple VMs to snapshot
+## vm config disk foo.qcow2
+## vm launch kvm foo
+## clear vm config
+## vm launch kvm foo-no-disk
+
+## # Dump migration and disk state files
+## vm snapshot foo foo.migrate foo.hdd
+## vm snapshot foo-no-disk foo-nd.migrate foo-nd.hdd
+
+## # Check that the snapshots completed after a quick nap
+## shell sleep 1
+## .column name,status vm snapshot
+name        | status
+foo         | completed
+foo-no-disk | completed
+
+## # Check for the files on disk
+## .filter name=foo.migrate .column dir,name file list
+dir  | name
+     | foo.migrate
+## .filter name=foo.hdd .column dir,name file list
+dir  | name
+     | foo.hdd
+## .filter name=foo-nd.migrate .column dir,name file list
+dir  | name
+     | foo-nd.migrate
+## # This one shouldn't exist
+## .filter name=foo-nd.hdd .column dir,name file list
+
+## # Check for VM state
+## .column name,state vm info
+name        | state
+foo         | PAUSED
+foo-no-disk | PAUSED
+
+## # Clean up
+## file delete foo.migrate
+## file delete foo.hdd
+## file delete foo-nd.migrate
+## file delete foo.qcow2


### PR DESCRIPTION
Closes #1309 

- Adds disk state save to `ns snapshot` command
- For each VM:
  - First the disk state is saved using the `drive-backup` qmp command (__*BLOCKS until finished; later plans to implement goroutine for this*__)
  - Next the rest of the VM state is saved using the normal `migrate`
- Addresses issue in #1445 by explicitly pausing all VMs as before proceeding with the snapshot