### PR TITLE
fix: include tools in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,31 +31,22 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /var/cache/apt/archives/*
 
-COPY --from=gobuilder /minimega/bin/minimega /opt/minimega/bin/minimega
-COPY --from=gobuilder /minimega/bin/miniweb  /opt/minimega/bin/miniweb
-
-# The version of miniccc used has to match exactly with the version of minimega
-# running, so let's include them in the image so we can easily grab a copy that
-# is sure to be the same version.
-COPY --from=gobuilder /minimega/bin/miniccc     /opt/minimega/bin/miniccc
-COPY --from=gobuilder /minimega/bin/miniccc.exe /opt/minimega/bin/miniccc.exe
-
-# For the sake of consistency, let's go ahead and include protonuke and
-# minirouter in the image too so we can easily grab a copy if/when necessary.
-COPY --from=gobuilder /minimega/bin/protonuke     /opt/minimega/bin/protonuke
-COPY --from=gobuilder /minimega/bin/protonuke.exe /opt/minimega/bin/protonuke.exe
-COPY --from=gobuilder /minimega/bin/minirouter    /opt/minimega/bin/minirouter
+# Copy all binaries, including tools such as vmbetter, rfbplay and vncdrone
+# While this includes some tools like minitest that generally aren't 
+# needed in a deployment, the disk utilization difference is minimal, 
+# and ensures any future tools get included in the Docker image.
+COPY --from=gobuilder /minimega/bin/ /opt/minimega/bin/
 
 # As the minimega API changes, so does the minimega.py generated file. Given
 # this, let's go ahead and also include the lib directory so we can grab the
 # updated Python package from the Docker image.
-COPY --from=gobuilder /minimega/lib     /opt/minimega/lib
-COPY --from=gobuilder /minimega/README.md  /opt/minimega/lib/README.md
-COPY --from=gobuilder /minimega/VERSION /opt/minimega/lib/VERSION
+COPY --from=gobuilder /minimega/lib       /opt/minimega/lib
+COPY --from=gobuilder /minimega/README.md /opt/minimega/lib/README.md
+COPY --from=gobuilder /minimega/VERSION   /opt/minimega/lib/VERSION
 
-COPY ./web       /opt/minimega/web
+# Copy files from source tree
+COPY ./web /opt/minimega/web
 COPY ./docker/mm /usr/local/bin/mm
-
 COPY ./docker/start-minimega.sh /start-minimega.sh
 
 RUN chmod +x /usr/local/bin/mm \


### PR DESCRIPTION
This PR includes the tool binaries in the docker image.

While this includes some tools like "minitest" that usually aren't needed in a deployment, the disk utilization difference is minimal, and this ensures any future tools get included in the Docker image. It also simplifies the Dockerfile a bit (less commands and potentially less layers).

8 binaries in `/opt/minimega/bin/` in final image, vs 26 binaries in `/minimega/bin/` directory as build outputs. 18 binaries NOT being included. `bin/` is 67 MB in current minimega image, vs 136MB in build output. That's a 69MB difference, which is relatively small.

`rfbplay` requires `ffmpeg`, which increases the image size by a bit (230MB or so), so I'm making a separate PR for adding ffmpeg to elicit debate about if that's worth adding.

Image without binaries: 774MB
Image with binaries: 840MB
Image with ffmpeg and binaries: 1.07GB

Relevant issue: #1572