### PR TITLE
[minimega] Periodically publish status of file transfers

### DIFF
--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -400,7 +400,7 @@ func cliCCFileSend(ns *Namespace, c *minicli.Command, resp *minicli.Response) er
 			file = rel
 		}
 
-		_, err := iomHelper(file)
+		_, err := iomHelper(file, c.Source)
 		if err != nil {
 			// There's no namespace directory created for the default namespace.
 			if ns.Name == DefaultNamespace {
@@ -410,7 +410,7 @@ func cliCCFileSend(ns *Namespace, c *minicli.Command, resp *minicli.Response) er
 			file = filepath.Join(ns.Name, file)
 
 			// Try again, but this time with the namespace directory prepended.
-			_, err := iomHelper(file)
+			_, err := iomHelper(file, c.Source)
 			if err != nil {
 				return fmt.Errorf("unable to get file %s via the mesh: %w", original, err)
 			}

--- a/cmd/minimega/cli.go
+++ b/cmd/minimega/cli.go
@@ -504,12 +504,12 @@ func cliPreprocess(v string) (string, error) {
 		switch u.Scheme {
 		case "file":
 			log.Debug("file preprocessor")
-			return iomHelper(u.Opaque)
+			return iomHelper(u.Opaque, "")
 		case "http", "https":
 			log.Debug("http/s preprocessor")
 
 			// Check if we've already downloaded the file
-			v2, err := iomHelper(u.Path)
+			v2, err := iomHelper(u.Path, "")
 			if err == nil {
 				return v2, err
 			}
@@ -534,7 +534,7 @@ func cliPreprocess(v string) (string, error) {
 
 			if !filepath.IsAbs(u.Path) {
 				// not absolute -- try to fetch via meshage
-				v2, err := iomHelper(u.Opaque)
+				v2, err := iomHelper(u.Opaque, "")
 				if err != nil {
 					return v, err
 				}

--- a/cmd/minimega/main.go
+++ b/cmd/minimega/main.go
@@ -241,6 +241,23 @@ func main() {
 	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
 
 	if !*f_nostdin {
+		// start status handler
+		go func() {
+			status := make(chan string)
+
+			addStatusMessageChannel("localcli", status)
+
+			for {
+				select {
+				case <-shutdown:
+					delStatusMessageChannel("localcli")
+					return
+				case s := <-status:
+					minipager.DefaultPager.Page(s)
+				}
+			}
+		}()
+
 		// start CLI
 		input := liner.NewLiner()
 		defer input.Close()

--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -524,10 +524,10 @@ Outer:
 
 // Launch wraps VMs.Launch, registering the launched VMs with ron. It blocks
 // until all the VMs are launched.
-func (n *Namespace) Launch(q *QueuedVMs) []error {
+func (n *Namespace) Launch(requestor string, q *QueuedVMs) []error {
 	// collect all the errors
 	errs := []error{}
-	for err := range n.VMs.Launch(n.Name, q) {
+	for err := range n.VMs.Launch(requestor, n.Name, q) {
 		errs = append(errs, err)
 	}
 
@@ -557,7 +557,7 @@ func (n *Namespace) hostLaunch(host string, queued *QueuedVMs, respChan chan<- m
 			Response: strconv.Itoa(len(queued.Names)),
 		}
 
-		if err := makeErrSlice(n.Launch(queued)); err != nil {
+		if err := makeErrSlice(n.Launch("", queued)); err != nil {
 			resp.Error = err.Error()
 		}
 

--- a/cmd/minimega/status.go
+++ b/cmd/minimega/status.go
@@ -1,0 +1,54 @@
+// Copyright (2013) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// meshageStatusMessage is a message that is sent over the minimega mesh to
+// another node in the mesh to update it on the status of a long running
+// command.
+type meshageStatusMessage struct {
+	TID    int64  // unique ID for this message
+	From   string // mesh node that generated the status
+	Status string // status message
+}
+
+var (
+	// guards messageStatusChans and meshageStatusPeriod
+	meshageStatusLock  sync.RWMutex
+	meshageStatusChans = make(map[string]chan string)
+	// default amount of time to wait between status update publishes
+	meshageStatusPeriod = 3 * time.Second
+)
+
+func addStatusMessageChannel(name string, c chan string) {
+	meshageStatusLock.Lock()
+	defer meshageStatusLock.Unlock()
+
+	meshageStatusChans[name] = c
+}
+
+func delStatusMessageChannel(name string) {
+	meshageStatusLock.Lock()
+	defer meshageStatusLock.Unlock()
+
+	delete(meshageStatusChans, name)
+}
+
+func sendStatusMessage(status string, to ...string) {
+	m := meshageStatusMessage{
+		TID:    rand.Int63(),
+		From:   hostname,
+		Status: status,
+	}
+
+	go func() {
+		meshageNode.Set(to, m)
+	}()
+}

--- a/doc/content/articles/developer/status_updates.article
+++ b/doc/content/articles/developer/status_updates.article
@@ -1,0 +1,59 @@
+Status Updates
+
+The minimega authors
+23 Aug 2022
+
+* Introduction
+
+Status updates allow developers to provide periodic feedback for long running
+commands, like file transfers, to users outside of the existing command response
+channel. A channel separate from the existing command response channel is used
+to prevent developers from having to change their existing workflow and allow
+developers to add status updates to existing code quickly and easily.
+
+* Overview
+
+One of the major design goals of status updates was to make as few changes to
+the existing code base as possible while facilitating periodic feedback to
+users. The initial use case for status updates was to prevent minimega from
+seeming like (to users) it has locked up when a user launches VMs that require
+disk images to be transferred between minimega nodes.
+
+** Sending status updates
+
+Status updates are simple strings describing whatever the current status of a
+long running command is -- they are context specific. They have their own
+message format -- `meshageStatusMessage` -- that is used to send status updates
+to nodes as the body of a meshage message, which contains the update message and
+the node that generated the update.
+
+The `sendStatusMessage` function can be used to send a status update to another
+node in the mesh. See `cmd/minimega/status.go` for implementation-specific
+details. See the `iomWait` function in `cmd/minimega/iomeshage.go` for an
+example of how status updates are being sent.
+
+The `meshageStatusPeriod` duration variable should be used by developers to
+limit how often status updates are sent for any particular long running task.
+The duration defaults to 3s, and can be configured by users via the `status
+update [frequency]` API command. Users are able to disable status updates by
+setting the frequency to 0. When status updates are disabled, rather than
+setting `meshageStatusPeriod` to 0, it is set to `math.MaxInt64` to make the
+common check of `if time.Since(lastUpdate) >= meshageStatusPeriod` work the same
+regardless.
+
+** Receiving and processing status updates
+
+The meshage mux handles status update messages coming into a node. It sends a
+copy of the status update string, prepended with the name of the node that sent
+the update, to one or more channels that have been registered to receive a copy.
+
+Functions that want to process (e.g., display) status updates, like
+`cmd/minimega/main.go` and `cmd/minimega/command_socket.go`, register a channel
+using `addStatusMessageChannel` and process updates that are sent to the channel
+(e.g., print them via the minipager).
+
+** Receiving status updates via miniclient
+
+The `miniclient.Response` struct has been updated to include a `Status bool`
+field. When set, the `Response` struct is a status update with the `Rendered`
+field containing the update string.

--- a/internal/iomeshage/iomeshage.go
+++ b/internal/iomeshage/iomeshage.go
@@ -476,7 +476,7 @@ func (iom *IOMeshage) whoHas(filename string, p int64) (string, error) {
 
 	var timeoutCount int
 
-	// wait for n responses, or too many timeouts
+	// wait for a response, or too many timeouts
 	for i := 0; i < len(recipients); i++ {
 		select {
 		case resp := <-c:

--- a/pkg/miniclient/client.go
+++ b/pkg/miniclient/client.go
@@ -42,6 +42,10 @@ type Response struct {
 	Rendered string
 	More     bool // whether there are more responses coming
 
+	// Status is set if responding with status update for command (Rendered will
+	// contain the status message).
+	Status bool
+
 	// Suggest is returned in response to Suggest request
 	Suggest []string `json:",omitempty"`
 }
@@ -218,6 +222,13 @@ func (mm *Conn) Run(cmd string) chan *Response {
 			}
 
 			out <- &r
+
+			// If this was a status update response then continue reading from the
+			// socket no matter what.
+			if r.Status {
+				continue
+			}
+
 			if !r.More {
 				log.Debugln("got last message")
 				break


### PR DESCRIPTION
A new "status update" construct was added to provide long running
commands the ability to periodically send status updates about the long
running command to one or more nodes in the mesh.

A "status update" API command was added to allow users to adjust how
often, if at all, status updates are sent.

A developer article was added to help developers understand how the
construct was added and how it can be used.

While testing status updates, it was discovered that a lot of error logs
were being generated for things that weren't actually errors, so that
was fixed as well.