### PR TITLE
[minimega] Get files to be sent to miniccc via mesh before sending

### DIFF
--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -382,10 +383,45 @@ func cliCCFilter(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 
 // send
 func cliCCFileSend(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	cmd, err := ns.ccServer.NewFilesSendCommand(c.ListArgs["file"])
+	files := make([]string, len(c.ListArgs["file"]))
+
+	// Ensure each file to be sent to the VM is present locally before sending.
+	for i, file := range c.ListArgs["file"] {
+		original := file
+
+		// Strip base path from the file if it's present since the base path gets
+		// prepended to the relative path somewhere along the way.
+		if strings.HasPrefix(file, *f_iomBase) {
+			rel, err := filepath.Rel(*f_iomBase, file)
+			if err != nil {
+				return err
+			}
+
+			file = rel
+		}
+
+		_, err := iomHelper(file)
+		if err != nil {
+			// There's no namespace directory created for the default namespace.
+			if ns.Name == DefaultNamespace {
+				return fmt.Errorf("unable to get file %s via the mesh: %w", original, err)
+			}
+
+			file = filepath.Join(ns.Name, file)
+
+			// Try again, but this time with the namespace directory prepended.
+			_, err := iomHelper(file)
+			if err != nil {
+				return fmt.Errorf("unable to get file %s via the mesh: %w", original, err)
+			}
+		}
+
+		files[i] = file
+	}
+
+	cmd, err := ns.ccServer.NewFilesSendCommand(files)
 	if err != nil {
 		return err
-
 	}
 
 	resp.Data = ns.NewCommand(cmd)


### PR DESCRIPTION
When a file is sent to a VM using cc, it's expected that the file is
already on the node running the VM. This commit adds support for
automatically getting the file to be sent to a VM from other nodes in
the mesh, similar to how it's done for VM disk images when they are
launched.