### PR TITLE
RKVM

### DIFF
--- a/doc/content/articles/vmtypes.article
+++ b/doc/content/articles/vmtypes.article
@@ -5,10 +5,10 @@ The minimega authors
 
 * Introduction
 
-This document describes the two virtual machine (VM) types minimega is capable
-of launching - QEMU/KVM virtual machines and containers. minimega uses a common
-API to describe features and supports launching experiments consisting of both
-types of VM.
+This document describes the various virtual machine (VM) types minimega is capable
+of launching - QEMU/KVM virtual machines, containers, and RKVM. Minimega uses 
+a common API to describe features and supports launching experiments consisting 
+of multiple types of VM.
 
 * A quick example
 
@@ -188,3 +188,41 @@ To better work with systemd-based systems, minimega requires the cgroup hierarch
 	mount -t cgroup cgroup -o memory /sys/fs/cgroup/memory
 	mount -t cgroup cgroup -o freezer /sys/fs/cgroup/freezer
 	mount -t cgroup cgroup -o devices /sys/fs/cgroup/devices
+
+** RKVM Remote Keyboard Video Mouse 
+
+minimega supports booting `rkvm` type VMs by using a vnc interface. When launching
+`rkvm` type VMs, minimega will use the configuration provided in the `vm`config`
+API.
+
+*** RKVM-specific configuration parameters
+
+Most `vm config` parameters are common to all VM types, however since RKVM
+does not actually build a VM but rather an interface only a few specfic 
+parameters apply. See the[[/articles/api.article][minimega API]] for 
+documentation on specific configuration parameters.
+
+Configuration parameters specific to `RKVM` instances:
+
+- `vnc_host` - Configure the hostname or ip address that hosts the vnc interface
+- `vnc_port` - Configure the tcp port that hosts the vnc interface
+
+*** Example
+
+.mega vmtypes/example2.mm
+
+*** Technical details
+
+When launching `rkvm` type VMs, the following occurs, in order:
+
+- A new VM handler is created within minimega, which is populated with a copy of the VM configuration
+- An instance directory for the VM is created (by default /tmp/minimega/N, where N is the VM ID), and the configuration is written to disk
+- Checks are performed to ensure there are no conflicts in names or duplicate connections
+- After a successful VNC connection, the VM is put into the BUILDING state, otherwise the VM is put in the ERROR state
+- minimega returns control to the user
+
+RKVM extends the Minimega VNC api to remotely connect to standalone VNC servers. This enables keybuffer and framebuffer recording, as well as VNC automation to external assets with Minimega. 
+
+RKVM has had limited testing against ESXI and x11vnc. Multiple connections are used and you will need to use the --shared and --forever switches with x11vnc. 
+
+Currently only VNC servers allowing RAW encoding are supported, VNC servers configured to force other encodings like TIGHT will not work.

--- a/doc/content/articles/vmtypes/example2.mm
+++ b/doc/content/articles/vmtypes/example2.mm
@@ -1,0 +1,17 @@
+#Configure RKVM for vnc endpoint
+vm config vnc_host 192.168.1.201
+vm config vnc_port 5900
+
+#launch 
+vm launch rkvm foo 
+
+#configure vnc endpoint using another VNC server
+vm config vnc_host 192.168.1.202
+vm config vnc_port 5900
+
+#launch 
+vm launch rkvm bar
+
+#start 
+vm start foo
+vm start bar

--- a/src/minimega/container.go
+++ b/src/minimega/container.go
@@ -774,6 +774,8 @@ func (vm *ContainerVM) Conflicts(vm2 VM) error {
 		return vm.ConflictsContainer(vm2)
 	case *KvmVM:
 		return vm.BaseVM.conflicts(vm2.BaseVM)
+	case *RKvmVM:
+		return vm.BaseVM.conflicts(vm2.BaseVM)
 	}
 
 	return errors.New("unknown VM type")

--- a/src/minimega/kvm.go
+++ b/src/minimega/kvm.go
@@ -413,6 +413,8 @@ func (vm *KvmVM) Conflicts(vm2 VM) error {
 		return vm.ConflictsKVM(vm2)
 	case *ContainerVM:
 		return vm.BaseVM.conflicts(vm2.BaseVM)
+	case *RKvmVM:
+		return vm.BaseVM.conflicts(vm2.BaseVM)
 	}
 
 	return errors.New("unknown VM type")

--- a/src/minimega/rkvm.go
+++ b/src/minimega/rkvm.go
@@ -1,0 +1,540 @@
+// Copyright 2017-2021 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	"image/draw"
+	"image/png"
+	"io"
+	"io/ioutil"
+	log "minilog"
+	"net"
+	"os"
+	"path/filepath"
+	"ron"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+	"vnc"
+)
+
+type ServerInfo struct {
+	Width  uint16
+	Height uint16
+}
+
+type RKVMConfig struct {
+	Vnc_host string
+	Vnc_port int
+}
+
+type RKvmVM struct {
+	*BaseVM     // embed
+	RKVMConfig  // embed
+	vncShim     net.Listener
+	vncShimPort int
+}
+
+// Ensure that RKVM implements the VM interface
+var _ VM = (*RKvmVM)(nil)
+var killVnc = make(chan bool, 1)
+
+// Copy makes a copy and returns reference to the new struct.
+func (old RKVMConfig) Copy() RKVMConfig {
+	res := old
+	return res
+}
+
+func (vm *RKvmVM) ProcStats() (map[int]*ProcStats, error) {
+	p, err := GetProcStats(vm.Pid)
+	if err != nil {
+		return nil, err
+	}
+	return map[int]*ProcStats{vm.Pid: p}, nil
+}
+
+func NewRKVM(name, namespace string, config VMConfig) (*RKvmVM, error) {
+	vm := new(RKvmVM)
+
+	vm.BaseVM = NewBaseVM(name, namespace, config)
+	vm.Type = RKVM
+
+	vm.RKVMConfig = config.RKVMConfig.Copy() // deep-copy configured fields
+
+	return vm, nil
+}
+
+func (vm *RKvmVM) Copy() VM {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	vm2 := new(RKvmVM)
+
+	// Make shallow copies of all fields
+	*vm2 = *vm
+
+	// Make deep copies
+	vm2.BaseVM = vm.BaseVM.copy()
+	vm2.RKVMConfig = vm.RKVMConfig.Copy()
+
+	return vm2
+}
+
+// Launch a new RKVM VM
+func (vm *RKvmVM) Launch() error {
+	defer vm.lock.Unlock()
+	return vm.launch()
+}
+
+// Flush cleans up all resources allocated to the VM
+func (vm *RKvmVM) Flush() error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+	return vm.BaseVM.Flush()
+}
+
+func (vm *RKvmVM) Config() *BaseConfig {
+	return &vm.BaseConfig
+}
+
+func (vm *RKvmVM) Start() (err error) {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	if vm.State&VM_RUNNING != 0 {
+		return nil
+	}
+
+	if vm.State == VM_QUIT || vm.State == VM_ERROR {
+		log.Info("relaunching VM: %v", vm.ID)
+		// Create a new channel since we closed the other one to indicate that
+		// the VM should quit.
+		vm.kill = make(chan bool)
+
+		// Launch handles setting the VM to error state
+		if err := vm.launch(); err != nil {
+			return err
+		}
+	}
+
+	log.Info("starting VM: %v", vm.ID)
+	//fmt.Println("starting id " + strconv.Itoa(vm.ID))
+	vm.setState(VM_RUNNING)
+
+	return nil
+}
+
+func (vm *RKvmVM) Stop() error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	if vm.Name == "vince" {
+		return errors.New("vince is stoppable, however one must posses a rare whiskey")
+	}
+
+	if vm.State != VM_RUNNING {
+		return vmNotRunning(strconv.Itoa(vm.ID))
+	}
+
+	log.Info("stopping VM: %v", vm.ID)
+
+	vm.setState(VM_PAUSED)
+
+	return nil
+}
+
+func (vm *RKvmVM) String() string {
+	return fmt.Sprintf("%s:%d:rkvm", vm.Vnc_host, vm.ID)
+}
+
+func (vm *RKvmVM) Info(field string) (string, error) {
+	// If the field is handled by BaseVM, return it
+	if v, err := vm.BaseVM.Info(field); err == nil {
+		return v, nil
+	}
+
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	switch field {
+	case "vnc_port":
+		return strconv.Itoa(vm.vncShimPort), nil
+	case "host":
+		return vm.Vnc_host, nil
+	}
+
+	return vm.RKVMConfig.Info(field)
+}
+
+// Tests whether rkvm types conflict with container and kvm types
+func (vm *RKvmVM) Conflicts(vm2 VM) error {
+	switch vm2 := vm2.(type) {
+	case *RKvmVM:
+		return vm.ConflictsRKVM(vm2)
+	case *KvmVM:
+		return vm.BaseVM.conflicts(vm2.BaseVM)
+	case *ContainerVM:
+		return vm.BaseVM.conflicts(vm2.BaseVM)
+
+	}
+
+	return errors.New("unknown VM type")
+}
+
+// ConflictsRKVM tests whether vm and vm2 share a vnc host, returns an
+// error if so. Also checks whether the BaseVMs conflict.
+func (vm *RKvmVM) ConflictsRKVM(vm2 *RKvmVM) error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	if vm.Vnc_host == vm2.Vnc_host {
+		return fmt.Errorf("duplicate rkvm %v: %v", vm.Name, vm2.Name)
+	}
+	return vm.BaseVM.conflicts(vm2.BaseVM)
+}
+
+func (vm *RKVMConfig) String() string {
+	// create output
+	var o bytes.Buffer
+	w := new(tabwriter.Writer)
+	w.Init(&o, 5, 0, 1, ' ', 0)
+	fmt.Fprintln(&o, "RKVM configuration:")
+	fmt.Fprintf(w, "Vnc Host:\t%v\n", vm.Vnc_host)
+	fmt.Fprintf(w, "Vnc Port:\t%v\n", vm.Vnc_port)
+	w.Flush()
+	fmt.Fprintln(&o)
+	return o.String()
+}
+
+func (vm *RKvmVM) Screenshot(size int) ([]byte, error) {
+	if vm.State != VM_RUNNING {
+		return nil, nil
+	}
+
+	tmp := filepath.Join(os.TempDir(), fmt.Sprintf("minimega_screenshot_rkvm_%v", vm.ID))
+	ppmFile, err := ioutil.ReadFile(tmp)
+	if err != nil {
+		log.Error("Unable to read " + tmp)
+		return nil, err
+	}
+	pngResult, err := ppmToPng(ppmFile, size)
+	if err != nil {
+		log.Error("Error converting screenshot")
+		return nil, err
+	}
+	return pngResult, nil
+
+}
+
+func (vm *RKvmVM) Connect(cc *ron.Server, reconnect bool) error {
+	if !vm.Backchannel {
+		return nil
+	}
+
+	if !reconnect {
+		cc.RegisterVM(vm)
+	}
+	return nil
+}
+
+func (vm *RKvmVM) Disconnect(cc *ron.Server) error {
+	if !vm.Backchannel {
+		return nil
+	}
+	cc.UnregisterVM(vm)
+	return nil
+}
+
+// launch is the low-level launch function for KVM VMs. The caller should hold
+// the VM's lock.
+func (vm *RKvmVM) launch() error {
+	log.Info("launching vm: %v", strconv.Itoa(vm.ID))
+	// If this is the first time launching the VM, do the final configuration
+	// check and create directories for it.
+	if vm.State == VM_BUILDING {
+		// create a directory for the VM at the instance path
+		if err := os.MkdirAll(vm.instancePath, os.FileMode(0700)); err != nil {
+			return vm.setErrorf("unable to create VM dir: %v", err)
+		}
+		// Create a snapshot of each disk image
+	}
+	mustWrite(vm.path("name"), vm.Name)
+
+	// create and add taps if we are associated with any networks
+	vmConfig := VMConfig{BaseConfig: vm.BaseConfig, RKVMConfig: vm.RKVMConfig}
+
+	// Create goroutine to wait to kill the VM
+	go func() {
+		defer vm.cond.Signal()
+		select {
+		case <-vm.kill:
+			log.Info("Killing VM %v", vm.ID)
+			killVnc <- true
+			vm.setState(VM_QUIT)
+			return
+		}
+	}()
+
+	err := vm.connectVNC(vmConfig)
+	return err
+}
+
+func (vm *RKvmVM) connectVNC(config VMConfig) error {
+	// should never create...
+	ns := GetOrCreateNamespace(vm.Namespace)
+	connectionString := config.RKVMConfig.Vnc_host + ":" + strconv.Itoa(config.RKVMConfig.Vnc_port)
+
+	shim, shimErr := net.Listen("tcp", "")
+	if shimErr != nil {
+		log.Error("Shim listen error")
+		return shimErr
+	}
+	vm.vncShim = shim
+	vm.vncShimPort = shim.Addr().(*net.TCPAddr).Port
+	log.Info("Connecting to Server at :" + strconv.Itoa(vm.vncShimPort))
+	var vncRx_c = make(chan interface{}, 1)
+	var vncTx_c = make(chan interface{}, 1)
+	var serverIntInfo_c = make(chan ServerInfo, 1)
+	var killFbRes_c = make(chan bool, 1)
+	var killFbReq_c = make(chan bool, 1)
+	var killVncRx_c = make(chan bool, 1)
+	var killShim_c = make(chan bool, 1)
+	var resetCon_c = make(chan bool, 1)
+	var conError_c = make(chan error, 1)
+
+	go func() {
+		defer shim.Close()
+		for {
+			remote, err := shim.Accept()
+			if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
+				return
+			} else if err != nil {
+				log.Errorln(err)
+				return
+			}
+			log.Debug("SHIM")
+			log.Info("vnc shim connect: %v -> %v", remote.RemoteAddr(), vm.Name)
+			go func() {
+				defer remote.Close()
+				// Dial domain socket
+				local, err := net.Dial("tcp", connectionString)
+
+				if err != nil {
+					log.Error("unable to dial vm vnc: %v", err)
+					return
+				}
+				defer local.Close()
+				// copy local -> remote
+				go io.Copy(remote, local)
+				// Reads will implicitly copy from remote -> local
+				tee := io.TeeReader(remote, local)
+				for {
+					msg, err := vnc.ReadClientMessage(tee)
+					if err == nil {
+						ns.Recorder.Route(vm.GetName(), msg)
+						continue
+					}
+					// shim is no longer connected
+					if err == io.EOF || strings.Contains(err.Error(), "broken pipe") {
+						log.Info("vnc shim quit: %v", vm.Name)
+						break
+					}
+					// ignore these
+					if strings.Contains(err.Error(), "unknown client-to-server message") {
+						continue
+					}
+					//unknown error
+					log.Warnln(err)
+				}
+
+			}()
+		}
+	}()
+
+	go func(vm *RKvmVM) {
+		var sin ServerInfo
+		var con *vnc.Conn
+		var conErr error
+		var reset bool = true
+		var errorCount int = 0
+		var conErrorCount int = 0
+		var connected bool = false
+		var ID = vm.ID
+
+		for {
+			select {
+			case reset = <-resetCon_c:
+				if connected {
+					killFbReq_c <- true
+					killFbRes_c <- true
+					killVncRx_c <- true
+					time.Sleep(2 * time.Second)
+					con.Close()
+
+				}
+				break
+			case <-killVnc:
+				killFbReq_c <- true
+				killFbRes_c <- true
+				killVncRx_c <- true
+				killShim_c <- true
+				_, _ = vnc.Dial("127.0.0.1" + ":" + strconv.Itoa(vm.vncShimPort))
+				time.Sleep(2 * time.Second)
+				con.Close()
+
+				return
+			case tx := <-vncTx_c:
+				//fmt.Println("TX Signal Comm")
+				switch tx.(type) {
+				case *vnc.FramebufferUpdateRequest:
+					//fmt.Println("TX FB Request")
+					sender := tx.(*vnc.FramebufferUpdateRequest)
+					if err := sender.Write(con); err != nil {
+						log.Error("unable to request framebuffer update")
+						errorCount++
+					}
+				default:
+					log.Error("unimplemented send type in vncTx_c channel")
+				}
+				break
+			default:
+				//fmt.Println("No signals communicating")
+				//break
+			} //end select for channel communication
+			if errorCount > 3 {
+				errorCount = 0
+				resetCon_c <- true
+			}
+			if reset {
+				log.Info("RESET VNC Connection")
+				reset = false
+				con, conErr = vnc.Dial(connectionString)
+				if conErr != nil {
+					log.Error("unable to dial vm vnc %v: %v", connectionString, conErr)
+					conErrorCount++
+					connected = false
+					resetCon_c <- true
+					time.Sleep(5 * time.Second)
+					log.Error("RESETTING")
+					continue
+				}
+				if conErrorCount > 12 {
+					vm.setErrorf("unable to connect to vnc after 1 minute %v ", conErr)
+					log.Error("Exit connect loop")
+					killVnc <- true
+					continue
+				}
+
+				height, width := con.GetDesktopSize()
+				sin.Height = height
+				sin.Width = width
+				serverIntInfo_c <- sin // give information to other routines
+				log.Debug("Size %v x %v", width, height)
+				connected = true
+				//Frame Buffer Request routine
+				go func() {
+					t0 := time.Now()
+					for {
+						select {
+						case <-killFbReq_c:
+							return
+						default:
+							//break
+						}
+						t1 := time.Now()
+						if t1.Sub(t0).Seconds() > 1 {
+							//fmt.Println("Attemping to Request Frame Buffer Update")
+							req := &vnc.FramebufferUpdateRequest{}
+							req.Width = width - 1
+							req.Height = height - 1
+							vncTx_c <- req
+							t0 = time.Now()
+						}
+					}
+				}()
+
+				//Frame Buffer Response
+				go func(ID int) {
+					tmp := filepath.Join(os.TempDir(), fmt.Sprintf("minimega_screenshot_rkvm_%v", ID))
+					var serverInfo ServerInfo
+					serverInfo = <-serverIntInfo_c
+					masterFrame := image.NewRGBA(image.Rectangle{image.Point{0, 0}, image.Point{int(serverInfo.Width), int(serverInfo.Height)}})
+					for {
+						//check if we need to kill
+						select {
+						case <-killFbRes_c:
+							log.Debug("RF killed")
+							os.Remove(tmp)
+							return
+						default:
+							break
+						}
+						//fmt.Println("Attempting to read from vnc rx channel")
+						msg := <-vncRx_c
+						//fmt.Println("vnc rx channel read success")
+						switch msg.(type) {
+						case *vnc.FramebufferUpdate:
+							fb := msg.(*vnc.FramebufferUpdate)
+							for _, rect := range fb.Rectangles {
+								// ignore non-image
+								if rect.RGBA == nil {
+									continue
+								}
+								drawPoint := image.Point{int(rect.X), int(rect.Y)}
+								draw.Draw(masterFrame, image.Rect(int(rect.X), int(rect.Y), int(rect.X+rect.Width), int(rect.Height+rect.Y)), rect.RGBA, drawPoint, draw.Src)
+							} // end for rectangles
+							out, err := os.Create(tmp)
+							if err != nil {
+								log.Error("Error creating screenshot file %v", err)
+							} else {
+								err = png.Encode(out, masterFrame)
+								out.Close()
+								if err != nil {
+									log.Error("Error writing out screenshot %v", err)
+								}
+							}
+						} // end message type switch
+					} // end for loop
+				}(ID) //end Read for Framebuffer Update
+
+				go func(con *vnc.Conn) {
+					for {
+						select {
+						case <-killVncRx_c:
+							return
+						default:
+						}
+						//fmt.Println("Attempt Vnc Read")
+						msg, err := con.ReadMessage()
+						//fmt.Println("VNC Message Read")
+						if err == nil {
+							ns.Recorder.Route(vm.GetName(), msg)
+							vncRx_c <- msg
+						} else if strings.Contains(err.Error(), "unknown client-to-server message") {
+							//fmt.Println("Unknown message %v",msg)
+							log.Error("Unknown message from vnc server")
+						} else {
+							// unknown error
+							log.Warnln(err)
+						}
+					}
+				}(con) //end go func
+			} //end if reset
+		} //end for loop
+	}(vm)
+	//error catch
+	select {
+	case er := <-conError_c:
+		return er
+	default:
+		return nil
+	}
+
+}

--- a/src/minimega/vm.go
+++ b/src/minimega/vm.go
@@ -30,6 +30,7 @@ const (
 	_ VMType = iota
 	KVM
 	CONTAINER
+	RKVM
 )
 
 type VM interface {
@@ -142,6 +143,8 @@ var vmInfo = []string{
 	// container fields
 	"filesystem", "hostname", "init", "preinit", "fifo", "volume",
 	"console_port",
+	//rkvm fields
+	"vnc_host", "vnc_port",
 	// more generic fields (tags can be huge so throw it at the end)
 	"tags",
 }
@@ -161,6 +164,7 @@ func init() {
 	gob.Register([]VM{})
 	gob.Register(&KvmVM{})
 	gob.Register(&ContainerVM{})
+	gob.Register(&RKvmVM{})
 }
 
 func NewVM(name, namespace string, vmType VMType, config VMConfig) (VM, error) {
@@ -169,6 +173,8 @@ func NewVM(name, namespace string, vmType VMType, config VMConfig) (VM, error) {
 		return NewKVM(name, namespace, config)
 	case CONTAINER:
 		return NewContainer(name, namespace, config)
+	case RKVM:
+		return NewRKVM(name, namespace, config)
 	}
 
 	return nil, errors.New("unknown VM type")
@@ -251,6 +257,8 @@ func (s VMType) String() string {
 		return "kvm"
 	case CONTAINER:
 		return "container"
+	case RKVM:
+		return "rkvm"
 	default:
 		return "???"
 	}
@@ -262,6 +270,8 @@ func ParseVMType(s string) (VMType, error) {
 		return KVM, nil
 	case "container":
 		return CONTAINER, nil
+	case "rkvm":
+		return RKVM, nil
 	default:
 		return 0, errors.New("invalid VMType")
 	}
@@ -843,4 +853,7 @@ func vmNotContainer(name string) error {
 
 func isVMNotFound(err string) bool {
 	return strings.HasPrefix(err, "vm not found: ")
+}
+func vmNotRKVM(name string) error {
+	return fmt.Errorf("vm not RKVM: %v", name)
 }

--- a/src/minimega/vm_cli.go
+++ b/src/minimega/vm_cli.go
@@ -34,7 +34,7 @@ info include:
 - state*     : one of (building, running, paused, quit, error)
 - uptime     : amount of time since the VM was launched
 - namespace* : namespace the VM belongs to
-- type*      : one of (kvm, container)
+- type*      : one of (kvm, container, rkvm)
 - uuid*      : QEMU system uuid
 - cc_active* : indicates whether cc is connected
 - vcpus      : the number of allocated CPUs
@@ -72,6 +72,11 @@ Additional fields are available for container-based VMs:
 - fifo         : number of fifo devices
 - console_port : port for console shim
 
+Additional fields are available for RKVM (Remote KVM via VNC) types: 
+
+- vnc_host 	: hostname or ip of the VNC server 
+- vnc_port	: port for the VNC server
+
 The optional summary flag limits the columns to those denoted with a '*'.
 
 Examples:
@@ -98,6 +103,7 @@ supported VM types are:
 
 - kvm : QEMU-based vms
 - container: Linux containers
+- rkvm : Remote KVM via VNC
 
 If you supply a name instead of a number of VMs, one VM with that name will be
 launched. You may also supply a range expression to launch VMs with a specific
@@ -121,6 +127,7 @@ better allocate resources across the cluster.`,
 			"vm launch",
 			"vm launch <kvm,> <name or count> [config]",
 			"vm launch <container,> <name or count> [config]",
