### PR TITLE
Fix race condition with nbd sockets during disk injection

### DIFF
--- a/internal/nbd/nbd.go
+++ b/internal/nbd/nbd.go
@@ -79,8 +79,8 @@ func GetDevice() (string, error) {
 			continue
 		}
 
-		// check whether a pid exists for the current nbd
-		_, err = os.Stat(filepath.Join("/sys/block", dev, "pid"))
+		// check whether a socket exists for the current nbd
+		_, err = os.Stat(filepath.Join("/var/lock", "qemu-nbd-"+dev))
 		if err != nil {
 			log.Debug("found available nbd: " + dev)
 			nbdPath = filepath.Join("/dev", dev)


### PR DESCRIPTION
There appears to be a race condition with the use of nbd devices during the `mm disk inject` command when running multiple disk injects in rapid succession (like starting a phenix experiment).

The error looks like this:
```bash
Starting Experiment
Starting experiment xxxxx
Mar  6 15:56:47.268 INF [✓] 'ntp' default app (pre-start)
Mar  6 15:56:47.270 INF [✓] 'serial' default app (pre-start)
Mar  6 15:56:47.299 INF [✓] 'startup' default app (pre-start)
Mar  6 15:56:47.312 INF [✓] 'vrouter' default app (pre-start)
Mar  6 15:56:47.778 INF [✓] 'mgmt_tap' user app (pre-start)
Mar  6 15:56:47.884 INF [✓] 'mirror' user app (pre-start)
Mar  6 15:56:48.648 INF [✓] 'sceptre' user app (pre-start)
Mar  6 15:56:48.662 INF [✓] 'scorch' user app (pre-start)
phenix 2025/03/06 15:56:54 [f1960d5b-bf0c-4514-84ea-5119aa8dc203] reading minimega script: reading mmcli script: 2 errors occurred:
        * unable to connect to nbd: qemu-nbd: Failed to connect to '/var/lock/qemu-nbd-nbd0': No such file or directory

        * unable to connect to nbd: qemu-nbd: Failed to connect to '/var/lock/qemu-nbd-nbd0': No such file or directory


Error: Unable to start the xxxxx experiment (search error logs for f1960d5b-bf0c-4514-84ea-5119aa8dc203)
```

This PR changes the logic of the nbd handling to check the status of the socket file itself for determining if an ndb is available.

## Testing
Multiple people ran a loop to start/stop a phenix experiment 100 times. Without this change each person got 5-10 failures like the one above. With this fix, there were no failures.