### PR TITLE
fix: use var name only

### DIFF
--- a/docker/start-minimega.sh
+++ b/docker/start-minimega.sh
@@ -31,7 +31,7 @@
 # Single Interface Example (where bridge name is "phenix"): OVS_HOST_IFACE=phenix:eth0
 # Multi Interface Example (where bridge name is "phenix"): OVS_HOST_IFACE=phenix:eth0,eth1,eth2
 
-if [[ -v "${OVS_HOST_IFACE}" ]]; then
+if [[ -v "OVS_HOST_IFACE" ]]; then
   iface=(${OVS_HOST_IFACE//:/ })
 
   if [[ -n "${iface[0]}" ]]; then


### PR DESCRIPTION
Fixes the previously-merged https://github.com/sandia-minimega/minimega/pull/1576 which is broken - using `-v` requires the variable name, not the [expanded variable](https://www.man7.org/linux/man-pages/man1/bash.1.html)

<img width="665" height="142" alt="image" src="https://github.com/user-attachments/assets/807ade7a-458d-4472-ab27-8b8cf5d15f00" />
