### PR TITLE
ron: add option for only executing a command once

### DIFF
--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -54,6 +54,12 @@ key=value pair. For example:
 	cc exec stderr=foo cat server.log
 	cc background stdin=foo stdout=bar /usr/bin/program
 
+Executed commands can also be marked to be sent to miniccc clients only once.
+This will prevent the command from being sent again if the client restarts (for
+example, after a reboot).
+
+	cc exec-once shutdown -r now
+
 Responses are organized in a structure within <filepath>/miniccc_responses, and
 include subdirectories for each client response named by the client's UUID.
 Responses can also be displayed on the command line with the 'responses'
@@ -118,7 +124,9 @@ For more documentation, see the article "Command and Control API Tutorial".`,
 			"cc <send,> <file>...",
 			"cc <recv,> <file>...",
 			"cc <exec,> <command>...",
+			"cc <exec-once,> <command>...",
 			"cc <background,> <command>...",
+			"cc <background-once,> <command>...",
 
 			"cc <process,> <list,> <vm name, uuid or all>",
 			"cc <process,> <kill,> <pid or all>",
@@ -177,22 +185,24 @@ See "help cc" for more information.`,
 
 // Functions pointers to the various handlers for the subcommands
 var ccCliSubHandlers = map[string]wrappedCLIFunc{
-	"background": cliCCBackground,
-	"clients":    cliCCClients,
-	"commands":   cliCCCommand,
-	"delete":     cliCCDelete,
-	"exec":       cliCCExec,
-	"filter":     cliCCFilter,
-	"log":        cliCCLog,
-	"prefix":     cliCCPrefix,
-	"process":    cliCCProcess,
-	"recv":       cliCCFileRecv,
-	"responses":  cliCCResponses,
-	"rtunnel":    cliCCTunnel,
-	"send":       cliCCFileSend,
-	"tunnel":     cliCCTunnel,
-	"listen":     cliCCListen,
-	"test-conn":  cliCCTestConn,
+	"background":      cliCCBackground,
+	"background-once": cliCCBackgroundOnce,
+	"clients":         cliCCClients,
+	"commands":        cliCCCommand,
+	"delete":          cliCCDelete,
+	"exec":            cliCCExec,
+	"exec-once":       cliCCExecOnce,
+	"filter":          cliCCFilter,
+	"log":             cliCCLog,
+	"prefix":          cliCCPrefix,
+	"process":         cliCCProcess,
+	"recv":            cliCCFileRecv,
+	"responses":       cliCCResponses,
+	"rtunnel":         cliCCTunnel,
+	"send":            cliCCFileSend,
+	"tunnel":          cliCCTunnel,
+	"listen":          cliCCListen,
+	"test-conn":       cliCCTestConn,
 }
 
 func cliCC(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
@@ -457,6 +467,23 @@ func cliCCBackground(ns *Namespace, c *minicli.Command, resp *minicli.Response) 
 	return nil
 }
 
