### PR TITLE
[minimega] copy global VERSION file to lib directory in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,15 +6,6 @@ WORKDIR /minimega/
 
 COPY . .
 
-# COPY ./.git     ./.git
-# COPY ./scripts  ./scripts
-# COPY ./cmd      ./cmd
-# COPY ./pkg      ./pkg
-# COPY ./internal ./internal
-# COPY ./packages ./packages
-# COPY ./go.mod   ./go.mod
-# COPY ./go.sum   ./go.sum
-
 RUN ./scripts/all.bash
 
 
@@ -47,8 +38,9 @@ COPY --from=gobuilder /minimega/bin/minirouter    /opt/minimega/bin/minirouter
 # As the minimega API changes, so does the minimega.py generated file. Given
 # this, let's go ahead and also include the lib directory so we can grab the
 # updated Python package from the Docker image.
-COPY --from=gobuilder /minimega/lib    /opt/minimega/lib
-COPY --from=gobuilder /minimega/README /opt/minimega/lib/README
+COPY --from=gobuilder /minimega/lib     /opt/minimega/lib
+COPY --from=gobuilder /minimega/README  /opt/minimega/lib/README
+COPY --from=gobuilder /minimega/VERSION /opt/minimega/lib/VERSION
 
 COPY ./web       /opt/minimega/web
 COPY ./docker/mm /usr/local/bin/mm


### PR DESCRIPTION
This is in support of rebuilding the minimega Python package in Docker images based off of this image. This is done, for example, in the sandia-labs/sceptre-phenix Docker image.

The Python package was updated to require this file in commit 1a428a9c.