### PR TITLE
[minimega] Retry (with backoff) finding disk partitions for injects

### DIFF
--- a/cmd/minimega/disk.go
+++ b/cmd/minimega/disk.go
@@ -227,11 +227,21 @@ func diskInject(dst, partition string, pairs map[string]string, options []string
 		path = nbdPath + "p" + partition
 
 		// check desired partition exists
-		_, err = os.Stat(path)
-		if err != nil {
-			return fmt.Errorf("[image %s] desired partition %s not found", dst, partition)
-		} else {
+		for i := 1; i <= 5; i++ {
+			_, err = os.Stat(path)
+			if err != nil {
+				err = fmt.Errorf("[image %s] desired partition %s not found", dst, partition)
+
+				time.Sleep(time.Duration(i*100) * time.Millisecond)
+				continue
+			}
+
 			log.Info("desired partition %s found in image %s", partition, dst)
+			break
+		}
+
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Lately we've been seeing a lot of `desired partition <n> not found` errors when injecting files into VM disk images. Adding this retry with backoff has proven to help reduce how often we see this issue (basically we don't see it anymore at all).