+			"vm launch <rkvm,> <name> [config]",
 		},
 		Call: wrapSimpleCLI(cliVMLaunch),
 	},
@@ -485,6 +492,7 @@ func init() {
 	gob.Register(VMs{})
 	gob.Register(&KvmVM{})
 	gob.Register(&ContainerVM{})
+	gob.Register(&RKvmVM{})
 }
 
 func cliVMApply(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/src/minimega/vmconfig.go
+++ b/src/minimega/vmconfig.go
@@ -23,6 +23,7 @@ type VMConfig struct {
 	BaseConfig
 	KVMConfig
 	ContainerConfig
+	RKVMConfig
 }
 
 type ConfigWriter interface {
@@ -90,19 +91,22 @@ func (old VMConfig) Copy() VMConfig {
 		BaseConfig:      old.BaseConfig.Copy(),
 		KVMConfig:       old.KVMConfig.Copy(),
 		ContainerConfig: old.ContainerConfig.Copy(),
+		RKVMConfig:      old.RKVMConfig.Copy(),
 	}
 }
 
 func (vm VMConfig) String(namespace string) string {
 	return vm.BaseConfig.String(namespace) +
 		vm.KVMConfig.String() +
-		vm.ContainerConfig.String()
+		vm.ContainerConfig.String() +
+		vm.RKVMConfig.String()
 }
 
 func (vm *VMConfig) Clear(mask string) {
 	vm.BaseConfig.Clear(mask)
 	vm.KVMConfig.Clear(mask)
 	vm.ContainerConfig.Clear(mask)
+	vm.RKVMConfig.Clear(mask)
 }
 
 func (vm *VMConfig) WriteConfig(w io.Writer) error {
@@ -110,6 +114,7 @@ func (vm *VMConfig) WriteConfig(w io.Writer) error {
 		vm.BaseConfig.WriteConfig,
 		vm.KVMConfig.WriteConfig,
 		vm.ContainerConfig.WriteConfig,
+		vm.RKVMConfig.WriteConfig,
 	}
 
 	for _, fn := range funcs {

--- a/src/minimega/vmconfig_cli.go
+++ b/src/minimega/vmconfig_cli.go
@@ -14,6 +14,52 @@ import (
 // vmconfigCLIHandlers are special cases that are not worth generating via
 // vmconfiger.
 var vmconfigCLIHandlers = []minicli.Handler{
+	{
+		HelpShort: "configures vnc host",
+		HelpLong: `Configure the hostname or ip address that hosts the rkvm vnc interface
+Note: this configuration only applies to rkvm and must be specified.
+`,
+		Patterns: []string{
+			"vm config vnc_host [value]",
+		},
+
+		Call: wrapSimpleCLI(func(ns *Namespace, c *minicli.Command, r *minicli.Response) error {
+			if len(c.StringArgs) == 0 {
+				r.Response = ns.vmConfig.Vnc_host
+				return nil
+			}
+
+			v := c.StringArgs["value"]
+
+			ns.vmConfig.Vnc_host = v
+
+			return nil
+		}),
+	},
+	{
+		HelpShort: "configures vnc port",
+		HelpLong: `Configure the port that hosts the rkvm vnc interface
+Note: this configuration only applies to rkvm and must be specified.
+`,
+		Patterns: []string{
+			"vm config vnc_port [value]",
+		},
+
+		Call: wrapSimpleCLI(func(ns *Namespace, c *minicli.Command, r *minicli.Response) error {
+			if len(c.StringArgs) == 0 {
+				r.Response = strconv.FormatInt(int64(ns.vmConfig.Vnc_port), 10)
+				return nil
+			}
+
+			i, err := strconv.ParseInt(c.StringArgs["value"], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			ns.vmConfig.Vnc_port = int(i)
+			return nil
+		}),
+	},
 	{ // vm config
 		HelpShort: "display, save, or restore the current VM configuration",
 		HelpLong: `
@@ -246,6 +292,9 @@ func cliVMConfig(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 		case *ContainerVM:
 			ns.vmConfig.BaseConfig = vm.BaseConfig.Copy()
 			ns.vmConfig.ContainerConfig = vm.ContainerConfig.Copy()
+		case *RKvmVM:
+			ns.vmConfig.BaseConfig = vm.BaseConfig.Copy()
+			ns.vmConfig.RKVMConfig = vm.RKVMConfig.Copy()
 		}
 
 		// clear UUID since we can't launch VMs with the same UUID

--- a/src/minimega/vmconfiger_cli.go
+++ b/src/minimega/vmconfiger_cli.go
@@ -1247,3 +1247,30 @@ func (v *KVMConfig) WriteConfig(w io.Writer) error {
 
 	return nil
 }
+
+func (v *RKVMConfig) Info(field string) (string, error) {
+	if field == "vnc_host" {
+		return v.Vnc_host, nil
+	}
+	if field == "vnc_port" {
+		return strconv.Itoa(v.Vnc_port), nil
+	}
+	return "", fmt.Errorf("invalid info field: %v", field)
+}
+func (v *RKVMConfig) Clear(mask string) {
+	if mask == Wildcard || mask == "vnc_host" {
+		v.Vnc_host = ""
+	}
+	if mask == Wildcard || mask == "vnc_port" {
+		v.Vnc_port = 0
+	}
+}
+func (v *RKVMConfig) WriteConfig(w io.Writer) error {
+	if v.Vnc_host != "" {
+		fmt.Fprintf(w, "vm config vnc_host %v\n", v.Vnc_host)
+	}
+	if v.Vnc_port != 0 {
+		fmt.Fprintf(w, "vm config vnc_port %v\n", v.Vnc_port)
+	}
+	return nil
+}

--- a/src/minimega/vms.go
+++ b/src/minimega/vms.go
@@ -243,6 +243,36 @@ func (vms *VMs) FindKvmVMs() []*KvmVM {
 	return res
 }
 
+func (vms *VMs) FindRKvmVM(s string) (*RKvmVM, error) {
+	vms.mu.Lock()
+	defer vms.mu.Unlock()
+
+	vm := vms.findVM(s)
+	if vm == nil {
+		return nil, vmNotFound(s)
+	}
+	if vm, ok := vm.(*RKvmVM); ok {
+		return vm, nil
+	}
+
+	return nil, vmNotRKVM(s)
+
+}
+func (vms *VMs) FindRKvmVMs() []*RKvmVM {
+	vms.mu.Lock()
+	defer vms.mu.Unlock()
+
+	res := []*RKvmVM{}
+
+	for _, vm := range vms.m {
+		if vm, ok := vm.(*RKvmVM); ok {
+			res = append(res, vm)
+		}
+	}
+
+	return res
+}
+
 // Launch takes QueuedVMs and launches them after performing a few sanity
 // checks. Launch returns any errors that occur via a channel since it launches
 // VMs asynchronously.

--- a/src/minimega/vnc_cli.go
+++ b/src/minimega/vnc_cli.go
@@ -114,13 +114,25 @@ func cliVNCPlay(ns *Namespace, c *minicli.Command, resp *minicli.Response) error
 	}
 
 	return ns.Apply(target, func(vm VM, _ bool) (bool, error) {
-		kvm, ok := vm.(*KvmVM)
-		if !ok {
-			return false, nil
-		}
+		id := ""
+		rhost := ""
 
-		id := kvm.GetName()
-		rhost := fmt.Sprintf("%v:%v", kvm.GetHost(), kvm.VNCPort)
+		switch vm.(type) {
+		case *KvmVM:
+			kvm, ok := vm.(*KvmVM)
+			rhost = fmt.Sprintf("%v:%v", kvm.GetHost(), kvm.VNCPort)
+			if !ok {
+				return false, nil
+			}
+			id = kvm.GetName()
+		case *RKvmVM:
+			rkvm, ok := vm.(*RKvmVM)
+			rhost = fmt.Sprintf("%v:%v", rkvm.Vnc_host, rkvm.Vnc_port)
+			if !ok {
+				return false, nil
+			}
+			id = rkvm.GetName()
+		}
 
 		switch {
 		case c.BoolArgs["play"]:
@@ -164,13 +176,25 @@ func cliVNCRecord(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 		fname = filepath.Join(*f_iomBase, fname)
 	}
 
-	vm, err := ns.FindKvmVM(c.StringArgs["vm"])
-	if err != nil {
-		return err
+	id := ""
+	rhost := ""
+	vm := ns.FindVM(c.StringArgs["vm"])
+	switch vm.(type) {
+	case *KvmVM:
+		kvm, ok := vm.(*KvmVM)
+		rhost = fmt.Sprintf("%v:%v", kvm.GetHost(), kvm.VNCPort)
+		if !ok {
+			return errors.New("Error finding VM")
+		}
+	case *RKvmVM:
+		rkvm, ok := vm.(*RKvmVM)
+		rhost = fmt.Sprintf("%v:%v", rkvm.Vnc_host, rkvm.Vnc_port)
+		if !ok {
+			return errors.New("Error finding VM")
+		}
 	}
 
-	id := vm.Name
-	rhost := fmt.Sprintf("%v:%v", vm.GetHost(), vm.VNCPort)
+	id = vm.GetName()
 
 	if c.BoolArgs["record"] {
 		if c.BoolArgs["kb"] {
@@ -181,9 +205,9 @@ func cliVNCRecord(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 	}
 
 	if c.BoolArgs["kb"] {
-		return ns.Recorder.StopKB(vm.Name)
+		return ns.Recorder.StopKB(id)
 	}
-	return ns.Recorder.StopFB(vm.Name)
+	return ns.Recorder.StopFB(id)
 }
 
 // List all active recordings and playbacks

--- a/src/miniweb/handlers.go
+++ b/src/miniweb/handlers.go
@@ -257,7 +257,7 @@ func connectHandler(w http.ResponseWriter, r *http.Request, name string) {
 
 	cmd := NewCommand(r)
 	cmd.Command = "vm info"
-	cmd.Columns = []string{"host", "type", "vnc_port", "console_port"}
+	cmd.Columns = []string{"host", "type", "vnc_port", "console_port", "vnc_host"}
 	cmd.Filters = []string{fmt.Sprintf("name=%q", name)}
 
 	for _, vm := range runTabular(cmd) {
@@ -269,6 +269,9 @@ func connectHandler(w http.ResponseWriter, r *http.Request, name string) {
 			port, _ = strconv.Atoi(vm["vnc_port"])
 		case "container":
 			port, _ = strconv.Atoi(vm["console_port"])
+		case "rkvm":
+			port, _ = strconv.Atoi(vm["vnc_port"])
+			log.Info("Connecting to " + host + ":" + strconv.Itoa(port))
 		default:
 			log.Info("unknown VM type: %v", vm["type"])
 			return
@@ -298,6 +301,8 @@ func connectHandler(w http.ResponseWriter, r *http.Request, name string) {
 		http.ServeFile(w, r, filepath.Join(*f_root, "vnc.html"))
 	case "container":
 		http.ServeFile(w, r, filepath.Join(*f_root, "terminal.html"))
+	case "rkvm":
+		http.ServeFile(w, r, filepath.Join(*f_root, "vnc.html"))
 	}
 }
 

--- a/src/miniweb/tabular.go
+++ b/src/miniweb/tabular.go
@@ -33,8 +33,10 @@ func tabularToMapCols(columns []string) tabularToMapper {
 		res := map[string]string{}
 		for _, column := range cols {
 			if strings.Contains(column, "host") {
-				res["host"] = resp.Host
-				continue
+				if !strings.Contains(column, "vnc_host") {
+					res["host"] = resp.Host
+					continue
+				}
 			}
 
 			for i, header := range resp.Header {

--- a/src/miniweb/ws.go
+++ b/src/miniweb/ws.go
@@ -25,6 +25,10 @@ func connectWsHandler(vmType, host string, port int) func(*websocket.Conn) {
 		case "container":
 			// See above. The javascript terminal needs it to be a TextFrame.
 			ws.PayloadType = websocket.TextFrame
+		case "rkvm":
+			// Undocumented "feature" of websocket -- need to set to
+			// PayloadType in order for a direct io.Copy to work.
+			ws.PayloadType = websocket.BinaryFrame
 		}
 
 		// connect to the remote host

--- a/src/vnc/decode.go
+++ b/src/vnc/decode.go
@@ -205,6 +205,12 @@ func (c *Conn) decodeRawEncoding(r *Rectangle) error {
 	return nil
 }
 
+func (c *Conn) GetDesktopSize() (height, width uint16) {
+	height = c.s.Height
+	width = c.s.Width
+	return
+}
+
 func (c *Conn) decodeDesktopSizeEncoding(r *Rectangle) error {
 	width, height := uint16(r.Rect.Dx()), uint16(r.Rect.Dy())
 	log.Info("new desktop size: %v x %v -> %v x %v", c.s.Width, c.s.Height, width, height)


### PR DESCRIPTION
https://github.com/sandia-minimega/minimega/issues/1398

This pull request is largely from the hard work of @zach-r-long. I'm leaving Sandia, so I wanted to push up the last version I know we had working.

RKVM extends the Minimega's VNC abilities to be able to remotely connect to standalone VNC servers. This enables keybuffer and framebuffer recording, as well as VNC automation to external assets within Minimega. RKVM has had limited testing against ESX, x11vnc, and PIKVM for physical hardware. Multiple connections are used and you will need to use the --shared and --forever switches with x11vnc. Currently only VNC servers allowing RAW encoding are supported, VNC servers configured to force other encodings like TIGHT will not work.

I have a container that has been used in testing this new feature.

https://github.com/mkunz7/vms/blob/master/vnc.tgz

```
tap create 1000 ip 1.0.0.1/24
dnsmasq start 1.0.0.1 1.0.0.2 1.0.0.254
dnsmasq configure 0 ip 00:11:22:33:44:55 1.0.0.3
vm config filesystem /root/vnc
vm config net 1000,00:11:22:33:44:55
vm launch container a
vm start a
log level debug
log file /root/test.log
shell sleep 5
vm config vnc_host 1.0.0.3
vm config vnc_port 5900
vm launch rkvm vnc
vm start vnc
```

Zach has been working on a branch that supports tight encoding, but novnc needs to first be updated to at least v1. VNC recording was broken when we tried to update it before. https://github.com/sandia-minimega/minimega/issues/1258

Zach feel free to add your own pull request with some cleaned up code.
