### PR TITLE
[minitunnel] track tunneled ports for listing and closing

### DIFF
--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -97,6 +97,11 @@ without arguments displays the existing mounts. Users can use "clear cc mount"
 to unmount the filesystem of one or all VMs. This should be done before killing
 or stopping the VM ("clear namespace <name>" will handle this automatically).
 
+"cc tunnel" allows users to tunnel TCP connections to a local port through a VM
+to a remote port. The local port will be created on the minimega cluster host
+that the tunneling VM is running on. The remote port can be on the same VM or on
+a different VM the tunneling VM has network access to.
+
 "cc test-conn" allows users to test network connectivity from a guest to the
 given IP or domain name and port. The wait timeout should be specified as a Go
 duration string (e.g. 5s, 1m). If "udp" is used, a "base64 udp packet" that will

--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -272,7 +272,12 @@ func cliCCTunnel(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 			clients := ns.ccServer.GetClients()
 
 			for _, client := range clients {
-				vms[client.Hostname] = client.UUID
+				vm := ns.FindVM(client.UUID)
+				if vm == nil {
+					return vmNotFound(client.UUID)
+				}
+
+				vms[vm.GetName()] = client.UUID
 			}
 		} else {
 			vm := ns.FindVM(v)

--- a/internal/minitunnel/forward.go
+++ b/internal/minitunnel/forward.go
@@ -1,0 +1,71 @@
+package minitunnel
+
+import (
+	"fmt"
+	"net"
+)
+
+type forward struct {
+	fid  int
+	src  int
+	host string
+	dst  int
+
+	listener    net.Listener
+	connections []net.Conn
+}
+
+func (f *forward) addConnection(c net.Conn) {
+	f.connections = append(f.connections, c)
+}
+
+func (f *forward) close() {
+	f.listener.Close()
+
+	for _, conn := range f.connections {
+		conn.Close()
+	}
+}
+
+func (f *forward) String() string {
+	return fmt.Sprintf("%d:%s:%d", f.src, f.host, f.dst)
+}
+
+func (t *Tunnel) newForward(l net.Listener, src int, host string, dst int) *forward {
+	return &forward{
+		fid:  <-t.forwardIDs,
+		src:  src,
+		host: host,
+		dst:  dst,
+
+		listener: l,
+	}
+}
+
+func (t *Tunnel) ListForwards() map[int]string {
+	list := make(map[int]string)
+
+	t.sendLock.Lock()
+	defer t.sendLock.Unlock()
+
+	for i, f := range t.forwards {
+		list[i] = f.String()
+	}
+
+	return list
+}
+
+func (t *Tunnel) CloseForward(id int) error {
+	f, ok := t.forwards[id]
+	if !ok {
+		return fmt.Errorf("forwarder with ID %d not found", id)
+	}
+
+	f.close()
+
+	t.sendLock.Lock()
+	defer t.sendLock.Unlock()
+
+	delete(t.forwards, f.fid)
+	return nil
+}

--- a/internal/minitunnel/minitunnel.go
+++ b/internal/minitunnel/minitunnel.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"strings"
 	"sync"
 
 	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
@@ -216,7 +217,10 @@ func (t *Tunnel) forward(ln net.Listener, source int, host string, dest int) {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
-			log.Errorln(err)
+			if !strings.Contains(err.Error(), "use of closed network connection") {
+				log.Errorln(err)
+			}
+
 			return
 		}
 
@@ -300,7 +304,9 @@ func (t *Tunnel) transfer(in chan *tunnelMessage, conn net.Conn, TID int) {
 	}
 
 	if err != io.EOF {
-		log.Errorln(err)
+		if !strings.Contains(err.Error(), "use of closed network connection") {
+			log.Errorln(err)
+		}
 
 		m := &tunnelMessage{
 			Type:  CLOSED,

--- a/internal/ron/tunnel.go
+++ b/internal/ron/tunnel.go
@@ -33,6 +33,38 @@ func (s *Server) Forward(uuid string, source int, host string, dest int) error {
 	return c.tunnel.Forward(source, host, dest)
 }
 
+func (s *Server) ListForwards(uuid string) (map[int]string, error) {
+	s.clientLock.Lock()
+	defer s.clientLock.Unlock()
+
+	c, ok := s.clients[uuid]
+	if !ok {
+		return nil, fmt.Errorf("no such client: %v", uuid)
+	}
+
+	if c.tunnel == nil {
+		return nil, fmt.Errorf("tunnel has not been initialized for %v", uuid)
+	}
+
+	return c.tunnel.ListForwards(), nil
+}
+
+func (s *Server) CloseForward(uuid string, id int) error {
+	s.clientLock.Lock()
+	defer s.clientLock.Unlock()
+
+	c, ok := s.clients[uuid]
+	if !ok {
+		return fmt.Errorf("no such client: %v", uuid)
+	}
+
+	if c.tunnel == nil {
+		return fmt.Errorf("tunnel has not been initialized for %v", uuid)
+	}
+
+	return c.tunnel.CloseForward(id)
+}
+
 // Reverse creates a reverse tunnel from guest->host. It is possible to have
 // multiple clients create a reverse tunnel simultaneously. filter allows
 // specifying which clients to have create the tunnel.


### PR DESCRIPTION
Track and display port forward tunnels created using miniccc, and allow for existing tunnels to be torn down.