### PR TITLE
[pyapigen] Allow zeros in minimega command args

### DIFF
--- a/cmd/pyapigen/template.go
+++ b/cmd/pyapigen/template.go
@@ -167,7 +167,7 @@ class minimega(object):
 		if self._namespace is not None:
 			cmd = ['namespace', self._namespace] + cmd
 
-		msg = json.dumps({'Command': ' '.join([str(v) for v in cmd if v])})
+		msg = json.dumps({'Command': ' '.join([str(v) for v in cmd if v is not None])})
 
 		with self._lock:
 			if self.moreResponses:


### PR DESCRIPTION
The Python command `' '.join([str(v) for v in cmd if v])` will exclude command args that are `0`, which breaks, for example, capturing traffic on interface 0 of a VM.

Instead, use test `if v is not None`. This will allow empty strings to get through, but that shouldn't cause a problem.