### PR TITLE
feat: allow disk inject to delete files

### DIFF
--- a/cmd/minimega/misc.go
+++ b/cmd/minimega/misc.go
@@ -126,6 +126,16 @@ func randomMac() string {
 	return mac
 }
 
+// Return true if any string in a string slice contains str
+func sliceContainsString(slice []string, str string) bool {
+	for _, s := range slice {
+		if strings.Contains(s, str) {
+			return true
+		}
+	}
+	return false
+}
+
 // Return a slice of strings, split on whitespace, not unlike strings.Fields(),
 // except that quoted fields are grouped.
 //


### PR DESCRIPTION
Adds the ability to delete files while doing disk inject via a keyword as the src. E.g.:

`disk inject window7_miniccc.qc2 files "-DELETE-":"Program Files/miniccc.exe"`