### PR TITLE
Support TCP and UDP connectivity testing from miniccc

### DIFF
--- a/src/ron/command.go
+++ b/src/ron/command.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	log "minilog"
 	"strings"
+	"time"
 )
 
 type Filter struct {
@@ -36,6 +37,9 @@ type Command struct {
 
 	// Files to transfer back to the master
 	FilesRecv []string
+
+	// Connectivity test to execute
+	ConnTest *ConnTest
 
 	// PID of the process to signal, -1 signals all processes
 	PID int
@@ -71,6 +75,12 @@ type Response struct {
 	// Output from responding command, if any
 	Stdout string
 	Stderr string
+}
+
+type ConnTest struct {
+	Endpoint string
+	Wait     time.Duration
+	Packet   []byte
 }
 
 func (f *Filter) String() string {
@@ -128,9 +138,15 @@ func (c *Command) Copy() *Command {
 		c2.Filter = new(Filter)
 		*c2.Filter = *c.Filter
 	}
+
 	if c.Level != nil {
 		c2.Level = new(log.Level)
 		*c2.Level = *c.Level
+	}
+
+	if c.ConnTest != nil {
+		c2.ConnTest = new(ConnTest)
+		*c2.ConnTest = *c.ConnTest
 	}
 
 	return c2


### PR DESCRIPTION
minimega, miniccc, and ron were updated to support executing tcp/udp
connectivity tests directly from miniccc agents.

ron was updated to include a new `ConnTest` command struct that
encapsulates the endpoint to test against, how long to wait, and what
UDP packet to send (if necessary).

miniccc was updated to include a handler for the new `ConnTest` command
that simply tries to dial the endpoint (in the case of TCP), and if
necessary write the UDP packet to the socket (in the case of UDP).

minimega was updated to include support for a new "cc test-conn"
command, as well as adding a "connectivity" column to the "cc commands"
table.

Documentation for minimega's "cc" command was also updated to include
details and examples of how to use the new "test-conn" command.