### PR TITLE
fix: Remove tailing space in comment

### DIFF
--- a/cmd/miniccc/dial.go
+++ b/cmd/miniccc/dial.go
@@ -49,7 +49,7 @@ func dial() error {
 			})
 		}
 
-		// Handle any errors with client initialization before we attempt to read 
+		// Handle any errors with client initialization before we attempt to read
 		// from the client below. Attempt another connection if there's any errors.
 		if err != nil {
 			log.Error("%v, retries = %v", err, i)


### PR DESCRIPTION
Fix tailing space in comment (from my PR #1579)  breaks the `gofmt` check in scripts/check.bash