+// background-once (just exec with background==true)
+func cliCCBackgroundOnce(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	stdin, stdout, stderr, command := ccCommandPreProcess(c.ListArgs["command"])
+
+	cmd := &ron.Command{
+		Once:       true,
+		Background: true,
+		Command:    command,
+		Stdin:      stdin,
+		Stdout:     stdout,
+		Stderr:     stderr,
+	}
+
+	resp.Data = ns.NewCommand(cmd)
+	return nil
+}
+
 func cliCCProcessKill(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 	// kill all processes
 	if c.StringArgs["pid"] == Wildcard {
@@ -492,6 +519,22 @@ func cliCCExec(ns *Namespace, c *minicli.Command, resp *minicli.Response) error 
 	stdin, stdout, stderr, command := ccCommandPreProcess(c.ListArgs["command"])
 
 	cmd := &ron.Command{
+		Command: command,
+		Stdin:   stdin,
+		Stdout:  stdout,
+		Stderr:  stderr,
+	}
+
+	resp.Data = ns.NewCommand(cmd)
+	return nil
+}
+
+// exec-once
+func cliCCExecOnce(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	stdin, stdout, stderr, command := ccCommandPreProcess(c.ListArgs["command"])
+
+	cmd := &ron.Command{
+		Once:    true,
 		Command: command,
 		Stdin:   stdin,
 		Stdout:  stdout,
@@ -626,7 +669,7 @@ func cliCCClients(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 // command
 func cliCCCommand(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 	resp.Header = []string{
-		"id", "prefix", "command", "responses", "background",
+		"id", "prefix", "command", "responses", "background", "once",
 		"sent", "received", "connectivity", "level", "filter",
 	}
 	resp.Tabular = [][]string{}
@@ -648,6 +691,7 @@ func cliCCCommand(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 			fmt.Sprintf("%v", v.Command),
 			strconv.Itoa(len(v.CheckedIn)),
 			strconv.FormatBool(v.Background),
+			strconv.FormatBool(v.Once),
 			fmt.Sprintf("%v", v.FilesSend),
 			fmt.Sprintf("%v", v.FilesRecv),
 		}

--- a/cmd/rond/handlers.go
+++ b/cmd/rond/handlers.go
@@ -98,6 +98,23 @@ var cliHandlers = []minicli.Handler{
 		}),
 	},
 	{
+		HelpShort: "run a command once",
+		Patterns: []string{
+			"<exec-once,> <command>...",
+			"<bg-once,> <command>...",
+		},
+		Call: wrapCLI(func(c *minicli.Command, resp *minicli.Response) error {
+			rond.NewCommand(&ron.Command{
+				Command:    c.ListArgs["command"],
+				Filter:     filter,
+				Background: c.BoolArgs["bg-once"],
+				Once:       true,
+			})
+
+			return nil
+		}),
+	},
+	{
 		HelpShort: "list processes",
 		Patterns: []string{
 			"processes",
@@ -221,8 +238,8 @@ Send one or more files. Supports globs such as:
 		},
 		Call: wrapCLI(func(c *minicli.Command, resp *minicli.Response) error {
 			resp.Header = []string{
-				"id", "command", "responses", "background", "sent", "received",
-				"filter",
+				"id", "command", "responses", "background", "once", "sent",
+				"received", "filter",
 			}
 
 			commands := rond.GetCommands()
@@ -240,6 +257,7 @@ Send one or more files. Supports globs such as:
 					fmt.Sprintf("%v", v.Command),
 					strconv.Itoa(len(v.CheckedIn)),
 					strconv.FormatBool(v.Background),
+					strconv.FormatBool(v.Once),
 					fmt.Sprintf("%v", v.FilesSend),
 					fmt.Sprintf("%v", v.FilesRecv),
 					fmt.Sprintf("%v", v.Filter),

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,12 @@ COPY --from=gobuilder /minimega/bin/protonuke     /opt/minimega/bin/protonuke
 COPY --from=gobuilder /minimega/bin/protonuke.exe /opt/minimega/bin/protonuke.exe
 COPY --from=gobuilder /minimega/bin/minirouter    /opt/minimega/bin/minirouter
 
+# As the minimega API changes, so does the minimega.py generated file. Given
+# this, let's go ahead and also include the lib directory so we can grab the
+# updated Python package from the Docker image.
+COPY --from=gobuilder /minimega/lib    /opt/minimega/lib
+COPY --from=gobuilder /minimega/README /opt/minimega/lib/README
+
 COPY ./web       /opt/minimega/web
 COPY ./docker/mm /usr/local/bin/mm
 

--- a/internal/ron/command.go
+++ b/internal/ron/command.go
@@ -63,6 +63,14 @@ type Command struct {
 	// not used by the server or client.
 	Prefix string
 
+	// Once specifies whether or not this command should only be sent to clients
+	// once, or if it should be sent after client reconnections.
+	Once bool
+
+	// Sent tracks whether or not this command has been sent already. Only used
+	// when Once is enabled.
+	Sent bool
+
 	// plumber connections
 	Stdin  string
 	Stdout string
@@ -123,6 +131,8 @@ func (c *Command) Copy() *Command {
 		PID:        c.PID,
 		KillAll:    c.KillAll,
 		Prefix:     c.Prefix,
+		Once:       c.Once,
+		Sent:       c.Sent,
 		Stdin:      c.Stdin,
 		Stdout:     c.Stdout,
 		Stderr:     c.Stderr,

--- a/internal/ron/server.go
+++ b/internal/ron/server.go
@@ -895,8 +895,12 @@ func (s *Server) sendCommands(uuid string) {
 		Commands: make(map[int]*Command),
 		UUID:     uuid,
 	}
+
 	for k, v := range s.commands {
-		m.Commands[k] = v.Copy()
+		if !v.Once || !v.Sent {
+			m.Commands[k] = v.Copy()
+			v.Sent = true
+		}
 	}
 
 	s.route(m)


### PR DESCRIPTION
This allows, for example, the `shutdown -r now` command to be sent to a VM using command and control without putting the VM into a perpetual reboot loop. This is a contrived example, since a minimega VM can be rebooted without using command and control, but it still gets the point across. There may be other commands that are sent via command and control that end up causing a VM to reboot that would benefit from this as well.

New cc commands added:

  cc exec-once command...
  cc background-once command...