### PR TITLE
Changed Docker OS from 20.04 to 22.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN ./scripts/all.bash
 
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt update && apt install -y \
   dnsmasq iproute2 isc-dhcp-client \


### PR DESCRIPTION
The issue in #1527 can be solved by changing the docker base image from Ubuntu 20.04 to 22.04. This will change the QEMU version from 4.2 to 6.2 which will resolve the problem as described within the previous pull request #1528.
