### PR TITLE
[minimega] fix bridge variable so deleting netflow capture works

### DIFF
--- a/cmd/minimega/capture_cli.go
+++ b/cmd/minimega/capture_cli.go
@@ -108,7 +108,7 @@ minimega instance:
 		Patterns: []string{
 			"capture <netflow,> <bridge,> <bridge> <filename>",
 			"capture <netflow,> <bridge,> <bridge> <tcp,udp> <hostname:port>",
-			"capture <netflow,> <delete,> bridge <name>",
+			"capture <netflow,> <delete,> bridge <bridge>",
 			"capture <netflow,> <timeout,> [timeout in seconds]",
 			"capture <pcap,> bridge <bridge> <filename>",
 			"capture <pcap,> <delete,> bridge <bridge>",


### PR DESCRIPTION
When deleting a netflow capture, the bridge name was getting assigned to the `<name>` variable but the code that deletes the capture was trying to get the name of the bridge from the `<bridge>` variable.