### PR TITLE
Add "router fw" commands to minirouter to add iptables FORWARD rules

### DIFF
--- a/src/minimega/router.go
+++ b/src/minimega/router.go
@@ -1034,7 +1034,7 @@ func (r *Router) FirewallDefault(d string) error {
 }
 
 func (r *Router) FirewallAdd(n int, in bool, src, dst, proto, action string) error {
-	log.Debug("RouterFirewallAdd: %d, %b, %s, %s, %s, %s", n, in, src, dst, proto, action)
+	log.Debug("RouterFirewallAdd: %d, %v, %s, %s, %s, %s", n, in, src, dst, proto, action)
 
 	if n >= len(r.FW.rules) {
 		return fmt.Errorf("no such network index: %v", n)
@@ -1075,7 +1075,7 @@ func (r *Router) FirewallChainAdd(chain, src, dst, proto, action string) error {
 }
 
 func (r *Router) FirewallChainApply(n int, in bool, chain string) error {
-	log.Debug("RouterFirewallChainApply: %d, %b, %s", n, in, chain)
+	log.Debug("RouterFirewallChainApply: %d, %v, %s", n, in, chain)
 
 	if _, ok := r.FW.chains[chain]; !ok {
 		return fmt.Errorf("unknown chain %s", chain)

--- a/src/minimega/router_cli.go
+++ b/src/minimega/router_cli.go
@@ -125,7 +125,7 @@ router takes a number of subcommands:
   put the previous rule into a chain named "allow-http" and apply it to the
   interface at index 0 via the following:
 
-	router foo fw chain allow-http default drop
+	router foo fw chain allow-http default action drop
 	router foo fw chain allow-http action accept 192.168.0.5:80 tcp
 	router foo fw chain allow-http apply out 0
 `,

--- a/src/minimega/router_cli.go
+++ b/src/minimega/router_cli.go
@@ -6,9 +6,11 @@ package main
 
 import (
 	"fmt"
-	"minicli"
 	"net"
 	"strconv"
+	"strings"
+
+	"minicli"
 )
 
 var routerCLIHandlers = []minicli.Handler{
@@ -62,7 +64,7 @@ router takes a number of subcommands:
   next-hop, and optionally a name for this router. For example to specify a
   static route(s):
 
-    router foo route static 0.0.0.0/0 10.0.0.1 default-route
+	router foo route static 0.0.0.0/0 10.0.0.1 default-route
 
   OSPF routes include an area and a network index corresponding to the
   interface described in 'vm config net'. You can also specify what networks
@@ -78,7 +80,7 @@ router takes a number of subcommands:
   For example, to advertise specific networks, advertise a static route or
   use a static route as a filter:
 
-    router foo route static 11.0.0.0/24 0 bar-route
+	router foo route static 11.0.0.0/24 0 bar-route
 	router foo route static 12.0.0.0/24 0 bar-route
 	router foo route ospf 0 export 10.0.0.0/24
 	router foo route ospf 0 export default-route
@@ -90,20 +92,42 @@ router takes a number of subcommands:
   For example, local router is in AS 100 with an ip 10.0.0.1 and bgp peer is in AS 200 with an ip of 20.0.0.1
   and you want to advterise network 10.0.0.0/24:
 
-    router foo route static 10.0.0.0/24 0 foo_out
-    router foo bgp bar local 10.0.0.1 100
+	router foo route static 10.0.0.0/24 0 foo_out
+	router foo bgp bar local 10.0.0.1 100
 	router foo bgp bar neighbor 20.0.0.1 200
 	router foo bgp bar export filter foo_out
 
   You can set up route reflection for BGP by ussing the rrclient command for that process.
   By using the command it indicates that the peer is a bgp client:
 
-    router foo bgp bar rrclient
+	router foo bgp bar rrclient
 
 - 'rid': Sets the 32 bit router ID for the router. Typically this ID is unqiue
   across the orginizations network and is used for various routing protocols ie OSPF
 
-    router foo rid 1.1.1.1
+	router foo rid 1.1.1.1
+
+- 'fw': specify flows to accept/drop/reject via iptables. For example, to
+  globally globally drop all forwarded packets and accept HTTP traffic from any
+  IP address to host 192.168.0.5 on the interface at index 0 (which is on the
+  192.168.0.0/24 network):
+
+	router foo fw default drop
+	router foo fw accept out 0 192.168.0.5:80 tcp
+
+  Note that we use 'out' here since we're applying the rule to the interface
+  that's on the same network as the destination. The source and destination does
+  not have to include a port.
+
+  New iptables chains can also be created, providing a method for grouping rules
+  together instead of adding rules at the global level. Chains are then applied
+  to one or more interfaces using the interface index. For example, one could
+  put the previous rule into a chain named "allow-http" and apply it to the
+  interface at index 0 via the following:
+
+	router foo fw chain allow-http default drop
+	router foo fw chain allow-http action accept 192.168.0.5:80 tcp
+	router foo fw chain allow-http apply out 0
 `,
 		Patterns: []string{
 			"router <vm>",
@@ -127,6 +151,13 @@ router takes a number of subcommands:
 			"router <vm> <route,> <bgp,> <processname> <rrclient,>",
 			"router <vm> <route,> <bgp,> <processname> <export,> <all,filter> <filtername>",
 			//"router <vm> <importbird,> <configfilepath>", TODO
+			"router <vm> <fw,> <default,> <accept,drop,reject>",
+			"router <vm> <fw,> <accept,drop,reject> <in,out> <index> <dst> <proto>",
+			"router <vm> <fw,> <accept,drop,reject> <in,out> <index> <src> <dst> <proto>",
+			"router <vm> <fw,> chain <chain> <default,> action <accept,drop,reject>",
+			"router <vm> <fw,> chain <chain> action <accept,drop,reject> <dst> <proto>",
+			"router <vm> <fw,> chain <chain> action <accept,drop,reject> <src> <dst> <proto>",
+			"router <vm> <fw,> chain <chain> apply <in,out> <index>",
 		},
 		Call:    wrapVMTargetCLI(cliRouter),
 		Suggest: wrapVMSuggest(VM_ANY_STATE, false),
@@ -164,6 +195,7 @@ router takes a number of subcommands:
 			"clear router <vm> <route,> <bgp,> <processname>",
 			"clear router <vm> <route,> <bgp,> <processname> <rrclient,>",
 			"clear router <vm> <route,> <bgp,> <processname> <local,neighbor>",
+			"clear router <vm> <fw,>",
 		},
 		Call:    wrapVMTargetCLI(cliClearRouter),
 		Suggest: wrapVMSuggest(VM_ANY_STATE, false),
@@ -295,6 +327,145 @@ func cliRouter(ns *Namespace, c *minicli.Command, resp *minicli.Response) error 
 			return fmt.Errorf("invalid routerid: %v", c.StringArgs["id"])
 		}
 		rtr.routerID = c.StringArgs["id"]
+	} else if c.BoolArgs["fw"] {
+		if chain := c.StringArgs["chain"]; chain != "" {
+			if c.BoolArgs["default"] {
+				if c.BoolArgs["accept"] {
+					return rtr.FirewallChainDefault(chain, "accept")
+				} else if c.BoolArgs["drop"] {
+					return rtr.FirewallChainDefault(chain, "drop")
+				} else if c.BoolArgs["reject"] {
+					return rtr.FirewallChainDefault(chain, "reject")
+				}
+
+				return fmt.Errorf("unexpected default fw chain action")
+			}
+
+			if c.BoolArgs["accept"] || c.BoolArgs["drop"] || c.BoolArgs["reject"] {
+				var src, dst string
+
+				if src = c.StringArgs["src"]; src != "" {
+					fields := strings.Split(src, ":")
+
+					switch len(fields) {
+					case 1: // all good here
+					case 2:
+						if _, err := strconv.Atoi(fields[1]); err != nil {
+							return fmt.Errorf("validating fw source port %s: %v", fields[1], err)
+						}
+					default:
+						return fmt.Errorf("malformed fw source %s", src)
+					}
+				}
+
+				if dst = c.StringArgs["dst"]; dst != "" {
+					fields := strings.Split(dst, ":")
+
+					switch len(fields) {
+					case 1: // all good here
+					case 2:
+						if _, err := strconv.Atoi(fields[1]); err != nil {
+							return fmt.Errorf("validating fw destination port %s: %v", fields[1], err)
+						}
+					default:
+						return fmt.Errorf("malformed fw destination %s", dst)
+					}
+				}
+
+				var (
+					proto  = c.StringArgs["proto"]
+					action string
+				)
+
+				if c.BoolArgs["accept"] {
+					action = "accept"
+				} else if c.BoolArgs["drop"] {
+					action = "drop"
+				} else if c.BoolArgs["reject"] {
+					action = "reject"
+				}
+
+				return rtr.FirewallChainAdd(chain, src, dst, proto, action)
+			}
+
+			if c.BoolArgs["in"] || c.BoolArgs["out"] {
+				idx, err := strconv.Atoi(c.StringArgs["index"])
+				if err != nil {
+					return fmt.Errorf("converting fw chain interface index: %v", err)
+				}
+
+				return rtr.FirewallChainApply(idx, c.BoolArgs["in"], chain)
+			}
+
+			// if we get here, it's an unexpected error...
+			return fmt.Errorf("error processing fw chain")
+		}
+
+		if c.BoolArgs["default"] {
+			if c.BoolArgs["accept"] {
+				return rtr.FirewallDefault("accept")
+			} else if c.BoolArgs["drop"] {
+				return rtr.FirewallDefault("drop")
+			} else if c.BoolArgs["reject"] {
+				return rtr.FirewallDefault("reject")
+			}
+
+			return fmt.Errorf("unexpected default fw action")
+		}
+
+		if c.BoolArgs["accept"] || c.BoolArgs["drop"] || c.BoolArgs["reject"] {
+			idx, err := strconv.Atoi(c.StringArgs["index"])
+			if err != nil {
+				return fmt.Errorf("converting fw interface index: %v", err)
+			}
+
+			var (
+				in    = c.BoolArgs["in"]
+				proto = c.StringArgs["proto"]
+				src   string
+				dst   string
+			)
+
+			if src = c.StringArgs["src"]; src != "" {
+				fields := strings.Split(src, ":")
+
+				switch len(fields) {
+				case 1: // all good here
+				case 2:
+					if _, err = strconv.Atoi(fields[1]); err != nil {
+						return fmt.Errorf("validating fw source port %s: %v", fields[1], err)
+					}
+				default:
+					return fmt.Errorf("malformed fw source %s", src)
+				}
+			}
+
+			if dst = c.StringArgs["dst"]; dst != "" {
+				fields := strings.Split(dst, ":")
+
+				switch len(fields) {
+				case 1: // all good here
+				case 2:
+					if _, err = strconv.Atoi(fields[1]); err != nil {
+						return fmt.Errorf("validating fw destination port %s: %v", fields[1], err)
+					}
+				default:
+					return fmt.Errorf("malformed fw destination %s", dst)
+				}
+			}
+
+			var action string
+
+			if c.BoolArgs["accept"] {
+				action = "accept"
+			} else if c.BoolArgs["drop"] {
+				action = "drop"
+			} else if c.BoolArgs["reject"] {
+				action = "reject"
+			}
+
+			return rtr.FirewallAdd(idx, in, src, dst, proto, action)
+		}
 	}
 
 	return nil
@@ -424,6 +595,8 @@ func cliClearRouter(ns *Namespace, c *minicli.Command, resp *minicli.Response) e
 	} else if c.BoolArgs["rid"] {
 		rtr.routerID = "0.0.0.0"
 		return nil
+	} else if c.BoolArgs["fw"] {
+		return rtr.FirewallFlush()
 	} else {
 		// remove everything about this router
 		err := rtr.InterfaceDel("", "", true)
@@ -438,6 +611,7 @@ func cliClearRouter(ns *Namespace, c *minicli.Command, resp *minicli.Response) e
 		rtr.dhcp = make(map[string]*dhcp)
 		rtr.RouteBGPDel("", false, true)
 		rtr.routerID = "0.0.0.0"
+		rtr.FirewallFlush()
 	}
 	return nil
 }

