### PR TITLE
fix: add /opt/minimega/bin to PATH in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,8 @@ RUN ./scripts/all.bash
 # -- minimega image --
 FROM ${BASE_IMAGE}
 
-ENV DEBIAN_FRONTEND="noninteractive"
+ENV DEBIAN_FRONTEND="noninteractive" \
+    PATH="$PATH:/opt/minimega/bin"
 
 RUN apt-get update \
   && apt-get install -y \


### PR DESCRIPTION
This change enables use of minimega binaries without having to specify an absolute path. This fixes the convenience aliases listed in the [Docker README](https://github.com/sandia-minimega/minimega/tree/master/docker#convenience-aliases), which if used as defined would not work.

phenix's internal minimega image worked around this by adding a symlink to `/usr/local/bin/`, however I believe editing the PATH variable is a more straightforward fix that also enables the other binaries to be used.