### PR TITLE
[fix] Correct docs and packaging for miniweb default path

### DIFF
--- a/doc/content/articles/miniweb.article
+++ b/doc/content/articles/miniweb.article
@@ -42,7 +42,7 @@ preferably the head node. It has many flags, seen here:
 	  -passwords string
 			password file for auth
 	  -root string
-			base path for web files (default "misc/web")
+			base path for web files (default "web")
 	  -v    log on stderr (default true)
 	  -verbose
 			log on stderr (default true)

--- a/doc/content/training/module04.slide
+++ b/doc/content/training/module04.slide
@@ -51,7 +51,7 @@ This will print the available options for miniweb
 
 Assuming minimega is located in /opt/bin/minimega, use:
 
- $ ./miniweb -root /opt/misc/web -console -base /opt &
+ $ ./miniweb -root /opt/web -console -base /opt &
 
 - miniweb supports per-path authentication so that users can be limited to specific namespaces or VMs.
 

--- a/doc/content/training/module04_content/mw_help.mm
+++ b/doc/content/training/module04_content/mw_help.mm
@@ -16,6 +16,6 @@ usage: miniweb [option]...
   -passwords string
     	password file for auth
   -root string
-    	base path for web files (default "misc/web")
+    	base path for web files (default "web")
   -v, -verbose
     	log on stderr (default true)

--- a/docker/README.md
+++ b/docker/README.md
@@ -100,7 +100,7 @@ MM_LOGFILE=/var/log/minimega.log
 By default, the following values are set for miniweb:
 
 ```
-MINIWEB_ROOT=/opt/minimega/misc/web
+MINIWEB_ROOT=/opt/minimega/web
 MINIWEB_HOST=0.0.0.0
 MINIWEB_PORT=9001
 ```

--- a/packaging/debian/.gitignore
+++ b/packaging/debian/.gitignore
@@ -1,3 +1,4 @@
 minimega.deb
 minimega/opt
 minimega/usr
+minimega/DEBIAN/control

--- a/packaging/debian/build.bash
+++ b/packaging/debian/build.bash
@@ -19,7 +19,7 @@ mkdir -p $DST/misc
 cp -r $MM/misc/daemon $DST/misc/
 cp -r $MM/misc/vmbetter_configs $DST/misc/
 mkdir -p $DST/web
-cp -r $MM/web $DST/web/
+cp -r $MM/web $DST/
 
 DOCS=$SCRIPT_DIR/minimega/usr/share/doc/minimega
 mkdir -p $DOCS


### PR DESCRIPTION
Default path for miniweb root is `web`. This corrects the docs to use `web` instead of `misc/web`. Also corrects the debian packaging process which was putting the web directory in `web/web` instead of just `web`