### PR TITLE
Use channel instead of mutex to serialize cli and meshage commands

### DIFF
--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -773,7 +773,6 @@ func cliCCMount(c *minicli.Command, respChan chan<- minicli.Responses) {
 
 	var res minicli.Responses
 
-	// LOCK: this is a CLI handler so we already hold the cmdLock.
 	for resps := range runCommands(namespaceCommands(ns, c)...) {
 		for _, resp := range resps {
 			res = append(res, resp)
@@ -818,7 +817,6 @@ func cliCCMountUUID(c *minicli.Command, respChan chan<- minicli.Responses) {
 	// If we're doing the local behavior, only look at the local VMs.
 	// Otherwise, look globally. See note in cli.go.
 	if c.Source == "" {
-		// LOCK: this is a CLI handler so we already hold the cmdLock.
 		for _, vm2 := range globalVMs(ns) {
 			if vm2.GetName() == id || vm2.GetUUID() == id {
 				vm = vm2
@@ -1015,7 +1013,6 @@ func cliCCClear(ns *Namespace, c *minicli.Command, resp *minicli.Response) error
 	}
 
 	// fan out behavior
-	// LOCK: this is a CLI handler so we already hold the cmdLock.
 	return consume(runCommands(namespaceCommands(ns, c)...))
 }
 
@@ -1034,7 +1031,6 @@ func cliCCClearMount(c *minicli.Command, respChan chan<- minicli.Responses) {
 	}
 
 	if c.Source == "" {
-		// LOCK: this is a CLI handler so we already hold the cmdLock.
 		err := consume(runCommands(namespaceCommands(ns, c)...))
 		if err != nil {
 			resp.Error = err.Error()

--- a/cmd/minimega/cli.go
+++ b/cmd/minimega/cli.go
@@ -148,7 +148,6 @@ func wrapBroadcastCLI(fn wrappedCLIFunc) minicli.CLIFunc {
 
 		res := minicli.Responses{}
 
-		// LOCK: this is a CLI handler so we already hold the cmdLock.
 		for resps := range runCommands(namespaceCommands(ns, c)...) {
 			// TODO: we are flattening commands that return multiple responses
 			// by doing this... should we implement proper buffering? Only a
@@ -183,7 +182,6 @@ func wrapVMTargetCLI(fn wrappedCLIFunc) minicli.CLIFunc {
 
 		var notFound string
 
-		// LOCK: this is a CLI handler so we already hold the cmdLock.
 		for resps := range runCommands(namespaceCommands(ns, c)...) {
 			for _, resp := range resps {
 				ok = ok || (resp.Error == "")

--- a/cmd/minimega/cli.go
+++ b/cmd/minimega/cli.go
@@ -17,7 +17,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"unicode"
 
 	"github.com/sandia-minimega/minimega/v2/pkg/minicli"
@@ -27,8 +26,13 @@ import (
 	"github.com/peterh/liner"
 )
 
+type commands struct {
+	in  []*minicli.Command
+	out chan minicli.Responses
+}
+
 // Prevents multiple commands from running at the same time
-var cmdLock sync.Mutex
+var cmdChannel chan commands
 
 type wrappedCLIFunc func(*Namespace, *minicli.Command, *minicli.Response) error
 type wrappedSuggestFunc func(*Namespace, string, string) []string
@@ -63,6 +67,21 @@ func cliSetup() {
 	registerHandlers("vmconfiger", vmconfigerCLIHandlers)
 	registerHandlers("vnc", vncCLIHandlers)
 	registerHandlers("plumb", plumbCLIHandlers)
+
+	cmdChannel = make(chan commands)
+	go cmdProcessor()
+}
+
+func cmdProcessor() {
+	for cmd := range cmdChannel {
+		go func(cmd commands) {
+			defer close(cmd.out)
+
+			for _, c := range cmd.in {
+				forward(minicli.ProcessCommand(c), cmd.out)
+			}
+		}(cmd)
+	}
 }
 
 // registerHandlers registers all the provided handlers with minicli, panicking
@@ -354,37 +373,13 @@ func consume(in <-chan minicli.Responses) error {
 	return err
 }
 
-// runCommands is RunCommands without locking cmdLock.
-func runCommands(cmd ...*minicli.Command) <-chan minicli.Responses {
-	out := make(chan minicli.Responses)
-
-	// Run commands serially and forward all the responses to out
-	go func() {
-		defer close(out)
-
-		for _, c := range cmd {
-			forward(minicli.ProcessCommand(c), out)
-		}
-	}()
-
-	return out
-}
-
-// RunCommands wraps minicli.ProcessCommand for multiple commands, combining
+// runCommands wraps minicli.ProcessCommand for multiple commands, combining
 // their outputs into a single channel.
-func RunCommands(cmd ...*minicli.Command) <-chan minicli.Responses {
-	cmdLock.Lock()
+func runCommands(cmd ...*minicli.Command) <-chan minicli.Responses {
+	c := commands{in: cmd, out: make(chan minicli.Responses)}
 
-	out := make(chan minicli.Responses)
-	go func() {
-		// Unlock and close the channel after forwarding all the responses
-		defer cmdLock.Unlock()
-		defer close(out)
-
-		forward(runCommands(cmd...), out)
-	}()
-
-	return out
+	cmdChannel <- c
+	return c.out
 }
 
 // namespaceCommands creates commands to run the given command on all hosts in
@@ -482,7 +477,7 @@ func cliLocal(input *liner.State) {
 			log.Warn("namespace changed between prompt and execution")
 		}
 
-		for resp := range RunCommands(cmd) {
+		for resp := range runCommands(cmd) {
 			// print the responses
 			minipager.DefaultPager.Page(resp.String())
 

--- a/cmd/minimega/command_meshage.go
+++ b/cmd/minimega/command_meshage.go
@@ -38,7 +38,7 @@ func meshageHandler() {
 			}
 
 			resps := []minicli.Responses{}
-			for resp := range RunCommands(cmd) {
+			for resp := range runCommands(cmd) {
 				resps = append(resps, resp)
 			}
 

--- a/cmd/minimega/command_socket.go
+++ b/cmd/minimega/command_socket.go
@@ -149,7 +149,7 @@ func commandSocketHandle(c net.Conn) {
 
 		// Keep sending until we hit the first error, then just consume the
 		// channel to ensure that we release any locks acquired by cmd.
-		for resp := range RunCommands(cmd) {
+		for resp := range runCommands(cmd) {
 			if prev != nil && err == nil {
 				err = sendLocalResp(enc, prev, true)
 			} else if err != nil && len(resp) > 0 {

--- a/cmd/minimega/dot.go
+++ b/cmd/minimega/dot.go
@@ -57,8 +57,6 @@ func cliDot(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 
 	vlans := make(map[int]bool)
 
-	// LOCK: This is a CLI handler so we already hold cmdLock (can call
-	// globalVMs instaed of GlobalVMs).
 	for _, vm := range globalVMs(ns) {
 		ip, err := vm.Info("ip")
 		ip6, err2 := vm.Info("ip6")

--- a/cmd/minimega/misc_cli.go
+++ b/cmd/minimega/misc_cli.go
@@ -60,14 +60,12 @@ Read a command file and execute it. This has the same behavior as if you typed
 the file in manually. read stops if it reads an invalid command. read does not
 stop if a command returns an error. Nested reads are not permitted.
 
-Because reading and executing long files can take a while, the read command
-releases the command lock that it holds so commands from other clients
-(including miniweb) can be interleaved. To prevent issues with another script
-changing the namespace and commands being run in a different namespace than
-originally intended, read records the active namespace when it starts and
-prepends that namespace to all commands that it reads from the file. If it
-reads a command that would change the active namespace, read updates its state
-so that the new namespace is prepended instead.
+To prevent issues with another script changing the namespace and commands being
+run in a different namespace than originally intended, read records the active
+namespace when it starts and prepends that namespace to all commands that it
+reads from the file. If it reads a command that would change the active
+namespace, read updates its state so that the new namespace is prepended
+instead.
 
 If the optional argument check is specified then read doesn't execute any of
 the commands in the file. Instead, it checks that all the commands are

--- a/cmd/minimega/misc_cli.go
+++ b/cmd/minimega/misc_cli.go
@@ -176,14 +176,8 @@ func cliRead(c *minicli.Command, respChan chan<- minicli.Responses) {
 		respChan <- minicli.Responses{resp}
 		return
 	}
-	defer file.Close()
 
-	// HACK: We *don't* want long-running read commands to cause all other
-	// commands to block so we *unlock* the command lock here and *lock* it
-	// again for each command that we read (well, `RunCommands` handles the
-	// locking for us).
-	cmdLock.Unlock()
-	defer cmdLock.Lock()
+	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
 
@@ -238,7 +232,7 @@ func cliRead(c *minicli.Command, respChan chan<- minicli.Responses) {
 			}
 		}
 
-		forward(RunCommands(cmd), respChan)
+		forward(runCommands(cmd), respChan)
 
 		if namespace != "" {
 			log.Info("read switching to namespace `%v`", namespace)

--- a/cmd/minimega/misc_cli.go
+++ b/cmd/minimega/misc_cli.go
@@ -343,7 +343,6 @@ func cliClearAll(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 
 	var cmds []*minicli.Command
 
-	// LOCK: this is a CLI hander so we already hold the cmdLock.
 	for _, v := range all {
 		cmd := minicli.MustCompile(v)
 		// keep the original source

--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -263,8 +263,6 @@ func (n *Namespace) Queue(arg string, vmType VMType, vmConfig VMConfig) error {
 	takenName := map[string]bool{}
 	takenUUID := map[string]bool{}
 
-	// LOCK: This is only invoked via the CLI so we already hold cmdLock (can
-	// call globalVMs instead of GlobalVMs).
 	for _, vm := range globalVMs(n) {
 		takenName[vm.GetName()] = true
 		takenUUID[vm.GetUUID()] = true
@@ -312,8 +310,6 @@ func (n *Namespace) Queue(arg string, vmType VMType, vmConfig VMConfig) error {
 }
 
 // hostStats returns stats from hosts in the namespace.
-//
-// LOCK: Assumes cmdLock is held.
 func (n *Namespace) hostStats() []*HostStats {
 	// run `host` across the namespace
 	cmds := namespaceCommands(n, minicli.MustCompile("host"))
@@ -343,8 +339,6 @@ func (n *Namespace) hostStats() []*HostStats {
 //
 // If dryRun is true, the scheduler will determine VM placement but not
 // actually launch any VMs so that the user can tinker with the schedule.
-//
-// LOCK: Assumes cmdLock is held.
 func (n *Namespace) Schedule(dryRun bool) error {
 	if len(n.Hosts) == 0 {
 		return errors.New("namespace must contain at least one host to launch VMs")
@@ -673,8 +667,6 @@ func (n *Namespace) processVMNets(vals []string) error {
 // Both a state file (migrate) and hard disk file (disk) are created for each
 // VM in the namespace. If dir is not an absolute path, it will be a
 // subdirectory of iomBase.
-//
-// LOCK: Assumes cmdLock is held.
 func (n *Namespace) Snapshot(dir string) error {
 	var useIOM bool
 	if !filepath.IsAbs(dir) {
@@ -710,8 +702,6 @@ func (n *Namespace) Snapshot(dir string) error {
 		return err
 	}
 
-	// LOCK: This is only invoked via the CLI so we already hold cmdLock (can
-	// call globalVMs instead of GlobalVMs).
 	for _, vm := range globalVMs(n) {
 		// only snapshot KVMs
 		if vm.GetType() == KVM {

--- a/cmd/minimega/namespace_cli.go
+++ b/cmd/minimega/namespace_cli.go
@@ -174,9 +174,6 @@ func cliNamespace(c *minicli.Command, respChan chan<- minicli.Responses) {
 			c.Subcommand.Record = false
 
 			// Run the subcommand and forward the responses.
-			//
-			// LOCK: This is a CLI so we already hold cmdLock (can call
-			// runCommands instead of RunCommands).
 			forward(runCommands(c.Subcommand), respChan)
 			return
 		}

--- a/cmd/minimega/vm_cli.go
+++ b/cmd/minimega/vm_cli.go
@@ -1038,7 +1038,7 @@ func cliVMSuggest(ns *Namespace, prefix string, mask VMState, wild bool) []strin
 		res = append(res, Wildcard)
 	}
 
-	for _, vm := range GlobalVMs(ns) {
+	for _, vm := range globalVMs(ns) {
 		if vm.GetState()&mask == 0 {
 			continue
 		}

--- a/cmd/minimega/vms.go
+++ b/cmd/minimega/vms.go
@@ -600,17 +600,9 @@ func meshageVMLauncher() {
 	}
 }
 
-// GlobalVMs gets the VMs from all hosts in the mesh, filtered to the current
+// globalVMs gets the VMs from all hosts in the mesh, filtered to the current
 // namespace, if applicable. The keys of the returned map do not match the VM's
 // ID.
-func GlobalVMs(ns *Namespace) []VM {
-	cmdLock.Lock()
-	defer cmdLock.Unlock()
-
-	return globalVMs(ns)
-}
-
-// globalVMs is GlobalVMs without locking cmdLock.
 func globalVMs(ns *Namespace) []VM {
 	// run `vm info` across the namespace
 	cmds := namespaceCommands(ns, minicli.MustCompile("vm info"))

--- a/doc/content/articles/developer/locking.article
+++ b/doc/content/articles/developer/locking.article
@@ -13,8 +13,7 @@ This leads to many potential deadlocks which this article aims to prevent.
 In general, locks should only be used in the file where they are defined. Files
 typically include a type definition and some number of functions that operate
 on those types. Therefore, if a file defines a lock, most of the functions that
-are semantically related to the lock should be defined in the same file. An
-exception to this rule is the `cmdLock` which is described below.
+are semantically related to the lock should be defined in the same file.
 
 We are in the process of moving towards a naming convention within minimega --
 if both an `exported` and `internal` function exist, the exported function
@@ -39,26 +38,16 @@ that calling the internal function is indeed correct.
 
 ** Locks in minimega
 
-*** `cmdLock`
+*** `cmdChannel`
 
-This is the biggest lock in minimega -- it serializes all commands from the
-CLI, meshage, the domain socket, and other sources.  All `cli*` handlers assume
-that this lock is held when they are invoked.  `RunCommands`, which wraps
-`minicli.ProcessCommand`, acquires the cmdLock and should be used for all
-asynchronous tasks (e.g. handling meshage requests). If a handler needs to run
-a subsequent command, it may use `runCommands` instead since the cmdLock is
-already held. `minicli.ProcessCommand` should only be called by `runCommands`.
+`cmdChannel` is a channel that acts as a lock to serialize all commands from the
+CLI, meshage, domain socket, and other sources. All `cli*` handlers assume this
+channel is used for synchronization when they are invoked. `runCommands`, which
+wraps `minicli.ProcessCommand`, adds commands to the `cmdChannel` and should be
+used for all asynchronous tasks (e.g. handling meshage requests).
+`minicli.ProcessCommand` should only be called by `runCommands`.
 
-This lock greatly reduces the overall locking in minimega -- if data is only
-accessed via a CLI handler, it does not require its own lock.
-
-Note: the `read` API handler uses the `cmdLock` unnaturally -- it releases the
-lock in the handler and relocks it upon returning. This allows the commands
-that are read from the file to be interleaved with commands from meshage and
-the web so that the user can observe the progression of the `read` command.
-This may create issues if the interleaved commands are not strictly read-only
-but it was unacceptable to lock up minimega for tens of minutes or more while
-it read long scripts.
+This channel greatly reduces the overall locking in minimega.
 
 *** `vmLock`
 
@@ -92,7 +81,7 @@ for minimega once, when we try to launch the first container.
 getting and setting the active namespace and creating a new namespace. The
 exported `*Namespace` functions acquire this lock automatically. We currently
 do not use this lock to synchronize access to the underlying Namespace structs
--- these should be synchronized via the `cmdLock`.
+-- these should be synchronized via the `cmdChannel` used by `runCommands`.
 
 ** Hierarchy of locks
 
@@ -100,7 +89,7 @@ One way to prevent deadlocks in programs with multiple locks is to ensure that
 threads always acquire locks in the same order. We attempt to follow this idea
 and have defined the following hierarchy:
 
-    cmdLock > vmLock > VM.lock > all other locks
+    cmdChannel > vmLock > VM.lock > all other locks
     locks in minimega >> locks in other packages
 
 Developers must ensure that any blocking operations on channels do not


### PR DESCRIPTION
There are cases where one mesh node sends commands to another, and while
waiting for the other node to respond it sends the original node a
command as well and waits for it to respond, leading to a blocking race
condition. Below is an example:

When adding a network interface to an existing VM using "vm net add",
the node the "vm net add" command is executed on sends a command over
the mesh to the node the VM is running on and waits for a response.

```
       vm net add
head --------------> compute
```

When the compute node adds the network interface to the VM, it checks to
see if the VLAN alias for the interface exists. If it doesn't, it
creates the Alias-to-ID mapping and publishes it out to all the nodes in
the mesh and waits for a response.

```
        vlans add
head <-------------- compute
```

This is where the blocking race condition occurs. The head node cannot
process the "vlan add" command from the compute node until the compute
node responds to the "vm net add" command, but the compute node is
waiting for the head node to respond to the "vlans add" command before
it responds to the "vm net add" command.

```
      vlans add resp
head -------X-------> compute

      vm net add resp
head <------X--------- compute
```

The reason the head node cannot respond to the "vlan add" command is due
to the cmdLock mutex (which isn't protecting data but is instead
ensuring commands are processed in a serial fashion), needed to process
the "vlan add" command, being held by the function that made the "vm net
add" call.

The fix for this was to switch from using a mutex ensuring commands are
run in serial to using a channel, because the channel can queue commands
to prevent blocking.