### PR TITLE
bugfix: restore old /sys/block/ check for nbd availability

### DIFF
--- a/internal/nbd/nbd.go
+++ b/internal/nbd/nbd.go
@@ -79,9 +79,12 @@ func GetDevice() (string, error) {
 			continue
 		}
 
-		// check whether a socket exists for the current nbd
-		_, err = os.Stat(filepath.Join("/var/lock", "qemu-nbd-"+dev))
-		if err != nil {
+		// Check whether the nbd has an associated socket or PID to determine
+		// if it is available
+		_, err_sock := os.Stat(filepath.Join("/var/lock", "qemu-nbd-"+dev))
+		_, err_pid := os.Stat(filepath.Join("/sys/block", dev, "pid"))
+
+		if os.IsNotExist(err_sock) && os.IsNotExist(err_pid) {
 			log.Debug("found available nbd: " + dev)
 			nbdPath = filepath.Join("/dev", dev)
 			break


### PR DESCRIPTION
I accidentally caused another bug with PR #1561. With larger experiments or on faster machines, we were seeing a race condition where nbds would be reused too quickly with only the socket check, resulting in `no partitions found on image` errors when doing many disk injects.

With this fix, we now do both the old check (pid file under `/sys/block`) and the new check (socket under `/var/lock`) to really really make sure an nbd is available for use.

