### PR TITLE
[minimega] Add flag for sending logs to a node via the mesh

### DIFF
--- a/cmd/minimega/deploy.go
+++ b/cmd/minimega/deploy.go
@@ -199,19 +199,30 @@ func deployRun(hosts []string, user, remotePath string, sudo bool) []error {
 func deployGetFlags() string {
 	if deployFlags != nil {
 		f := strings.Join(deployFlags, " ")
+
 		if !strings.Contains(f, "nostdin") {
 			f += " -nostdin=true"
 		}
+
 		return f
 	}
-	var flags []string
+
+	// default to having all mesh nodes send logs to this node
+	flags := []string{fmt.Sprintf("-lognode=%s", hostname)}
+
 	flag.VisitAll(func(f *flag.Flag) {
+		// ignore lognode setting for this node (will likely be empty)
+		if f.Name == "lognode" {
+			return
+		}
+
 		if f.Name == "nostdin" {
 			flags = append(flags, fmt.Sprintf("-%v=true", f.Name))
 		} else {
 			flags = append(flags, fmt.Sprintf("-%v=%v", f.Name, f.Value.String()))
 		}
 	})
+
 	return strings.Join(flags, " ")
 }
 

--- a/cmd/minimega/log.go
+++ b/cmd/minimega/log.go
@@ -5,7 +5,9 @@
 package main
 
 import (
+	"fmt"
 	"math/rand"
+	"strings"
 
 	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
 )
@@ -24,8 +26,7 @@ type meshageLogMessage struct {
 }
 
 type meshageLogWriter struct {
-	dest  string
-	level log.Level
+	dest string
 }
 
 // Write implements the io.Writer interface for meshageLogWriter.
@@ -38,23 +39,50 @@ func (this meshageLogWriter) Write(p []byte) (n int, err error) {
 // response is expected, thus this is non-blocking. Any errors sending logs over
 // the mesh are silently ignored.
 func (this meshageLogWriter) log(l []byte) {
-	to := []string{this.dest}
+	var (
+		to     = []string{this.dest}
+		msg    = string(l)
+		fields = strings.Fields(msg)
+	)
 
-	msg := meshageLogMessage{
+	// Should never happen... but let's do our best to avoid a panic anyway.
+	if len(fields) < 3 {
+		return
+	}
+
+	// The incoming log will have already been formatted with the standard log
+	// flags, to include the log level as the 3rd word in the log. This should
+	// *always* be the case. If for some reason it's not, the level variable will
+	// be set to -1 which means the receiving node won't end up doing anything
+	// with it.
+	level, _ := log.ParseLevel(strings.ToLower(fields[2]))
+
+	m := meshageLogMessage{
 		TID:   rand.Int63(),
 		From:  hostname,
-		Level: this.level,
-		Log:   string(l),
+		Level: level,
+		Log:   msg,
 	}
 
 	go func() {
-		meshageNode.Set(to, msg)
+		if _, ok := meshageNode.Mesh()[this.dest]; !ok {
+			log.Warn("log destination node not found: %s", this.dest)
+			return
+		}
+
+		meshageNode.Set(to, m)
 	}()
 }
 
-func setupMeshageLogging(node string) {
+func setupMeshageLogging(node string) error {
 	if node == "" {
-		return
+		// Do not error out here, since node will be an empty string if the -lognode
+		// flag was not provided (which is the default).
+		return nil
+	}
+
+	if node == hostname {
+		return fmt.Errorf("cannot use self as destination node for mesh logging")
 	}
 
 	level := logLevel
@@ -65,7 +93,19 @@ func setupMeshageLogging(node string) {
 		level = log.INFO
 	}
 
-	meshLogger := meshageLogWriter{dest: node, level: level}
+	// We do not verify the presence of the destination node in the mesh in this
+	// function just in case the mesh hasn't been fully formed by the time this
+	// function is called (for example, at startup when the destination node is
+	// specified via the -lognode flag).
+
+	meshLogger := meshageLogWriter{dest: node}
+
 	log.AddLogger("meshage", meshLogger, level, false)
+	// Add a filter for the log message that could be generated if the log
+	// destination node isn't in the mesh (defined above). Without this filter, we
+	// end up in a memory-consuming loop.
+	log.AddFilter("meshage", "log destination node not found")
+
 	logMeshNode = node
+	return nil
 }

--- a/cmd/minimega/log.go
+++ b/cmd/minimega/log.go
@@ -1,0 +1,71 @@
+// Copyright (2013) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"math/rand"
+
+	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
+)
+
+// mesh node we are currently logging to
+var logMeshNode string
+
+// Message is a log message that can be sent over the minimega mesh to another
+// node in the mesh. It's primary use is to consolidate logs from all nodes in a
+// mesh on a single node.
+type meshageLogMessage struct {
+	TID   int64     // unique ID for this message
+	From  string    // mesh node that generated the log
+	Level log.Level // log level
+	Log   string    // log message
+}
+
+type meshageLogWriter struct {
+	dest  string
+	level log.Level
+}
+
+// Write implements the io.Writer interface for meshageLogWriter.
+func (this meshageLogWriter) Write(p []byte) (n int, err error) {
+	this.log(p)
+	return len(p), nil
+}
+
+// log sends a log message to the specified host over the minimega mesh. No
+// response is expected, thus this is non-blocking. Any errors sending logs over
+// the mesh are silently ignored.
+func (this meshageLogWriter) log(l []byte) {
+	to := []string{this.dest}
+
+	msg := meshageLogMessage{
+		TID:   rand.Int63(),
+		From:  hostname,
+		Level: this.level,
+		Log:   string(l),
+	}
+
+	go func() {
+		meshageNode.Set(to, msg)
+	}()
+}
+
+func setupMeshageLogging(node string) {
+	if node == "" {
+		return
+	}
+
+	level := logLevel
+
+	// Meshage events get included in debug logs... if we propogate those here we
+	// end up in a memory-consuming loop.
+	if level == log.DEBUG {
+		level = log.INFO
+	}
+
+	meshLogger := meshageLogWriter{dest: node, level: level}
+	log.AddLogger("meshage", meshLogger, level, false)
+	logMeshNode = node
+}

--- a/cmd/minimega/log_cli.go
+++ b/cmd/minimega/log_cli.go
@@ -211,14 +211,17 @@ func cliLogMesh(ns *Namespace, c *minicli.Command, resp *minicli.Response) error
 		return nil
 	}
 
-	// rese logging to mesh if it's already enabled
-	if logMeshNode != "" {
-		log.DelLogger("meshage")
+	node := c.StringArgs["node"]
+
+	if _, ok := meshageNode.Mesh()[node]; !ok {
+		return fmt.Errorf("node %s not in mesh", node)
 	}
 
-	setupMeshageLogging(c.StringArgs["node"])
+	// reset logging to mesh if it's already enabled
+	log.DelLogger("meshage")
+	logMeshNode = ""
 
-	return nil
+	return setupMeshageLogging(node)
 }
 
 func cliLogRing(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/cmd/minimega/log_cli.go
+++ b/cmd/minimega/log_cli.go
@@ -53,6 +53,15 @@ Log to a file. To disable file logging, call "clear log file".`,
 		},
 		Call: wrapSimpleCLI(cliLogFile),
 	},
+	{ // log mesh
+		HelpShort: "enable logging to a mesh node",
+		HelpLong: `
+Log to a mesh node. To disable mesh logging, call "clear log mesh".`,
+		Patterns: []string{
+			"log mesh [node]",
+		},
+		Call: wrapSimpleCLI(cliLogMesh),
+	},
 	{ // log ring
 		HelpShort: "enable, disable, or dump log ring",
 		HelpLong: `
@@ -99,6 +108,7 @@ Resets state for logging. See "help log ..." for more information.`,
 		Patterns: []string{
 			"clear log",
 			"clear log <file,>",
+			"clear log <mesh,>",
 			"clear log <level,>",
 			"clear log <stderr,>",
 			"clear log <filter,>",
@@ -120,8 +130,21 @@ func cliLogLevel(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 	for k := range c.BoolArgs {
 		level, _ := log.ParseLevel(k)
 
+		// Meshage events get included in debug logs... if we propogate those to the
+		// meshage logger we end up in a memory-consuming loop.
+		if level == log.DEBUG {
+			for _, logger := range log.Loggers() {
+				if logger == "meshage" {
+					log.SetLevel(logger, log.INFO)
+				} else {
+					log.SetLevel(logger, level)
+				}
+			}
+		} else {
+			log.SetLevelAll(level)
+		}
+
 		logLevel = level
-		log.SetLevelAll(level)
 	}
 
 	return nil
@@ -174,6 +197,27 @@ func cliLogFile(ns *Namespace, c *minicli.Command, resp *minicli.Response) error
 	}
 
 	log.AddLogger("file", logFile, logLevel, false)
+	return nil
+}
+
+func cliLogMesh(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	if len(c.StringArgs) == 0 {
+		if logMeshNode == "" {
+			resp.Response = "mesh logging disabled"
+		} else {
+			resp.Response = fmt.Sprintf("sending all logs to node %s", logMeshNode)
+		}
+
+		return nil
+	}
+
+	// rese logging to mesh if it's already enabled
+	if logMeshNode != "" {
+		log.DelLogger("meshage")
+	}
+
+	setupMeshageLogging(c.StringArgs["node"])
+
 	return nil
 }
 
@@ -268,6 +312,12 @@ func cliLogClear(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 		if err := stopFileLogger(); err != nil {
 			return err
 		}
+	}
+
+	// Reset mesh if explicitly cleared or we're clearing everything
+	if c.BoolArgs["mesh"] || len(c.BoolArgs) == 0 {
+		log.DelLogger("meshage")
+		logMeshNode = ""
 	}
 
 	// Reset syslog if explicitly cleared or we're clearing everything

--- a/cmd/minimega/main.go
+++ b/cmd/minimega/main.go
@@ -49,6 +49,7 @@ var (
 	f_panic       = flag.Bool("panic", false, "panic on quit, producing stack traces for debugging")
 	f_cgroup      = flag.String("cgroup", "/sys/fs/cgroup", "path to cgroup mount")
 	f_pipe        = flag.String("pipe", "", "read/write to or from a named pipe")
+	f_lognode     = flag.String("lognode", "", "mesh node to send all logs to")
 
 	f_e         = flag.Bool("e", false, "execute command on running minimega")
 	f_attach    = flag.Bool("attach", false, "attach the minimega command line to a running instance of minimega")
@@ -227,6 +228,7 @@ func main() {
 	time.Sleep(500 * time.Millisecond)
 
 	plumberStart(meshageNode)
+	setupMeshageLogging(*f_lognode)
 
 	// has to happen after meshageNode is created
 	GetOrCreateNamespace(DefaultNamespace)

--- a/cmd/minimega/main.go
+++ b/cmd/minimega/main.go
@@ -157,9 +157,7 @@ func main() {
 				parts = append(parts, "namespace", *f_namespace)
 			}
 
-			for _, arg := range flag.Args() {
-				parts = append(parts, arg)
-			}
+			parts = append(parts, flag.Args()...)
 
 			cmd := quoteJoin(parts, " ")
 			if len(parts) == 1 {
@@ -228,7 +226,10 @@ func main() {
 	time.Sleep(500 * time.Millisecond)
 
 	plumberStart(meshageNode)
-	setupMeshageLogging(*f_lognode)
+
+	if err := setupMeshageLogging(*f_lognode); err != nil {
+		log.Fatal("unable to setup mesh logging: %v", err)
+	}
 
 	// has to happen after meshageNode is created
 	GetOrCreateNamespace(DefaultNamespace)


### PR DESCRIPTION
The new flag is `-lognode` and takes the name of a node on the mesh.
When minimega is deployed to other nodes using `deploy launch` the flag
will automatically be included using the hostname the deployment is
being run from.