### PR TITLE
minimega: add CLI flag for setting default VLAN range for namespaces

### DIFF
--- a/cmd/minimega/main.go
+++ b/cmd/minimega/main.go
@@ -14,11 +14,13 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/sandia-minimega/minimega/v2/internal/version"
+	"github.com/sandia-minimega/minimega/v2/internal/vlans"
 	"github.com/sandia-minimega/minimega/v2/pkg/minicli"
 	"github.com/sandia-minimega/minimega/v2/pkg/miniclient"
 	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
@@ -39,6 +41,7 @@ var (
 	f_degree      = flag.Uint("degree", 0, "meshage starting degree")
 	f_msaTimeout  = flag.Uint("msa", 10, "meshage MSA timeout")
 	f_broadcastIP = flag.String("broadcast", "255.255.255.255", "meshage broadcast address to use")
+	f_vlanRange   = flag.String("vlanrange", "101-4096", "default VLAN range for namespaces")
 	f_port        = flag.Int("port", 9000, "meshage port to listen on")
 	f_force       = flag.Bool("force", false, "force minimega to run even if it appears to already be running")
 	f_nostdin     = flag.Bool("nostdin", false, "disable reading from stdin, useful for putting minimega in the background")
@@ -242,6 +245,30 @@ func main() {
 	// has to happen after meshageNode is created
 	GetOrCreateNamespace(DefaultNamespace)
 	SetNamespace(DefaultNamespace)
+
+	// set default VLAN range
+	vlanRange := strings.Split(*f_vlanRange, "-")
+	if len(vlanRange) != 2 {
+		log.Fatal("invalid VLAN range provided")
+	}
+
+	min, err := strconv.Atoi(vlanRange[0])
+	if err != nil {
+		log.Fatal("expected integer values for VLAN range")
+	}
+
+	max, err := strconv.Atoi(vlanRange[1])
+	if err != nil {
+		log.Fatal("expected integer values for VLAN range")
+	}
+
+	if max <= min {
+		log.Fatal("expected min < max")
+	}
+
+	if err := vlans.SetRange("", min, max); err != nil {
+		log.Fatal("unable to set default VLAN range to %s: %v", *f_vlanRange, err)
+	}
 
 	commandSocketStart()
 

--- a/cmd/minimega/main.go
+++ b/cmd/minimega/main.go
@@ -263,7 +263,7 @@ func main() {
 	}
 
 	if max <= min {
-		log.Fatal("expected min < max")
+		log.Fatal("expected min < max for VLAN range")
 	}
 
 	if err := vlans.SetRange("", min, max); err != nil {

--- a/docker/start-minimega.sh
+++ b/docker/start-minimega.sh
@@ -9,6 +9,7 @@
 : "${MM_BASE:=/tmp/minimega}"
 : "${MM_FILEPATH:=/tmp/minimega/files}"
 : "${MM_BROADCAST:=255.255.255.255}"
+: "${MM_VLANRANGE:=101-4096}"
 : "${MM_PORT:=9000}"
 : "${MM_DEGREE:=2}"
 : "${MM_CONTEXT:=minimega}"
@@ -25,6 +26,7 @@
   -base=${MM_BASE} \
   -filepath=${MM_FILEPATH} \
   -broadcast=${MM_BROADCAST} \
+  -vlanrange=${MM_VLANRANGE} \
   -port=${MM_PORT} \
   -degree=${MM_DEGREE} \
   -context=${MM_CONTEXT} \


### PR DESCRIPTION
This is useful for avoiding VLAN ID ranges that are used for production or lab networks that minimega may be tied into for hardware-in-the-loop access to real devices/workstations/servers.

The default for the flag is the same as the current default range, so not setting the flag provides backwards compatibility.