### PR TITLE
feat: better docker logging and error handling

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,8 +32,8 @@ RUN apt-get update \
   && rm -rf /var/cache/apt/archives/*
 
 # Copy all binaries, including tools such as vmbetter, rfbplay and vncdrone
-# While this includes some tools like minitest that generally aren't 
-# needed in a deployment, the disk utilization difference is minimal, 
+# While this includes some tools like minitest that generally aren't
+# needed in a deployment, the disk utilization difference is minimal,
 # and ensures any future tools get included in the Docker image.
 COPY --from=gobuilder /minimega/bin/ /opt/minimega/bin/
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,19 +2,18 @@
 
 ## Install Docker
 
-Follow the official installation instructions: [Install Docker Engine](https://docs.docker.com/engine/install/)
+Follow the official installation instructions:
+[Install Docker Engine](https://docs.docker.com/engine/install/)
 
-For development purposes, it maybe helpful to add your user to the `docker` group: `sudo usermod -aG docker $USER`
-
+> [!TIP]
+> For development purposes, it maybe helpful to add your user to the `docker`
+> group: `sudo usermod -aG docker $USER`
 
 ## Build the minimega Docker image
 
-> NOTE: Currently, only minimega, miniweb, miniccc, minirouter, and protonuke
-> will exist in the minimega docker image. If you need additional binaries, add
-> them to the Dockerfile using the `COPY --from=gobuilder …` directive.
-
-> NOTE: The docker image needs to be built from the base directory of the
-> minimega repository.
+> [!IMPORTANT]
+> The docker image needs to be built from the base directory of the minimega
+> repository.
 
 ```bash
 docker build -t minimega -f docker/Dockerfile .
@@ -25,14 +24,16 @@ docker run -it minimega /opt/minimega/bin/minimega --version
 
 ## Start the minimega Docker container
 
-> NOTE: The additional privileges and system mounts (e.g. /dev) are required for
-> the openvswitch process to run inside the container and to allow minimega to
+> [!NOTE]
+> The additional privileges and system mounts (e.g. /dev) are required for the
+> openvswitch process to run inside the container and to allow minimega to
 > perform file injections.
 
-> NOTE: If the `deploy launch` minimega command is used to initialize a
-> multi-node minimega cluster, then a directory containing SSH keys will likely
-> need to be mounted as a volume as well (and can be read-only). An example
-> would be `-v /root/.ssh:/root/.ssh:ro`.
+> [!WARNING]
+> If the `deploy launch` minimega command is used to initialize a multi-node
+> minimega cluster, then a directory containing SSH keys will likely need to be
+> mounted as a volume as well (and can be read-only). An example would be
+> `-v /root/.ssh:/root/.ssh:ro`.
 
 ```bash
 docker run -d \
@@ -50,12 +51,17 @@ docker run -d \
   minimega
 ```
 
-The container runs the `start-minimega.sh` script as PID 1, which takes care of starting openvswitch, miniweb, and finally minimega. This means the minimega logs will be available in the container logs via Docker (`docker logs minimega`).
-
+The container runs the `start-minimega.sh` script as PID 1, which takes care of
+starting openvswitch, miniweb, and finally minimega. This means the minimega
+logs will be available in the container logs via Docker (`docker logs minimega`).
 
 # Using Docker Compose
 
-If you followed the [Docker installation instructions](https://docs.docker.com/engine/install/), then `docker compose` should already be installed. Verify this by running `docker compose version`.  If it's not, then install it: `sudo apt install docker-compose-plugin`
+If you followed the
+[Docker installation instructions](https://docs.docker.com/engine/install/),
+then `docker compose` should already be installed. Verify this by running
+`docker compose version`. If it's not, then install it using the command:
+`sudo apt install docker-compose-plugin`
 
 Start the minimega Docker container with Docker Compose:
 
@@ -64,7 +70,6 @@ cd docker/
 docker compose up -d
 docker compose logs -f  # CTRL+C to stop following logs
 ```
-
 
 # Extras
 
@@ -82,18 +87,26 @@ EOF
 source ~/.bash_aliases
 ```
 
-On Ubuntu, `~/.bash_aliases` should be auto-sourced by `~/.profile` or `~/.bashrc` on login, so the source command is only needed to load them into current session.
+> [!TIP]
+> On Ubuntu, `~/.bash_aliases` should be auto-sourced by `~/.profile` or
+> `~/.bashrc` on login, so the source command is only needed to load them into
+> the current session.
 
 ## minimega and miniweb configuration
 
-By default, the following values are set for minimega:
+The order of precedence for configuration options is:
+1. Existing environment variables
+2. Variables in `/etc/default/minimega`
+3. A set of defaults in the `start-minimega.sh` script
+
+The defaults set for minimega are:
 
 ```shell
 MM_BASE=/tmp/minimega
 MM_FILEPATH=/tmp/minimega/files
 MM_BROADCAST=255.255.255.255
 MM_PORT=9000
-MM_DEGREE=2
+MM_DEGREE=1
 MM_CONTEXT=minimega
 MM_LOGLEVEL=info
 MM_LOGFILE=/var/log/minimega.log
@@ -102,10 +115,10 @@ MM_RECOVER=false
 MM_CGROUP=/sys/fs/cgroup
 ```
 
-By default, the following values are set for miniweb:
+The defaults set for miniweb are:
 
 ```shell
-MINIWEB_ROOT=/opt/minimega/misc/web
+MINIWEB_ROOT=/opt/minimega/web
 MINIWEB_HOST=0.0.0.0
 MINIWEB_PORT=9001
 ```
@@ -114,17 +127,54 @@ These values can be overwritten either by passing environment variables to
 Docker when starting the container or by binding a file to
 `/etc/default/minimega` in the container that contains updated values.
 
-> NOTE: If a value is specified both as an environment variable to Docker and in
+> [!NOTE]
+> If a value is specified both as an environment variable to Docker and in
 > the file bound to `/etc/default/minimega`, the value in
 > `/etc/default/minimega` will be used.
 
-> NOTE: If the port is changed for minimega or miniweb and standard container
+> [!WARNING]
+> If the port is changed for minimega or miniweb and standard container
 > networking is used (not host networking), then the `ports` section in your
 > `docker-compose.yml` or `-p` arguments to `docker run` will need to be updated
 > to the new value(s) specified.
 
-Additional values can be appended to the minimega command by using:
+Additional values can be appended to the minimega command by using the
+`MM_APPEND` environment variable, for example:
 
 ```shell
 MM_APPEND="-hashfiles -headnode=foo1"
+```
+
+## Open vSwitch configuration
+
+The docker container `start-minimega.sh` script takes care of starting
+Open vSwitch server using the
+[`ovs-ctl`](https://docs.openvswitch.org/en/latest/ref/ovs-ctl.8/) program.
+
+Additional values can be appended to the `ovs-ctl start` command by using the
+`OVS_APPEND` environment variable, for example if you are runnng the
+ovsdb-server externally and only need the Open vSwitch client:
+
+```shell
+OVS_APPEND: --no-ovsdb-server --no-ovs-vswitchd
+```
+
+The script has the ability to optionally add host Ethernet interface(s) to a
+Open vSwitch bridge using the `OVS_HOST_IFACE` environment variable. The format
+of the variable is `<bridge>:<port>[,<port>,...]`.
+
+> [!CAUTION]
+> The OVS bridge to add the interface(s) to __*must be specified*__
+
+For example, the following will add the `eth0` host interface to the `phenix`
+OVS bridge, creating the bridge if it doesn't exist already:
+
+```shell
+OVS_HOST_IFACE: phenix:eth0
+```
+
+Multiple interfaces can also be specified:
+
+```shell
+OVS_HOST_IFACE=phenix:eth0,eth1,eth2
 ```

--- a/docker/start-minimega.sh
+++ b/docker/start-minimega.sh
@@ -1,7 +1,30 @@
 #!/bin/bash
 
-/usr/share/openvswitch/scripts/ovs-ctl start
+set -o pipefail
 
+# Check if there are values in /etc/default/minimega
+#   The order of precedence is:
+#     1. Existing environment variables
+#     2. Variables in /etc/default/minimega
+#     3. A set of defaults in this script
+if [[ -f "/etc/default/minimega" ]]; then
+    # Check if any variables are already set
+    while IFS='=' read -r key value; do
+        # Skip empty lines and comments
+        if [[ -n "$key" && -n "$value" && "$key" != \#* ]]; then
+            # Remove surrounding quotes
+            value="${value%\"}"
+            value="${value#\"}"
+
+            # Only set the variable if it is not already set
+            if [[ -z "${!key}" ]]; then
+                export "${key}=${value}"
+            fi
+        fi
+    done < <(grep -v '^#' "/etc/default/minimega")
+fi
+
+# Final default assignment (if these are not set already)
 : "${MINIWEB_ROOT:=/opt/minimega/web}"
 : "${MINIWEB_HOST:=0.0.0.0}"
 : "${MINIWEB_PORT:=9001}"
@@ -11,7 +34,7 @@
 : "${MM_BROADCAST:=255.255.255.255}"
 : "${MM_VLANRANGE:=101-4096}"
 : "${MM_PORT:=9000}"
-: "${MM_DEGREE:=2}"
+: "${MM_DEGREE:=1}"
 : "${MM_CONTEXT:=minimega}"
 : "${MM_LOGLEVEL:=info}"
 : "${MM_LOGFILE:=/var/log/minimega.log}"
@@ -20,48 +43,76 @@
 : "${MM_CGROUP:=/sys/fs/cgroup}"
 : "${MM_APPEND:=}"
 
+: "${OVS_APPEND:=}"
 : "${OVS_HOST_IFACE:=}"
 
-[[ -f "/etc/default/minimega" ]] && source "/etc/default/minimega"
-
-# Use OVS_HOST_IFACE env variable to auto add a host Ethernet interface(s) to an
-# OVS bridge. Note that the OVS bridge to add the interface(s) to must be
-# specified. The format of the value is "<bridge>:<port>[,<port>,...]".
-#
-# Single Interface Example (where bridge name is "phenix"): OVS_HOST_IFACE=phenix:eth0
-# Multi Interface Example (where bridge name is "phenix"): OVS_HOST_IFACE=phenix:eth0,eth1,eth2
-
-if [[ -v "OVS_HOST_IFACE" ]]; then
-  iface=(${OVS_HOST_IFACE//:/ })
-
-  if [[ -n "${iface[0]}" ]]; then
-    /usr/bin/ovs-vsctl --may-exist add-br ${iface[0]}
-    ip link set dev ${iface[0]} up
-  fi
-
-  if [[ -n "${iface[1]}" ]]; then
-    ports=(${iface[1]//,/ })
-
-    for port in "${ports[@]}"; do
-      /usr/bin/ovs-vsctl --may-exist add-port ${iface[0]} ${port}
-    done
-  fi
+# Start Open vSwitch
+/usr/share/openvswitch/scripts/ovs-ctl start ${OVS_APPEND} |& tee -a ${MM_LOGFILE}
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo "failed to start Open vSwitch" | tee -a ${MM_LOGFILE}
+    exit 1
 fi
 
-/opt/minimega/bin/miniweb -root=${MINIWEB_ROOT} -addr=${MINIWEB_HOST}:${MINIWEB_PORT} &
+# Ensure Open vSwitch is available
+TIMEOUT=30
+INTERVAL=1
+START=$(date +%s)
 
+echo "waiting for Open vSwitch to become available (timeout: ${TIMEOUT}s)..." | tee -a ${MM_LOGFILE}
+while true; do
+    current=$(date +%s)
+    elapsed=$((current - START))
+
+    if [[ "$elapsed" -ge "$TIMEOUT" ]]; then
+        echo "failed to connect to Open vSwitch" | tee -a ${MM_LOGFILE}
+        exit 1
+    fi
+
+    if ovs-vsctl show &>/dev/null; then
+        break
+    else
+        sleep $INTERVAL
+    fi
+done
+
+# Check if there are bridge:port values to add
+if [[ -v "OVS_HOST_IFACE" ]]; then
+    iface=(${OVS_HOST_IFACE//:/ })
+    bridge=${iface[0]}
+
+    if [[ -n "${bridge}" ]]; then
+        echo -e "\tadding '${bridge}' bridge..." | tee -a ${MM_LOGFILE}
+        /usr/bin/ovs-vsctl --may-exist add-br ${bridge}
+        ip link set dev ${bridge} up
+    fi
+
+    if [[ -n "${iface[1]}" ]]; then
+        ports=(${iface[1]//,/ })
+
+        for port in "${ports[@]}"; do
+            echo -e "\tadding '${port}' port to '${bridge}' bridge..." | tee -a ${MM_LOGFILE}
+            /usr/bin/ovs-vsctl --may-exist add-port ${bridge} ${port}
+        done
+    fi
+fi
+
+echo "starting miniweb..." | tee -a ${MM_LOGFILE}
+/opt/minimega/bin/miniweb -root=${MINIWEB_ROOT} -addr=${MINIWEB_HOST}:${MINIWEB_PORT} &
+echo "miniweb started on ${MINIWEB_HOST}:${MINIWEB_PORT}" | tee -a ${MM_LOGFILE}
+
+echo "starting minimega..." | tee -a ${MM_LOGFILE}
 /opt/minimega/bin/minimega \
-  -nostdin \
-  -force=${MM_FORCE} \
-  -recover=${MM_RECOVER} \
-  -base=${MM_BASE} \
-  -filepath=${MM_FILEPATH} \
-  -broadcast=${MM_BROADCAST} \
-  -vlanrange=${MM_VLANRANGE} \
-  -port=${MM_PORT} \
-  -degree=${MM_DEGREE} \
-  -context=${MM_CONTEXT} \
-  -level=${MM_LOGLEVEL} \
-  -logfile=${MM_LOGFILE} \
-  -cgroup=${MM_CGROUP} \
-  ${MM_APPEND}
+    -nostdin \
+    -force=${MM_FORCE} \
+    -recover=${MM_RECOVER} \
+    -base=${MM_BASE} \
+    -filepath=${MM_FILEPATH} \
+    -broadcast=${MM_BROADCAST} \
+    -vlanrange=${MM_VLANRANGE} \
+    -port=${MM_PORT} \
+    -degree=${MM_DEGREE} \
+    -context=${MM_CONTEXT} \
+    -level=${MM_LOGLEVEL} \
+    -logfile=${MM_LOGFILE} \
+    -cgroup=${MM_CGROUP} \
+    ${MM_APPEND}


### PR DESCRIPTION
This PR adds new functionality to the docker `start-minimega.sh` entrypoint script:
- Adds better logging and error handling
- Adds an `OVS_APPEND` env var that supports a use case of using an external OVS server instance, with this being used as strictly a client. Some example minimega log output is below
- Adds a wait loop to ensure openvswitch is available before attempting to create a bridge and/or ports
  * Without the wait, it's possible the bridge/port may not get created even if one passed in the correct [env variable](https://github.com/sandia-minimega/minimega/pull/1576)

Example minimega log output:

- docker compose deployment, external OVS server, without passing OVS_APPEND:
    <img width="797" height="51" alt="image" src="https://github.com/user-attachments/assets/2b8b45d9-c509-4a24-b4e6-a3b0c9f1de75" />

- docker compose deployment, external OVS server, with passing `OVS_APPEND: --no-ovsdb-server --no-ovs-vswitchd` and `OVS_HOST_IFACE: __CORE__:experiment`:
    <img width="528" height="105" alt="image" src="https://github.com/user-attachments/assets/3ae7a695-412e-4f7b-9083-f1de3c576761" />

- docker compose deployment using `docker-compose up -d` from the README instructions (no extra env vars):
    <img width="531" height="191" alt="image" src="https://github.com/user-attachments/assets/a371caf1-4bd1-4b6d-b8e5-f2bc9ae5f07c" />