### PR TITLE
[minimega] smartcard support

### DIFF
--- a/internal/qmp/qmp.go
+++ b/internal/qmp/qmp.go
@@ -458,6 +458,43 @@ func (q *Conn) USBDeviceAdd(id, bus, serial string) (string, error) {
 	return resp, err
 }
 
+func (q *Conn) CCIDAdd() (string, error) {
+	if !q.ready {
+		return "", ERR_READY
+	}
+
+	arg := fmt.Sprintf("device_add usb-ccid")
+
+	log.Debugln("sending qmp command: ", arg)
+	resp, err := q.HumanMonitorCommand(arg)
+	return resp, err 
+}
+
+func (q *Conn) SmartcardAdd(id, smartcard_path string) (string, error) {
+	if !q.ready {
+		return "", ERR_READY
+	}
+	var arg string 
+
+
+	default_options := fmt.Sprintf("backend=certificates,cert1=id-cert,cert2=signing-cert,cert3=encryption-cert")
+
+	if smartcard_path != "" {
+		arg = fmt.Sprintf("device_add ccid-card-emulated,id=%v,%v,db=sql:%v", id, default_options, smartcard_path)
+	} else {
+		arg = fmt.Sprintf("device_add ccid-card-emulated,id=%v", id)
+	}
+	log.Debugln("sending qmp command: ", arg)
+	resp, err := q.HumanMonitorCommand(arg)
+	return resp, err
+}
+
+func (q *Conn) SmartcardRemove(id string) (string, error) {
+	resp, err := q.USBDeviceDel(id)
+	return resp, err 
+}
+
+
 func (q *Conn) NetDevAdd(devType, id, ifname string) (string, error) {
 	if !q.ready {
 		return "", ERR_READY


### PR DESCRIPTION
Adding smartcard support to minimega. Work in progress -- Needs testing for physical smart cards and different types of emulated smart cards.

Only one smartcard per launched VM at a time. Supports both physical and emulated cards.

This pull request will not change minimega functionality outside of smart cards.  Upon a call to `vm smartcard add VM_NAME`, a `usb-ccid` device will be added to the VM, as well as `usb-smartcard-emulated`. 

A smart card reader (`usb-ccid`) is added on the first call of `vm smartcard add` and remains for the lifespan of the VM. Launched VMs that are not using smart cards will not have a reader attached during start up.

## TODO
- Test connecting physical smart card to machine running the experiment
- Test different types of emulated smart cards
	- The provided arguments are rigid -- making all parameters configurable would be a good idea
	- `internal/qmp/qmp.go line 480`
- Add ability to attach multiple smart cards at once
	- Does this require multiple `usb-ccid` devices? 
- Update documentation

## Commands
`vm smartcard` - display attached smartcards
`vm smartcard add VM_NAME` - add a physical smart card (and CCID bus if connecting for the first time)
`vm smartcard add VM_NAME /path/to/smartcard` - add an emulated (or fake) smartcard
`vm smartcard remove VM_NAME` - disconnect the attached smartcard

## Tests
On a VM, install the following packages:
```
pcscd pcsc-tools libnss3-tools opensc
```

To view attached smart cards (and CCID interfaces):
- `lsusb`
	- show connected USB devices (will show smart card reader after first smart card attached)
- `opensc-tool -l`
	- list all connected smart card readers
- `pcsc_scan`
	- shows connected smart card readers and cards. Runs continuously, you can see the card being added and removed

1. Launch a VM as normal
2. Create a fake smartcard (As seen in the [QEMU CCID article](https://www.qemu.org/docs/master/system/devices/ccid.html))
```
mkdir fake-smartcard
cd fake-smartcard
certutil -N -d sql:$PWD
certutil -S -d sql:$PWD -s "CN=Fake Smart Card CA" -x -t TC,TC,TC -n fake-smartcard-ca
certutil -S -d sql:$PWD -t ,, -s "CN=John Doe" -n id-cert -c fake-smartcard-ca
certutil -S -d sql:$PWD -t ,, -s "CN=John Doe (signing)" --nsCertType smime -n signing-cert -c fake-smartcard-ca
certutil -S -d sql:$PWD -t ,, -s "CN=John Doe (encryption)" --nsCertType sslClient -n encryption-cert -c fake-smartcard-ca
```
3. Make sure `pcscd` is running and run `pcsc_scan` on vm
```
$ sudo systemctl restart pcscd
$ pcsc_scan
```
4. Attach smartcard to VM, verify card appears in vm
```
#minimega commands
vm smartcard add foo /path/to/fake-smartcard
vm smartcard remove foo 
```

## Resources
- [QEMU CCID](https://www.qemu.org/docs/master/system/devices/ccid.html)