### PR TITLE
[minimega] Log error instead of returning if cc mount path can't be unmounted

### DIFF
--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -820,7 +820,7 @@ func (ns *Namespace) clearCCMount(s string) error {
 
 		if mnt.Path != "" {
 			if err := syscall.Unmount(mnt.Path, 0); err != nil {
-				return err
+				log.Error("unable to unmount %s: %v", mnt.Path, err)
 			}
 		}
 
@@ -833,7 +833,7 @@ func (ns *Namespace) clearCCMount(s string) error {
 
 		// VM is running locally
 		if err := ns.ccServer.DisconnectUFS(uuid); err != nil {
-			return err
+			log.Error("unable to disconnect UFS for %s mount: %v", mnt.Name, err)
 		}
 
 		delete(ns.ccMounts, uuid)


### PR DESCRIPTION
When unmounting a VM's file system using `clear cc mount`, don't immediately return on errors, but instead log the error and allow the remaining commands to still attempt to be run.