--- a/src/minimega/router_cli.go
+++ b/src/minimega/router_cli.go
@@ -328,6 +328,10 @@ func cliRouter(ns *Namespace, c *minicli.Command, resp *minicli.Response) error 
 		}
 		rtr.routerID = c.StringArgs["id"]
 	} else if c.BoolArgs["fw"] {
+		if vm.GetType() == CONTAINER {
+			return fmt.Errorf("firewall rules cannot be applied to minirouter containers")
+		}
+
 		if chain := c.StringArgs["chain"]; chain != "" {
 			if c.BoolArgs["default"] {
 				if c.BoolArgs["accept"] {

--- a/src/minimega/router_cli.go
+++ b/src/minimega/router_cli.go
@@ -151,7 +151,7 @@ router takes a number of subcommands:
 			"router <vm> <route,> <bgp,> <processname> <rrclient,>",
 			"router <vm> <route,> <bgp,> <processname> <export,> <all,filter> <filtername>",
 			//"router <vm> <importbird,> <configfilepath>", TODO
-			"router <vm> <fw,> <default,> <accept,drop,reject>",
+			"router <vm> <fw,> <default,> <accept,drop>",
 			"router <vm> <fw,> <accept,drop,reject> <in,out> <index> <dst> <proto>",
 			"router <vm> <fw,> <accept,drop,reject> <in,out> <index> <src> <dst> <proto>",
 			"router <vm> <fw,> chain <chain> <default,> action <accept,drop,reject>",
@@ -410,8 +410,6 @@ func cliRouter(ns *Namespace, c *minicli.Command, resp *minicli.Response) error 
 				return rtr.FirewallDefault("accept")
 			} else if c.BoolArgs["drop"] {
 				return rtr.FirewallDefault("drop")
-			} else if c.BoolArgs["reject"] {
-				return rtr.FirewallDefault("reject")
 			}
 
 			return fmt.Errorf("unexpected default fw action")

--- a/src/minimega/router_test.go
+++ b/src/minimega/router_test.go
@@ -178,6 +178,8 @@ bird bgp r2 filter route1
 bird bgp r2 filter route2
 bird routerid 192.168.4.1
 bird commit
+fw flush
+fw default accept
 `
 const testInterfaceWant = `
 IPs:

--- a/src/minimega/router_test.go
+++ b/src/minimega/router_test.go
@@ -178,8 +178,6 @@ bird bgp r2 filter route1
 bird bgp r2 filter route2
 bird routerid 192.168.4.1
 bird commit
-fw flush
-fw default accept
 `
 const testInterfaceWant = `
 IPs:
@@ -188,6 +186,8 @@ Network: 1: [192.168.2.1/24]
 Network: 2: [192.168.3.1/24]
 Loopback IPs:
 192.168.4.1/32
+Firewall Rules:
+  Default Action: accept
 `
 const testOSPFWant = `
 IPs:
@@ -199,6 +199,8 @@ Interfaces:
 	0
 OSPF Export Networks or Routes:
 	192.168.3.0/24
+Firewall Rules:
+  Default Action: accept
 `
 const testStaticWant = `
 IPs:
@@ -213,6 +215,8 @@ defaultroute
 ospf
 	192.168.1.1/32
 	192.168.1.2/32
+Firewall Rules:
+  Default Action: accept
 `
 const testBGPAddWant = `
 IPs:
@@ -225,6 +229,8 @@ BGP Local As:	200
 BGP Neighbor IP:	192.168.1.1
 BGP Neighbor As:	100
 BGP RouteReflector:	false
+Firewall Rules:
+  Default Action: accept
 `
 const testBGPExportWant = `
 IPs:
@@ -240,4 +246,6 @@ BGP RouteReflector:	false
 BGP Export Networks or Routes:
 	all
 	r1route
+Firewall Rules:
+  Default Action: accept
 `

--- a/src/minirouter/fw.go
+++ b/src/minirouter/fw.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"minicli"
+	log "minilog"
+)
+
+func init() {
+	minicli.Register(&minicli.Handler{
+		Patterns: []string{
+			"fw <default,> <accept,drop,reject>",
+			"fw <accept,drop,reject> <in,out> <index> <dst> <proto>",
+			"fw <accept,drop,reject> <in,out> <index> <src> <dst> <proto>",
+			"fw chain <chain> <default,> action <accept,drop,reject>",
+			"fw chain <chain> action <accept,drop,reject> <dst> <proto>",
+			"fw chain <chain> action <accept,drop,reject> <src> <dst> <proto>",
+			"fw chain <chain> apply <in,out> <index>",
+			"fw <flush,>",
+		},
+		Call: handleFW,
+	})
+}
+
+func handleChain(c *minicli.Command, r chan<- minicli.Responses) error {
+	name := c.StringArgs["chain"]
+
+	if out, err := exec.Command("iptables", "-N", name).CombinedOutput(); err != nil {
+		if !strings.Contains(string(out), "exists") { // error isn't due to existing chain
+			return fmt.Errorf("creating %s chain %v: %v", name, err, string(out))
+		}
+	}
+
+	if c.BoolArgs["default"] {
+		if c.BoolArgs["accept"] {
+			if out, err := exec.Command("iptables", "-A", name, "-j", "ACCEPT").CombinedOutput(); err != nil {
+				return fmt.Errorf("defaulting %s chain to ACCEPT %v: %v", name, err, string(out))
+			}
+		} else if c.BoolArgs["drop"] {
+			if out, err := exec.Command("iptables", "-A", name, "-j", "DROP").CombinedOutput(); err != nil {
+				return fmt.Errorf("defaulting %s chain to DROP %v: %v", name, err, string(out))
+			}
+		} else if c.BoolArgs["reject"] {
+			if out, err := exec.Command("iptables", "-A", name, "-j", "REJECT").CombinedOutput(); err != nil {
+				return fmt.Errorf("defaulting %s chain to REJECT %v: %v", name, err, string(out))
+			}
+		}
+
+		return nil
+	}
+
+	if c.BoolArgs["accept"] || c.BoolArgs["drop"] || c.BoolArgs["reject"] {
+		rule := []string{name}
+
+		if proto := c.StringArgs["proto"]; proto != "" {
+			rule = append(rule, "-p", proto)
+		}
+
+		if src := c.StringArgs["src"]; src != "" {
+			fields := strings.Split(src, ":")
+
+			switch len(fields) {
+			case 1:
+				rule = append(rule, "-s", src)
+			case 2:
+				if _, err := strconv.Atoi(fields[1]); err != nil {
+					return fmt.Errorf("converting source port: %v", err)
+				}
+
+				if proto := c.StringArgs["proto"]; proto == "" {
+					return fmt.Errorf("must specify proto when specifying ports")
+				}
+
+				rule = append(rule, "-s", fields[0], "--sport", fields[1])
+			default:
+				return fmt.Errorf("malformed source")
+			}
+		}
+
+		if dst := c.StringArgs["dst"]; dst != "" {
+			fields := strings.Split(dst, ":")
+
+			switch len(fields) {
+			case 1:
+				rule = append(rule, "-d", dst)
+			case 2:
+				if _, err := strconv.Atoi(fields[1]); err != nil {
+					return fmt.Errorf("converting destination port: %v", err)
+				}
+
+				if proto := c.StringArgs["proto"]; proto == "" {
+					return fmt.Errorf("must specify proto when specifying ports")
+				}
+
+				rule = append(rule, "-d", fields[0], "--dport", fields[1])
+			default:
+				return fmt.Errorf("malformed destination")
+			}
+		}
+
+		if c.BoolArgs["accept"] {
+			rule = append(rule, "-j", "ACCEPT")
+		} else if c.BoolArgs["drop"] {
+			rule = append(rule, "-j", "DROP")
+		} else if c.BoolArgs["reject"] {
+			rule = append(rule, "-j", "REJECT")
+		}
+
+		return addRule(rule)
+	}
+
+	if c.BoolArgs["in"] || c.BoolArgs["out"] {
+		var (
+			idx   = -1
+			iface = "lo"
+			err   error
+		)
+
+		if c.StringArgs["index"] != "lo" {
+			idx, err = strconv.Atoi(c.StringArgs["index"])
+			if err != nil {
+				return fmt.Errorf("converting interface index: %v", err)
+			}
+		}
+
+		if idx != -1 {
+			// get interface name using the index
+			if iface, err = findEth(idx); err != nil {
+				return fmt.Errorf("getting interface name for index: %v", err)
+			}
+		}
+
+		var rule []string
+
+		if c.BoolArgs["in"] {
+			rule = []string{"FORWARD", "-i", iface, "-j", name}
+		} else {
+			rule = []string{"FORWARD", "-o", iface, "-j", name}
+		}
+
+		return addRule(rule)
+	}
+
+	return nil
+}
+
+func handleFW(c *minicli.Command, r chan<- minicli.Responses) {
+	defer func() {
+		r <- nil
+	}()
+
+	if c.BoolArgs["flush"] {
+		log.Debug("flushing firwall")
+
+		if err := flushFW(); err != nil {
+			log.Errorln(err)
+		}
+
+		return
+	}
+
+	if c.StringArgs["chain"] != "" {
+		if err := handleChain(c, r); err != nil {
+			log.Errorln(err)
+		}
+
+		return
+	}
+
+	if c.BoolArgs["default"] {
+		if c.BoolArgs["accept"] {
+			if out, err := exec.Command("iptables", "-P", "FORWARD", "ACCEPT").CombinedOutput(); err != nil {
+				log.Errorln("defaulting FORWARD to ACCEPT %v: %v", err, string(out))
+				return
+			}
+		} else if c.BoolArgs["drop"] {
+			if out, err := exec.Command("iptables", "-P", "FORWARD", "DROP").CombinedOutput(); err != nil {
+				log.Errorln("defaulting FORWARD to DROP %v: %v", err, string(out))
+				return
+			}
+		} else if c.BoolArgs["reject"] {
+			if out, err := exec.Command("iptables", "-P", "FORWARD", "REJECT").CombinedOutput(); err != nil {
+				log.Errorln("defaulting FORWARD to REJECT %v: %v", err, string(out))
+				return
+			}
+		}
+
+		return
+	}
+
+	if c.BoolArgs["accept"] || c.BoolArgs["drop"] || c.BoolArgs["reject"] {
+		var (
+			idx   = -1
+			iface = "lo"
+			err   error
+		)
+
+		if c.StringArgs["index"] != "lo" {
+			idx, err = strconv.Atoi(c.StringArgs["index"])
+			if err != nil {
+				log.Errorln("converting interface index: %v", err)
+				return
+			}
+		}
+
+		if idx != -1 {
+			// get interface name using the index
+			if iface, err = findEth(idx); err != nil {
+				log.Errorln("getting interface name for index: %v", err)
+				return
+			}
+		}
+
+		var rule []string
+
+		if c.BoolArgs["in"] {
+			rule = []string{"FORWARD", "-i", iface}
+		} else {
+			rule = []string{"FORWARD", "-o", iface}
+		}
+
+		if proto := c.StringArgs["proto"]; proto != "" {
+			rule = append(rule, "-p", proto)
+		}
+
+		if src := c.StringArgs["src"]; src != "" {
+			fields := strings.Split(src, ":")
+
+			switch len(fields) {
+			case 1:
+				rule = append(rule, "-s", src)
+			case 2:
+				if _, err = strconv.Atoi(fields[1]); err != nil {
+					log.Errorln("converting source port: %v", err)
+					return
+				}
+
+				if proto := c.StringArgs["proto"]; proto == "" {
+					log.Errorln("must specify proto when specifying ports")
+					return
+				}
+
+				rule = append(rule, "-s", fields[0], "--sport", fields[1])
+			default:
+				log.Errorln("malformed source")
+				return
+			}
+		}
+
+		if dst := c.StringArgs["dst"]; dst != "" {
+			fields := strings.Split(dst, ":")
+
+			switch len(fields) {
+			case 1:
+				rule = append(rule, "-d", dst)
+			case 2:
+				if _, err = strconv.Atoi(fields[1]); err != nil {
+					log.Errorln("converting destination port: %v", err)
+					return
+				}
+
+				if proto := c.StringArgs["proto"]; proto == "" {
+					log.Errorln("must specify proto when specifying ports")
+					return
+				}
+
+				rule = append(rule, "-d", fields[0], "--dport", fields[1])
+			default:
+				log.Errorln("malformed destination")
+				return
+			}
+		}
+
+		if c.BoolArgs["accept"] {
+			rule = append(rule, "-j", "ACCEPT")
+		} else if c.BoolArgs["drop"] {
+			rule = append(rule, "-j", "DROP")
+		} else if c.BoolArgs["reject"] {
+			rule = append(rule, "-j", "REJECT")
+		}
+
+		if err := addRule(rule); err != nil {
+			log.Errorln(err)
+			return
+		}
+	}
+}
+
+func addRule(rule []string) error {
+	args := append([]string{"-A"}, rule...)
+
+	out, err := exec.Command("iptables", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("adding iptables rule (%s) %v: %v", strings.Join(rule, " "), err, string(out))
+	}
+
+	return nil
+}
+
+func flushFW() error {
+	if out, err := exec.Command("iptables", "-F").CombinedOutput(); err != nil {
+		return fmt.Errorf("flushing rules %v: %v", err, string(out))
+	}
+
+	if out, err := exec.Command("iptables", "-X").CombinedOutput(); err != nil {
+		return fmt.Errorf("deleting custom chains %v: %v", err, string(out))
+	}
+
+	if err := defaultAllAccept(); err != nil {
+		return err
+	}
+
+	if err := createEstablishedChain(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func defaultAllAccept() error {
+	if out, err := exec.Command("iptables", "-P", "INPUT", "ACCEPT").CombinedOutput(); err != nil {
+		return fmt.Errorf("defaulting INPUT to ACCEPT %v: %v", err, string(out))
+	}
+
+	if out, err := exec.Command("iptables", "-P", "FORWARD", "ACCEPT").CombinedOutput(); err != nil {
+		return fmt.Errorf("defaulting FORWARD to ACCEPT %v: %v", err, string(out))
+	}
+
+	if out, err := exec.Command("iptables", "-P", "OUTPUT", "ACCEPT").CombinedOutput(); err != nil {
+		return fmt.Errorf("defaulting OUTPUT to ACCEPT %v: %v", err, string(out))
+	}
+
+	return nil
+}
+
+func createEstablishedChain() error {
+	if out, err := exec.Command("iptables", "-N", "ESTABLISHED").CombinedOutput(); err != nil {
+		return fmt.Errorf("creating custom ESTABLISHED chain %v: %v", err, string(out))
+	}
+
+	rule := "-A ESTABLISHED -p %s -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT"
+
+	for _, proto := range []string{"tcp", "udp", "icmp"} {
+		args := strings.Fields(fmt.Sprintf(rule, proto))
+
+		if out, err := exec.Command("iptables", args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("creating custom ESTABLISHED chain %v: %v", err, string(out))
+		}
+	}
+
+	if out, err := exec.Command("iptables", "-A", "ESTABLISHED", "-j", "RETURN").CombinedOutput(); err != nil {
+		return fmt.Errorf("creating custom ESTABLISHED chain %v: %v", err, string(out))
+	}
+
+	if out, err := exec.Command("iptables", "-A", "FORWARD", "-j", "ESTABLISHED").CombinedOutput(); err != nil {
+		return fmt.Errorf("creating custom ESTABLISHED chain %v: %v", err, string(out))
+	}
+
+	return nil
+}

--- a/src/minirouter/fw.go
+++ b/src/minirouter/fw.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	minicli.Register(&minicli.Handler{
 		Patterns: []string{
-			"fw <default,> <accept,drop,reject>",
+			"fw <default,> <accept,drop>",
 			"fw <accept,drop,reject> <in,out> <index> <dst> <proto>",
 			"fw <accept,drop,reject> <in,out> <index> <src> <dst> <proto>",
 			"fw chain <chain> <default,> action <accept,drop,reject>",
@@ -180,11 +180,6 @@ func handleFW(c *minicli.Command, r chan<- minicli.Responses) {
 		} else if c.BoolArgs["drop"] {
 			if out, err := exec.Command("iptables", "-P", "FORWARD", "DROP").CombinedOutput(); err != nil {
 				log.Error("defaulting FORWARD to DROP %v: %v", err, string(out))
-				return
-			}
-		} else if c.BoolArgs["reject"] {
-			if out, err := exec.Command("iptables", "-P", "FORWARD", "REJECT").CombinedOutput(); err != nil {
-				log.Error("defaulting FORWARD to REJECT %v: %v", err, string(out))
 				return
 			}
 		}

--- a/src/minirouter/fw.go
+++ b/src/minirouter/fw.go
@@ -174,17 +174,17 @@ func handleFW(c *minicli.Command, r chan<- minicli.Responses) {
 	if c.BoolArgs["default"] {
 		if c.BoolArgs["accept"] {
 			if out, err := exec.Command("iptables", "-P", "FORWARD", "ACCEPT").CombinedOutput(); err != nil {
-				log.Errorln("defaulting FORWARD to ACCEPT %v: %v", err, string(out))
+				log.Error("defaulting FORWARD to ACCEPT %v: %v", err, string(out))
 				return
 			}
 		} else if c.BoolArgs["drop"] {
 			if out, err := exec.Command("iptables", "-P", "FORWARD", "DROP").CombinedOutput(); err != nil {
-				log.Errorln("defaulting FORWARD to DROP %v: %v", err, string(out))
+				log.Error("defaulting FORWARD to DROP %v: %v", err, string(out))
 				return
 			}
 		} else if c.BoolArgs["reject"] {
 			if out, err := exec.Command("iptables", "-P", "FORWARD", "REJECT").CombinedOutput(); err != nil {
-				log.Errorln("defaulting FORWARD to REJECT %v: %v", err, string(out))
+				log.Error("defaulting FORWARD to REJECT %v: %v", err, string(out))
 				return
 			}
 		}
@@ -202,7 +202,7 @@ func handleFW(c *minicli.Command, r chan<- minicli.Responses) {
 		if c.StringArgs["index"] != "lo" {
 			idx, err = strconv.Atoi(c.StringArgs["index"])
 			if err != nil {
-				log.Errorln("converting interface index: %v", err)
+				log.Error("converting interface index: %v", err)
 				return
 			}
 		}
@@ -210,7 +210,7 @@ func handleFW(c *minicli.Command, r chan<- minicli.Responses) {
 		if idx != -1 {
 			// get interface name using the index
 			if iface, err = findEth(idx); err != nil {
-				log.Errorln("getting interface name for index: %v", err)
+				log.Error("getting interface name for index: %v", err)
 				return
 			}
 		}
@@ -235,7 +235,7 @@ func handleFW(c *minicli.Command, r chan<- minicli.Responses) {
 				rule = append(rule, "-s", src)
 			case 2:
 				if _, err = strconv.Atoi(fields[1]); err != nil {
-					log.Errorln("converting source port: %v", err)
+					log.Error("converting source port: %v", err)
 					return
 				}
 
@@ -259,7 +259,7 @@ func handleFW(c *minicli.Command, r chan<- minicli.Responses) {
 				rule = append(rule, "-d", dst)
 			case 2:
 				if _, err = strconv.Atoi(fields[1]); err != nil {
-					log.Errorln("converting destination port: %v", err)
+					log.Error("converting destination port: %v", err)
 					return
 				}
 


### PR DESCRIPTION
Both minimega and minirouter were updated to support configuring
iptables in the minirouter instance using new "router fw" commands.

minirouter was updated to include support for "fw" commands for both
global iptables rules and grouped rules using iptables chains.

minimega was updated to include support for "router <vm> fw" commands
that generate the minirouter "fw" commands in the config script sent to
the minirouter instance via miniccc.

Documentation for minimega's "router" command was also updated to
include details and examples of how to use the new "fw" commands.

closes #1236