### PR TITLE
docker: add MM_APPEND env var

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -117,3 +117,10 @@ Docker when starting the container or by binding a file to
 > networking is used (not host networking), then the `ports` section in your
 > `docker-compose.yml` or `-p` arguments to `docker run` will need to be updated
 > to the new value(s) specified.
+
+Additional values can be appended to the minimega command by using:
+
+```
+MM_APPEND="-hashfiles -headnode=foo1"
+```
+

--- a/docker/start-minimega.sh
+++ b/docker/start-minimega.sh
@@ -18,6 +18,7 @@
 : "${MM_FORCE:=true}"
 : "${MM_RECOVER:=false}"
 : "${MM_CGROUP:=/sys/fs/cgroup}"
+: "${MM_APPEND:=}"
 
 [[ -f "/etc/default/minimega" ]] && source "/etc/default/minimega"
 
@@ -36,4 +37,5 @@
   -context=${MM_CONTEXT} \
   -level=${MM_LOGLEVEL} \
   -logfile=${MM_LOGFILE} \
-  -cgroup=${MM_CGROUP}
+  -cgroup=${MM_CGROUP} \
+  ${MM_APPEND}


### PR DESCRIPTION
Instead of adding every flag to the `start-minimega.sh` script, this allows users to add whatever they need to the minimega startup command. Useful for appending additional minimega flags at runtime, e.g.:

```
MM_APPEND: -hashfiles -headnode=foo1
```