### PR TITLE
fix: Stop returning an Error if users set a namespace that they are already in

### DIFF
--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -947,7 +947,8 @@ func SetNamespace(name string) error {
 	log.Debug("setting active namespace: %v", name)
 
 	if name == namespace {
-		return fmt.Errorf("already in namespace: %v", name)
+		log.Info("already in namespace: %v", name)
+		return nil
 	}
 
 	namespace = name


### PR DESCRIPTION
Currently, when a user tries to set the namespace to the currently active namespace, minimega will throw an error. For example:

```
minimega:/tmp/minimega$ namespace 
host       | namespace | vlans    | active
host1 | firewheel |          | true
minimega:/tmp/minimega$ namespace firewheel
Error (host1): already in namespace: firewheel
```

It looks like this was created a long time ago in  #834 and likely should have been cleaned up in #915 but has since lingered with seemingly no added benefit. Logging the situation and returning seems like a reasonable response and will enable running ``mm`` scripts that happen to use the ``namespace`` command while in the currently active namespace.