### PR TITLE
chore: Adding LDFLAGS to remove symbols thereby reducing binary size

### DIFF
--- a/scripts/build.bash
+++ b/scripts/build.bash
@@ -40,7 +40,7 @@ echo "BUILD PACKAGES (linux)"
 for i in ${DIRECTORY_ARRAY[@]}; do
     for j in `ls $i | grep -v plumbing`; do
         echo $j
-        go install $i/$j
+        go install -ldflags="-s -w" $i/$j
         if [[ $? != 0 ]]; then
             exit 1
         fi
@@ -52,7 +52,7 @@ echo "BUILD PACKAGES (windows)"
 for i in ${DIRECTORY_ARRAY[@]}; do
     for j in `ls $i | grep -E "protonuke|miniccc"`; do
         echo $j
-        GOOS=windows go build -o $ROOT_DIR/bin/$j.exe $i/$j
+        GOOS=windows go build -ldflags="-s -w" -o $ROOT_DIR/bin/$j.exe $i/$j
         if [[ $? != 0 ]]; then
             exit 1
         fi


### PR DESCRIPTION
This adds the following linker flags to building the minimega binary files:
* `-s`  - omit symbol table
* `-w` - omit DWARF debug information

Together these flags reduce the size of building the minimega binaries files dramatically. Without the flags, the created `bin` folder is 161M, but with the flags it is reduced to 110M. Below is a before/after comparison for each binary:

### Before
```bash
5.0M Sep  8 12:38 apigen*
2.2M Sep  8 12:39 count*
2.3M Sep  8 12:39 delay*
2.6M Sep  8 12:39 execf*
5.0M Sep  8 12:38 miniccc*
5.4M Sep  8 12:39 miniccc.exe*
 13M Sep  8 12:38 minidoc*
4.3M Sep  8 12:38 minifuzzer*
 17M Sep  8 12:38 minimega*
5.9M Sep  8 12:38 minirouter*
4.4M Sep  8 12:38 minitest*
 13M Sep  8 12:38 miniweb*
2.7M Sep  8 12:38 nfcat*
2.3M Sep  8 12:39 normal*
3.0M Sep  8 12:38 passwordify*
3.7M Sep  8 12:38 powerbot*
 17M Sep  8 12:38 protonuke*
 17M Sep  8 12:39 protonuke.exe*
5.3M Sep  8 12:39 pyapigen*
2.4M Sep  8 12:39 ranger*
8.6M Sep  8 12:39 rfbplay*
5.6M Sep  8 12:39 rond*
3.1M Sep  8 12:39 vmbetter*
9.7M Sep  8 12:39 vmconfiger*
4.1M Sep  8 12:39 vncdrone*
```

### After
```bash
3.3M Sep  8 12:34 apigen*
1.4M Sep  8 12:34 count*
1.5M Sep  8 12:34 delay*
1.7M Sep  8 12:34 execf*
3.3M Sep  8 12:34 miniccc*
3.6M Sep  8 12:34 miniccc.exe*
8.3M Sep  8 12:34 minidoc*
2.9M Sep  8 12:34 minifuzzer*
 12M Sep  8 12:34 minimega*
4.0M Sep  8 12:34 minirouter*
3.0M Sep  8 12:34 minitest*
8.5M Sep  8 12:34 miniweb*
1.8M Sep  8 12:34 nfcat*
1.5M Sep  8 12:34 normal*
2.0M Sep  8 12:34 passwordify*
2.4M Sep  8 12:34 powerbot*
 12M Sep  8 12:34 protonuke*
 12M Sep  8 12:34 protonuke.exe*
3.6M Sep  8 12:34 pyapigen*
1.6M Sep  8 12:34 ranger*
5.9M Sep  8 12:34 rfbplay*
3.8M Sep  8 12:34 rond*
2.1M Sep  8 12:34 vmbetter*
6.6M Sep  8 12:34 vmconfiger*
2.7M Sep  8 12:34 vncdrone*
```

