### PR TITLE
Misc bug fixes and logging improvements

### DIFF
--- a/cmd/minimega/vm.go
+++ b/cmd/minimega/vm.go
@@ -145,7 +145,7 @@ var vmInfo = []string{
 	// kvm fields
 	"vcpus", "disks", "snapshot", "initrd", "kernel", "cdrom", "migrate",
 	"append", "serial-ports", "virtio-ports", "vnc_port", "usb-use-xhci",
-	"tpm-socket",
+	"tpm-socket", "bidirectional-copy-paste",
 	// container fields
 	"filesystem", "hostname", "init", "preinit", "fifo", "volume",
 	"console_port",

--- a/cmd/minimega/vm_cli.go
+++ b/cmd/minimega/vm_cli.go
@@ -646,7 +646,7 @@ func cliVMTag(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 
 func cliClearVMTag(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 	// Get the specified tag name or use Wildcard if not provided
-	key, ok := c.StringArgs["key"]
+	key, ok := c.StringArgs["tag"]
 	if !ok {
 		key = Wildcard
 	}

--- a/cmd/vmbetter/main.go
+++ b/cmd/vmbetter/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	f_debian_mirror = flag.String("mirror", "http://mirrors.ocf.berkeley.edu/debian", "path to the debian mirror to use")
+	f_debian_mirror = flag.String("mirror", "http://ftp.us.debian.org/debian", "path to the debian mirror to use")
 	f_noclean       = flag.Bool("noclean", false, "do not remove build directory")
 	f_stage1        = flag.Bool("1", false, "stop after stage one, and copy build files to <config>_stage1")
 	f_stage2        = flag.String("2", "", "complete stage 2 from an existing stage 1 directory")

--- a/internal/qmp/qmp.go
+++ b/internal/qmp/qmp.go
@@ -218,7 +218,7 @@ func (q *Conn) BlockdevEject(device string, force bool) error {
 	}
 	v := <-q.messageSync
 	if !success(v) {
-		return errors.New("eject")
+		return fmt.Errorf("eject failed: %v", v)
 	}
 	return nil
 }
@@ -228,10 +228,10 @@ func (q *Conn) BlockdevChange(device, path string) error {
 		return ERR_READY
 	}
 	s := map[string]interface{}{
-		"execute": "change",
+		"execute": "blockdev-change-medium",
 		"arguments": map[string]interface{}{
-			"device": device,
-			"target": path,
+			"device":   device,
+			"filename": path,
 		},
 	}
 	err := q.write(s)
@@ -240,7 +240,7 @@ func (q *Conn) BlockdevChange(device, path string) error {
 	}
 	v := <-q.messageSync
 	if !success(v) {
-		return errors.New("change")
+		return fmt.Errorf("change failed: %v", v)
 	}
 	return nil
 }

--- a/internal/ron/server.go
+++ b/internal/ron/server.go
@@ -735,7 +735,7 @@ func (s *Server) handshake(conn net.Conn) (*client, error) {
 	c.Namespace = namespace
 
 	if m.Client.Version != version.Revision {
-		log.Warn("mismatched miniccc version: %v", m.Client.Version)
+		log.Warn("mismatched miniccc version on %v: %v", m.Client.Hostname, m.Client.Version)
 	}
 
 	if majorVersion(m.Version) > 0 {

--- a/internal/vnc/decode.go
+++ b/internal/vnc/decode.go
@@ -54,10 +54,12 @@ func ReadClientMessage(r io.Reader) (interface{}, error) {
 		msg = msg2
 	case TypeClientCutText:
 		msg2 := &ClientCutText{_ClientCutText: *msg.(*_ClientCutText)}
-		if msg2.Length < 0 {
-			msg2.Length = -msg2.Length
+		length := msg2.Length
+		// negative length used for extended pseudo-encoding
+		if length < 0 {
+			length = -length
 		}
-		msg2.Text = make([]uint8, msg2.Length)
+		msg2.Text = make([]uint8, length)
 
 		err = binary.Read(r, binary.BigEndian, &msg2.Text)
 		msg = msg2

--- a/internal/vnc/keysym.go
+++ b/internal/vnc/keysym.go
@@ -47,7 +47,7 @@ func asciiCharToKeysymString(c rune) (string, error) {
 	}
 	keysym, err := xKeysymToString(uint32(c))
 	if err != nil {
-		return "uint32(0)", fmt.Errorf("character has no keysym mapping: %c", c)
+		return "uint32(0)", fmt.Errorf("character has no keysym mapping: %c [%x]", c, c)
 	}
 	return keysym, nil
 }


### PR DESCRIPTION
Bug fixes:
* Don't try typing extended vnc clipboard commands (fixes warning on connection to vm)
* Update debian mirror in vmbetter (closes #1529)
* Fix tpm qemu arguments for newer qemu versions
* Add bidirectional-copy-paste to "vm info" output
* Fix `vm clear tag <vm> <tag>` not applying to a specific tag (closes #1535)
* Fix `vm cdrom change` for QEMU 6+


Logging Improvements:
* Print hex for keysym character that couldn't be found
* Print hostname in "mismatched miniccc" warning
* Include qemu std err in "unable to connect to qmp socket" error