### PR TITLE
Update disk.go with more attempts to find partitions

### DIFF
--- a/cmd/minimega/disk.go
+++ b/cmd/minimega/disk.go
@@ -275,7 +275,7 @@ func diskInject(dst, partition string, pairs map[string]string, options []string
 	// decide whether to mount partition or raw disk
 	if partition != "none" {
 		// keep rereading partitions and waiting for them to show up for a bit
-		timeoutTime := time.Now().Add(5 * time.Second)
+		timeoutTime := time.Now().Add(10 * time.Second)
 		for i := 1; ; i++ {
 			if time.Now().After(timeoutTime) {
 				return fmt.Errorf("[image %s] no partitions found on image", dst)


### PR DESCRIPTION
In larger experiments (300+ VMs), this action fails to find partitions on the image. I believe increasing the number of possibles may patch this issue while investigate root causes. Performance issues may be hindering the ability for large experiments to find these objects and cause it to fail. Increasing this count will allow greater chance for success. Better handling may improve the experience instead of failing out of an experiment launch entirely.