### PR TITLE
Allow user to specify which broadcast IP to use for meshage

### DIFF
--- a/docker/minimega.service
+++ b/docker/minimega.service
@@ -5,6 +5,7 @@ After=multi-user.target
 [Service]
 Environment="MM_BASE=/tmp/minimega"
 Environment="MM_FILEPATH=/tmp/minimega/files"
+Environment="MM_BROADCAST=255.255.255.255"
 Environment="MM_PORT=9000"
 Environment="MM_DEGREE=2"
 Environment="MM_CONTEXT=minimega"
@@ -16,6 +17,7 @@ ExecStart=/opt/minimega/bin/minimega \
   -nostdin \
   -base=${MM_BASE} \
   -filepath=${MM_FILEPATH} \
+  -broadcast=${MM_BROADCAST} \
   -port=${MM_PORT} \
   -degree=${MM_DEGREE} \
   -context=${MM_CONTEXT} \

--- a/src/minimega/main.go
+++ b/src/minimega/main.go
@@ -34,19 +34,20 @@ const (
 )
 
 var (
-	f_base       = flag.String("base", BASE_PATH, "base path for minimega data")
-	f_degree     = flag.Uint("degree", 0, "meshage starting degree")
-	f_msaTimeout = flag.Uint("msa", 10, "meshage MSA timeout")
-	f_port       = flag.Int("port", 9000, "meshage port to listen on")
-	f_force      = flag.Bool("force", false, "force minimega to run even if it appears to already be running")
-	f_nostdin    = flag.Bool("nostdin", false, "disable reading from stdin, useful for putting minimega in the background")
-	f_version    = flag.Bool("version", false, "print the version and copyright notices")
-	f_context    = flag.String("context", "minimega", "meshage context for discovery")
-	f_iomBase    = flag.String("filepath", IOM_PATH, "directory to serve files from")
-	f_cli        = flag.Bool("cli", false, "validate and print the minimega cli, in JSON, to stdout and exit")
-	f_panic      = flag.Bool("panic", false, "panic on quit, producing stack traces for debugging")
-	f_cgroup     = flag.String("cgroup", "/sys/fs/cgroup", "path to cgroup mount")
-	f_pipe       = flag.String("pipe", "", "read/write to or from a named pipe")
+	f_base        = flag.String("base", BASE_PATH, "base path for minimega data")
+	f_degree      = flag.Uint("degree", 0, "meshage starting degree")
+	f_msaTimeout  = flag.Uint("msa", 10, "meshage MSA timeout")
+	f_broadcastIP = flag.String("broadcast", "255.255.255.255", "meshage broadcast address to use")
+	f_port        = flag.Int("port", 9000, "meshage port to listen on")
+	f_force       = flag.Bool("force", false, "force minimega to run even if it appears to already be running")
+	f_nostdin     = flag.Bool("nostdin", false, "disable reading from stdin, useful for putting minimega in the background")
+	f_version     = flag.Bool("version", false, "print the version and copyright notices")
+	f_context     = flag.String("context", "minimega", "meshage context for discovery")
+	f_iomBase     = flag.String("filepath", IOM_PATH, "directory to serve files from")
+	f_cli         = flag.Bool("cli", false, "validate and print the minimega cli, in JSON, to stdout and exit")
+	f_panic       = flag.Bool("panic", false, "panic on quit, producing stack traces for debugging")
+	f_cgroup      = flag.String("cgroup", "/sys/fs/cgroup", "path to cgroup mount")
+	f_pipe        = flag.String("pipe", "", "read/write to or from a named pipe")
 
 	f_e         = flag.Bool("e", false, "execute command on running minimega")
 	f_attach    = flag.Bool("attach", false, "attach the minimega command line to a running instance of minimega")
@@ -216,7 +217,7 @@ func main() {
 	// needs a reference to the plumber, so the order here counts
 	tapReaperStart()
 
-	if err := meshageStart(hostname, *f_context, *f_degree, *f_msaTimeout, *f_port); err != nil {
+	if err := meshageStart(hostname, *f_context, *f_degree, *f_msaTimeout, *f_broadcastIP, *f_port); err != nil {
 		// TODO: we've created the PID file...
 		log.Fatal("unable to start meshage: %v", err)
 	}

--- a/src/minimega/meshage.go
+++ b/src/minimega/meshage.go
@@ -7,6 +7,7 @@ package main
 import (
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"iomeshage"
 	"math"
 	"math/rand"
@@ -14,6 +15,7 @@ import (
 	"minicli"
 	log "minilog"
 	"miniplumber"
+	"net"
 	"ranges"
 	"reflect"
 	"strconv"
@@ -67,8 +69,13 @@ func init() {
 	gob.Register(miniplumber.Message{})
 }
 
-func meshageStart(host, namespace string, degree, msaTimeout uint, port int) error {
-	meshageNode, meshageMessages = meshage.NewNode(host, namespace, degree, port, version.Revision)
+func meshageStart(host, namespace string, degree, msaTimeout uint, broadcastIP string, port int) error {
+	bip := net.ParseIP(broadcastIP)
+	if bip == nil {
+		return fmt.Errorf("invalid broadcast IP %s for meshage", broadcastIP)
+	}
+
+	meshageNode, meshageMessages = meshage.NewNode(host, namespace, degree, bip, port, version.Revision)
 
 	meshageNode.Snoop = meshageSnooper
 


### PR DESCRIPTION
In some cases, cluster compute nodes have multiple interfaces and
networks they can communicate with each other over, and one may be
desirable over another for meshage comms. By default, minimega uses
`255.255.255.255` as the broadcast address, and when multiple interfaces
are present, the one acting as the default route is the one used.

This commit adds a new command line option, `-broadcast`, for users to
specify which broadcast IP to use for the mesh. It defaults to
`255.255.255.255`, so this commit should be backwards compatible.