### PR TITLE
Add command to print arguments in use

### DIFF
--- a/cmd/minimega/misc_cli.go
+++ b/cmd/minimega/misc_cli.go
@@ -142,7 +142,7 @@ you can get without restarting minimega. Restarting minimega is preferable.`,
 		Call: wrapSimpleCLI(cliClearAll),
 	},
 	{ // args
-		HelpShort: "display arguments used ",
+		HelpShort: "display arguments used",
 		HelpLong: `
 Displays the CLI arguments minimega is using to run. 
 If an argument was not set by CLI, the default value is displayed.`,

--- a/cmd/minimega/misc_cli.go
+++ b/cmd/minimega/misc_cli.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bufio"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -139,6 +140,15 @@ you can get without restarting minimega. Restarting minimega is preferable.`,
 			"clear all",
 		},
 		Call: wrapSimpleCLI(cliClearAll),
+	},
+	{ // filepath
+		HelpShort: "prints arguments used ",
+		HelpLong: `
+Prints the arguments used to launch minimega`,
+		Patterns: []string{
+			"args",
+		},
+		Call: wrapSimpleCLI(cliPrintArgs),
 	},
 }
 
@@ -400,4 +410,15 @@ func cliClearAll(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 	}
 
 	return consume(runCommands(cmds...))
+}
+
+func cliPrintArgs(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	var header, values []string
+	flag.VisitAll(func(f *flag.Flag) {
+		header = append(header, f.Name)
+		values = append(values, f.Value.String())
+	})
+	resp.Header = header
+	resp.Tabular = [][]string{values}
+	return nil
 }

--- a/cmd/minimega/misc_cli.go
+++ b/cmd/minimega/misc_cli.go
@@ -141,10 +141,11 @@ you can get without restarting minimega. Restarting minimega is preferable.`,
 		},
 		Call: wrapSimpleCLI(cliClearAll),
 	},
-	{ // filepath
-		HelpShort: "prints arguments used ",
+	{ // args
+		HelpShort: "display arguments used ",
 		HelpLong: `
-Prints the arguments used to launch minimega`,
+Displays the CLI arguments minimega is using to run. 
+If an argument was not set by CLI, the default value is displayed.`,
 		Patterns: []string{
 			"args",
 		},


### PR DESCRIPTION
Adds a command to print the CLI arguments minimega is using. 

This is being added so other programs (e.g., phenix) have any easy way to identify paths, ports, etc. Specifically this will replace phenix using `ps` to determine the `filepath`: https://github.com/sandialabs/sceptre-phenix/blob/main/src/go/util/file.go#L32