### PR TITLE
build: add iptables to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
     dnsmasq iproute2 isc-dhcp-client \
     libpcap-dev ntfs-3g openssh-client \
     openvswitch-switch qemu-kvm qemu-utils \
+    iptables \
   && apt autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Add `iptables` to the Docker image. While not directly used by minimega core, it's required for phenix. This has resulted in a lot of unnecessary complexity just to add a single package. This change would enable phenix to depend directly on minimega, instead of maintaining a separate image. The only significant side-effect of this change is an increase of the image size by ~7MB, from 760MB to 767MB.