### PR TITLE
fix: add ffmpeg to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     dnsmasq iproute2 isc-dhcp-client \
     libpcap-dev ntfs-3g openssh-client \
     openvswitch-switch qemu-kvm qemu-utils \
-    iptables \
+    iptables ffmpeg \
   && apt autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This is required by `rfbplay`. Not sure if it's worth adding, as it increases image size by ~230MB. However, given the amount of disk space most deployments have, is saving a few hundred MB worth it over convenience of having tools available?

Related PR: #1573
Relevant issue: #1572