### PR TITLE
Snapshot and migrate functionality.

### DIFF
--- a/cmd/minimega/command_socket.go
+++ b/cmd/minimega/command_socket.go
@@ -30,7 +30,7 @@ func commandSocketStart() {
 				log.Error("commandSocketStart: accept: %v", err)
 				continue
 			}
-			log.Infoln("client connected")
+			log.Debugln("client connected")
 
 			go commandSocketHandle(conn)
 		}
@@ -185,7 +185,7 @@ func commandSocketHandle(c net.Conn) {
 
 	// finally, log the error, if there was one
 	if err == nil || err == io.EOF {
-		log.Infoln("command client disconnected")
+		log.Debugln("command client disconnected")
 	} else if err != nil && strings.Contains(err.Error(), "write: broken pipe") {
 		log.Infoln("command client disconnected without waiting for responses")
 	} else if err != nil {

--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -913,7 +913,7 @@ func SetNamespace(name string) error {
 		return errors.New("namespace name cannot be the empty string")
 	}
 
-	log.Info("setting active namespace: %v", name)
+	log.Debug("setting active namespace: %v", name)
 
 	if name == namespace {
 		return fmt.Errorf("already in namespace: %v", name)
@@ -929,7 +929,7 @@ func RevertNamespace(old, curr *Namespace) {
 	namespaceLock.Lock()
 	defer namespaceLock.Unlock()
 
-	log.Info("reverting to namespace: %v", old)
+	log.Debug("reverting to namespace: %v", old)
 
 	// This is very odd and should *never* happen unless something has gone
 	// horribly wrong.


### PR DESCRIPTION
-29ea35c:  Fixed some log levels causing unnecessary noise when using Phenix
-379c4bf:  Snapshot now only does snapshot. Migrate does migrate (and snapshot, because they are often linked). Will also take care of multiple disks automatically.  [Note: vm snapshot previously paused VM because of calling migrate. This is no longer the case.  vm migrate still pauses the VM for the operation, but does not restart the VM]