### PR TITLE
refactor: Move docker labeling data to the CI pipeline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,14 +10,21 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Get metadata
-        id: build_metadata
-        run: |
-          echo "::set-output name=sha::$(git rev-parse --short HEAD)"
-          echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
-          echo "::set-output name=mmversion::$(cat VERSION)"
-          echo "::set-output name=buildtime::$(date -I'seconds')"
-          echo "::set-output name=repolowercase::$(echo ${GITHUB_REPOSITORY,,})"
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=,suffix=,format=short
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v3
         with:
@@ -29,11 +36,6 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          build-args: |
-            MM_COMMIT=${{ github.sha }}
-            MM_VERSION=${{ steps.build_metadata.outputs.mmversion }}
-            BUILD_TIME=$${ steps.build_metadata.outputs.buildtime }}
           push: true
-          tags: |
-            ghcr.io/${{ steps.build_metadata.outputs.repolowercase }}/minimega:${{ steps.build_metadata.outputs.sha }}
-            ghcr.io/${{ steps.build_metadata.outputs.repolowercase }}/minimega:${{ steps.build_metadata.outputs.branch }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,12 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             ghcr.io/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.vendor=Sandia National Laboratories
+            org.opencontainers.image.authors=minimega dev team <minimega-dev@sandia.gov>
+            org.opencontainers.image.documentation=https://www.sandia.gov/minimega/
+            org.opencontainers.image.description=minimega is a tool for launching and managing virtual machines
+            org.opencontainers.image.licenses=GPL-3.0
           # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,27 +20,6 @@ FROM ${BASE_IMAGE}
 # General image metadata
 # Reference: https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ARG MM_VERSION
-# LABEL org.opencontainers.image.authors="minimega dev team <minimega-dev@sandia.gov>" \
-#   org.opencontainers.image.documentation="https://www.sandia.gov/minimega/" \
-#   org.opencontainers.image.vendor="Sandia National Laboratories" \
-#   org.opencontainers.image.licenses="GPL-3.0-only" \
-
-
-#   "Labels": {
-#     "org.opencontainers.image.authors": "minimega dev team \u003cminimega-dev@sandia.gov\u003e",
-#     "org.opencontainers.image.created": "2025-02-11T16:13:37.952Z",
-#     "org.opencontainers.image.description": "FIREWHEEL is an experiment orchestration tool that assists a user in building and controlling, repeatable experiments of distributed network systems at any scale.",
-#     "org.opencontainers.image.documentation": "https://www.sandia.gov/minimega/",
-#     "org.opencontainers.image.licenses": "NOASSERTION",
-#     "org.opencontainers.image.ref.name": "ubuntu",
-#     "org.opencontainers.image.revision": "bbb41714d4b4c428a7d45acee07dae2430c5bff4",
-#     "org.opencontainers.image.source": "https://github.com/sdelliot/firewheel",
-#     "org.opencontainers.image.title": "firewheel",
-#     "org.opencontainers.image.url": "https://github.com/sdelliot/firewheel",
-#     "org.opencontainers.image.vendor": "Sandia National Laboratories",
-#     "org.opencontainers.image.version": "feat-dockerize"
-# }
-# },
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,10 @@ FROM ${BASE_IMAGE}
 
 # General image metadata
 # Reference: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-ARG MM_VERSION
+LABEL org.opencontainers.image.authors="minimega dev team <minimega-dev@sandia.gov>" \
+  org.opencontainers.image.documentation="https://www.sandia.gov/minimega/" \
+  org.opencontainers.image.vendor="Sandia National Laboratories" \
+  org.opencontainers.image.description="minimega is a tool for launching and managing virtual machines"
 
 ENV DEBIAN_FRONTEND="noninteractive"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,13 +17,6 @@ RUN ./scripts/all.bash
 # -- minimega image --
 FROM ${BASE_IMAGE}
 
-# General image metadata
-# Reference: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.authors="minimega dev team <minimega-dev@sandia.gov>" \
-  org.opencontainers.image.documentation="https://www.sandia.gov/minimega/" \
-  org.opencontainers.image.vendor="Sandia National Laboratories" \
-  org.opencontainers.image.description="minimega is a tool for launching and managing virtual machines"
-
 ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,19 +19,28 @@ FROM ${BASE_IMAGE}
 
 # General image metadata
 # Reference: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-ARG BUILD_TIME
 ARG MM_VERSION
-ARG MM_COMMIT
-LABEL org.opencontainers.image.created="${BUILD_TIME}" \
-  org.opencontainers.image.authors="minimega dev team <minimega-dev@sandia.gov>" \
-  org.opencontainers.image.documentation="https://www.sandia.gov/minimega/" \
-  org.opencontainers.image.source="https://github.com/sandia-minimega/minimega" \
-  org.opencontainers.image.version="${MM_VERSION}" \
-  org.opencontainers.image.revision="${MM_COMMIT}" \
-  org.opencontainers.image.vendor="Sandia National Laboratories" \
-  org.opencontainers.image.licenses="GPL-3.0-only" \
-  org.opencontainers.image.title="minimega" \
-  org.opencontainers.image.description="minimega is a tool for launching and managing virtual machines"
+# LABEL org.opencontainers.image.authors="minimega dev team <minimega-dev@sandia.gov>" \
+#   org.opencontainers.image.documentation="https://www.sandia.gov/minimega/" \
+#   org.opencontainers.image.vendor="Sandia National Laboratories" \
+#   org.opencontainers.image.licenses="GPL-3.0-only" \
+
+
+#   "Labels": {
+#     "org.opencontainers.image.authors": "minimega dev team \u003cminimega-dev@sandia.gov\u003e",
+#     "org.opencontainers.image.created": "2025-02-11T16:13:37.952Z",
+#     "org.opencontainers.image.description": "FIREWHEEL is an experiment orchestration tool that assists a user in building and controlling, repeatable experiments of distributed network systems at any scale.",
+#     "org.opencontainers.image.documentation": "https://www.sandia.gov/minimega/",
+#     "org.opencontainers.image.licenses": "NOASSERTION",
+#     "org.opencontainers.image.ref.name": "ubuntu",
+#     "org.opencontainers.image.revision": "bbb41714d4b4c428a7d45acee07dae2430c5bff4",
+#     "org.opencontainers.image.source": "https://github.com/sdelliot/firewheel",
+#     "org.opencontainers.image.title": "firewheel",
+#     "org.opencontainers.image.url": "https://github.com/sdelliot/firewheel",
+#     "org.opencontainers.image.vendor": "Sandia National Laboratories",
+#     "org.opencontainers.image.version": "feat-dockerize"
+# }
+# },
 
 ENV DEBIAN_FRONTEND="noninteractive"
 


### PR DESCRIPTION
This PR cleans up the dockerfile by using a well-supported docker metadata github-action to automatically generate most container tags and labels.

### Original Labels
```json
"Labels": {
    "org.opencontainers.image.authors": "minimega dev team \u003cminimega-dev@sandia.gov\u003e",
    "org.opencontainers.image.created": "$${ steps.build_metadata.outputs.buildtime }}",
    "org.opencontainers.image.description": "minimega is a tool for launching and managing virtual machines",
    "org.opencontainers.image.documentation": "https://www.sandia.gov/minimega/",
    "org.opencontainers.image.licenses": "GPL-3.0-only",
    "org.opencontainers.image.ref.name": "ubuntu",
    "org.opencontainers.image.revision": "04215d1c2d2e6b7d78630ff7dcae2adb94df3dd3",
    "org.opencontainers.image.source": "https://github.com/sandia-minimega/minimega",
    "org.opencontainers.image.title": "minimega",
    "org.opencontainers.image.vendor": "Sandia National Laboratories",
    "org.opencontainers.image.version": "VERSION=2.9"
}
```
### Original Tags
* [04215d1](https://github.com/orgs/sandia-minimega/packages/container/minimega%2Fminimega/346636894?tag=04215d1)
* [master](https://github.com/orgs/sandia-minimega/packages/container/minimega%2Fminimega/346636894?tag=master)

### New Labels
```json
"Labels": {
    "org.opencontainers.image.authors": "minimega dev team \u003cminimega-dev@sandia.gov\u003e",
    "org.opencontainers.image.created": "2025-02-13T20:12:36.524Z",
    "org.opencontainers.image.description": "minimega is a tool for launching and managing virtual machines",
    "org.opencontainers.image.documentation": "https://www.sandia.gov/minimega/",
    "org.opencontainers.image.licenses": "GPL-3.0",
    "org.opencontainers.image.ref.name": "ubuntu",
    "org.opencontainers.image.revision": "3fe8e715f39f8e30f52873d530034e666d0bdb70",
    "org.opencontainers.image.source": "https://github.com/sdelliot/minimega",
    "org.opencontainers.image.title": "minimega",
    "org.opencontainers.image.url": "https://github.com/sdelliot/minimega",
    "org.opencontainers.image.vendor": "Sandia National Laboratories",
    "org.opencontainers.image.version": "feat-docker-ci-improvements"
}
```
> [!NOTE]
> The source, url, and version are automatically generated based on the repository that runs the CI script.

### New Tags
* [3fe8e71](https://github.com/users/sdelliot/packages/container/minimega/355372468?tag=3fe8e71)
* [feat-docker-ci-improvements](https://github.com/users/sdelliot/packages/container/minimega/355372468?tag=feat-docker-ci-improvements)

> [!NOTE]
> The branch label will be updated when new containers are generated.

## Primary Changes
1. There are a few notable changes to this structure. The first is that the version no longer uses the version populated within minimega. However, when a new version is tagged, that tag will be provided as a new tag automatically.
2. The Docker path will change from `ghcr.io/sandia-minimega/minimega/minimega` to `ghcr.io/sandia-minimega/minimega`. The new path is shorter and IMHO makes sense, but it is totally feasible to re-add the double "minimega".
3. The build-time is set correctly by well-maintained code.
4. There are no longer arguments passed into the Dockerfile.
