### PR TITLE
ron: version the cc message so heartbeats work across revisions

### DIFF
--- a/src/miniccc/heartbeat.go
+++ b/src/miniccc/heartbeat.go
@@ -77,9 +77,10 @@ func heartbeat() {
 	client.Tags = make(map[string]string)
 
 	m := &ron.Message{
-		Type:   ron.MESSAGE_CLIENT,
-		UUID:   c.UUID,
-		Client: c,
+		Type:    ron.MESSAGE_CLIENT,
+		UUID:    c.UUID,
+		Client:  c,
+		Version: "v1",
 	}
 
 	if err := sendMessage(m); err != nil {

--- a/src/ron/message.go
+++ b/src/ron/message.go
@@ -57,6 +57,11 @@ type Message struct {
 
 	// MESSAGE_UFS
 	UfsMode int
+
+	// version of message
+	// (initially added to help determine if server should send periodic
+	// heartbeats to client in support of serial reconnect)
+	Version string
 }
 
 func (t Type) String() string {

--- a/src/ron/version.go
+++ b/src/ron/version.go
@@ -1,0 +1,59 @@
+package ron
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var regex = regexp.MustCompile(`^(v|V)`)
+
+func majorVersion(v string) int {
+	parts := versionParts(v)
+
+	if len(parts) < 1 {
+		return 0
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0
+	}
+
+	return major
+}
+
+func minorVersion(v string) int {
+	parts := versionParts(v)
+
+	if len(parts) < 2 {
+		return 0
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0
+	}
+
+	return minor
+}
+
+func patchVersion(v string) int {
+	parts := versionParts(v)
+
+	if len(parts) < 3 {
+		return 0
+	}
+
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return 0
+	}
+
+	return patch
+}
+
+func versionParts(v string) []string {
+	v = regex.ReplaceAllString(v, "")
+	return strings.Split(v, ".")
+}


### PR DESCRIPTION
This is an attempt to make miniccc somewhat future-proof. Right now, if minimega is updated then miniccc running in existing images will continually fail and reconnect because currently we only start the heartbeat on the server if the commit versions between the server and miniccc match. This is somewhat okay, except for when `cc mount` needs to be used.

By versioning the cc message, we can now accurately determine if older miniccc agents can be used with newer versions of deployed servers.