### PR TITLE
fix: Allow VMs/containers with a certain name.

### DIFF
--- a/cmd/minimega/container.go
+++ b/cmd/minimega/container.go
@@ -735,7 +735,7 @@ func (vm *ContainerVM) Stop() error {
 	defer vm.lock.Unlock()
 
 	if vm.Name == "vince" {
-		return errors.New("vince is unstoppable")
+		log.Warn("vince is unstoppable")
 	}
 
 	if vm.State != VM_RUNNING {

--- a/cmd/minimega/kvm.go
+++ b/cmd/minimega/kvm.go
@@ -460,7 +460,7 @@ func (vm *KvmVM) Stop() error {
 	defer vm.lock.Unlock()
 
 	if vm.Name == "vince" {
-		return errors.New("vince is unstoppable")
+		log.Warn("vince is unstoppable")
 	}
 
 	if vm.State != VM_RUNNING {


### PR DESCRIPTION
This bug fix enables VMs/containers to have the name "vince" while still honoring the initial intent of the easter egg within the code base: https://github.com/sandia-minimega/minimega/commit/a1e84558a9bb5a6f07107a417af3fd2bd11fe6cc.