### PR TITLE
fix(minirouter): update bird template to work with bird v2 and v3

### DIFF
--- a/cmd/minirouter/bird.go
+++ b/cmd/minirouter/bird.go
@@ -321,7 +321,7 @@ protocol kernel kernel_ipv4 {
     export all;   # Actually insert routes into the kernel routing table
   };
 
-	learn;
+  learn;
 }
 
 protocol kernel kernel_ipv6 {
@@ -332,7 +332,7 @@ protocol kernel kernel_ipv6 {
     export all;   # Actually insert routes into the kernel routing table
   };
 
-	learn;
+  learn;
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
@@ -346,14 +346,14 @@ protocol device {
 {{ if ne $DOSTATIC 0 }}
 #static routes
 protocol static static_ipv4 {
-	check link;
+  check link;
 
   ipv4 {
     import all;
   };
 
 {{ range $network, $nh := .Static4 }}
-	route {{ $network }} via {{ $nh }};
+  route {{ $network }} via {{ $nh }};
 {{ end }}
 }
 {{ end }}
@@ -362,14 +362,14 @@ protocol static static_ipv4 {
 {{ if ne $DOSTATIC 0 }}
 #static routes
 protocol static static_ipv6 {
-	check link;
+  check link;
 
   ipv6 {
     import all;
   };
 
 {{ range $network, $nh := .Static6 }}
-	route {{ $network }} via {{ $nh }};
+  route {{ $network }} via {{ $nh }};
 {{ end }}
 }
 {{ end }}
@@ -379,7 +379,7 @@ protocol static static_ipv6 {
 #Named IPv4 static routes
 {{ range $name, $network := .NamedStatic4 }}
 protocol static static_{{$name}}_ipv4 {
-	check link;
+  check link;
 
   ipv4 {
     import all;
@@ -387,9 +387,9 @@ protocol static static_{{$name}}_ipv4 {
 
 {{ range $net, $nh := $network }}
 	{{ if ne $nh "" }}
-	route {{ $net }} via {{ $nh }};
+  route {{ $net }} via {{ $nh }};
 	{{ else }}
-	route {{ $net }} reject;
+  route {{ $net }} reject;
 	{{ end }}
 {{ end }}
 }
@@ -401,7 +401,7 @@ protocol static static_{{$name}}_ipv4 {
 #Named IPv6 static routes
 {{ range $name, $network := .NamedStatic6 }}
 protocol static static_{{$name}}_ipv6 {
-	check link;
+  check link;
 
   ipv6 {
     import all;
@@ -409,9 +409,9 @@ protocol static static_{{$name}}_ipv6 {
 
 {{ range $net, $nh := $network }}
 	{{ if ne $nh "" }}
-	route {{ $net }} via {{ $nh }};
+  route {{ $net }} via {{ $nh }};
 	{{ else }}
-	route {{ $net }} reject;
+  route {{ $net }} reject;
 	{{ end }}
 {{ end }}
 }

--- a/cmd/minirouter/bird.go
+++ b/cmd/minirouter/bird.go
@@ -15,14 +15,12 @@ import (
 )
 
 const (
-	BIRD_CONFIG  = "/etc/bird.conf"
-	BIRD6_CONFIG = "/etc/bird6.conf"
+	BIRD_CONFIG = "/etc/bird.conf"
 )
 
 type Bird struct {
 	Static      map[string]string
 	NamedStatic map[string]map[string]string
-	Static6     map[string]string
 	OSPF        map[string]*OSPF
 	BGP         map[string]*BGP
 	RouterID    string
@@ -32,7 +30,6 @@ type Bird struct {
 var (
 	birdData *Bird
 	birdCmd  *exec.Cmd
-	bird6Cmd *exec.Cmd
 	birdID   string
 )
 
@@ -74,14 +71,13 @@ func init() {
 	birdData = &Bird{
 		Static:      make(map[string]string),
 		NamedStatic: make(map[string]map[string]string),
-		Static6:     make(map[string]string),
 		OSPF:        make(map[string]*OSPF),
 		BGP:         make(map[string]*BGP),
 		RouterID:    birdID,
 		ExportOSPF:  false,
 	}
-
 }
+
 func handleBird(c *minicli.Command, r chan<- minicli.Responses) {
 	defer func() {
 		r <- nil
@@ -91,7 +87,6 @@ func handleBird(c *minicli.Command, r chan<- minicli.Responses) {
 		birdData = &Bird{
 			Static:      make(map[string]string),
 			NamedStatic: make(map[string]map[string]string),
-			Static6:     make(map[string]string),
 			OSPF:        make(map[string]*OSPF),
 			BGP:         make(map[string]*BGP),
 			RouterID:    birdID,
@@ -107,19 +102,15 @@ func handleBird(c *minicli.Command, r chan<- minicli.Responses) {
 			nh = ""
 		}
 
-		if isIPv4(nh) || nh == "" {
-			if name == "null" && nh != "" {
-				birdData.Static[network] = nh
-			} else {
-				if birdData.NamedStatic[name] == nil {
-					birdData.NamedStatic[name] = make(map[string]string)
-				}
-				birdData.NamedStatic[name][network] = nh
+		if name == "null" && nh == "" {
+			log.Warnln("skipping unnamed static route: next hop not provided")
+		} else if name == "null" {
+			birdData.Static[network] = nh
+		} else {
+			if birdData.NamedStatic[name] == nil {
+				birdData.NamedStatic[name] = make(map[string]string)
 			}
-		} else if isIPv6(nh) {
-			if name == "null" {
-				birdData.Static6[network] = nh
-			}
+			birdData.NamedStatic[name][network] = nh
 		}
 	} else if c.BoolArgs["ospf"] {
 		area := c.StringArgs["area"]
@@ -200,7 +191,7 @@ func handleBird(c *minicli.Command, r chan<- minicli.Responses) {
 }
 
 func birdConfig() {
-	log.Debugln("bird: Setting preparing template")
+	log.Debugln("bird: preparing template")
 	t, err := template.New("bird").Parse(birdTmpl)
 	if err != nil {
 		log.Errorln(err)
@@ -215,22 +206,6 @@ func birdConfig() {
 	}
 	log.Debugln("bird: executing template")
 	err = t.Execute(f, birdData)
-	if err != nil {
-		log.Errorln(err)
-		return
-	}
-
-	// Now, IPv6
-	f, err = os.Create(BIRD6_CONFIG)
-	if err != nil {
-		log.Errorln(err)
-		return
-	}
-
-	// Weird hack: copy birdData and move Static6
-	// into Static so we can use the same template
-	bd2 := &Bird{Static: birdData.Static6, OSPF: birdData.OSPF, RouterID: birdData.RouterID}
-	err = t.Execute(f, bd2)
 	if err != nil {
 		log.Errorln(err)
 		return
@@ -256,26 +231,6 @@ func birdRestart() {
 	if err != nil {
 		log.Errorln(err)
 		birdCmd = nil
-	}
-
-	if bird6Cmd != nil {
-		err := bird6Cmd.Process.Kill()
-		if err != nil {
-			log.Errorln(err)
-			return
-		}
-		_, err = bird6Cmd.Process.Wait()
-		if err != nil {
-			log.Errorln(err)
-			return
-		}
-	}
-
-	bird6Cmd = exec.Command("bird6", "-f", "-s", "/bird6.sock", "-P", "/bird6.pid", "-c", BIRD6_CONFIG)
-	err = bird6Cmd.Start()
-	if err != nil {
-		log.Errorln(err)
-		bird6Cmd = nil
 	}
 }
 
@@ -344,16 +299,24 @@ var birdTmpl = `
 router id {{ .RouterID }};
 
 protocol kernel {
-        scan time 60;
-        import none;
-        export all;   # Actually insert routes into the kernel routing table
+  scan time 60;
+
+  ipv4 {
+    import none;
+    export all;   # Actually insert routes into the kernel routing table
+  };
+
+  ipv6 {
+    import none;
+    export all;   # Actually insert routes into the kernel routing table
+  };
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+  scan time 60;
 }
 
 {{ $DOSTATIC := len .Static }}
@@ -372,7 +335,14 @@ protocol static {
 #Named static routes
 {{ range $name, $network := .NamedStatic }}
 protocol static static_{{$name}}{
-	import all;
+  ipv4 {
+    import all;
+  };
+
+  ipv6 {
+    import all;
+  };
+
 {{ range $net, $nh := $network }}
 	{{ if ne $nh "" }}
 	route {{ $net }} via {{ $nh }};
@@ -387,18 +357,34 @@ protocol static static_{{$name}}{
 {{ $DOOSPF := len .OSPF }}
 {{ if ne $DOOSPF 0 }}
 protocol ospf {
-	import all;
-	{{ if .ExportOSPF}}
-	export filter {
-		{{ range $v := .OSPF }}
-		{{ range $f , $options := $v.Filternetworks }}
-		if proto = "static_{{ $f }}" then
-			accept;
-		{{ end }}
+	ipv4 {
+		import all;
+		{{ if .ExportOSPF}}
+		export filter {
+			{{ range $v := .OSPF }}
+			{{ range $f , $options := $v.Filternetworks }}
+			if proto = "static_{{ $f }}" then
+				accept;
+			{{ end }}
+			{{ end }}
+		};
 		{{ end }}
 	};
-	{{ end }}
-{{ range $v := .OSPF }}
+
+	ipv6 {
+		import all;
+		{{ if .ExportOSPF}}
+		export filter {
+			{{ range $v := .OSPF }}
+			{{ range $f , $options := $v.Filternetworks }}
+			if proto = "static_{{ $f }}" then
+				accept;
+			{{ end }}
+			{{ end }}
+		};
+		{{ end }}
+	};
+  {{ range $v := .OSPF }}
 	area {{ $v.Area }} {
 		{{ $DONETWORK := len $v.Prefixes }}
 		{{ if ne $DONETWORK 0 }}
@@ -416,7 +402,7 @@ protocol ospf {
 		};
 		{{ end }}
 	};
-{{ end }}
+  {{ end }}
 }
 {{ end }}
 
@@ -425,20 +411,35 @@ protocol ospf {
 
 {{ range $v := .BGP }}
 protocol bgp {{ $v.ProcessName }} {
-	import all;
 	local {{ $v.LocalIP }} as {{ $v.LocalAS }};
 	neighbor {{ $v.NeighborIP }} as {{ $v.NeighborAS }};
 	{{ if $v.RouteReflector }}
 	rr client;
 	{{ end }}
-	{{ $EXPORT := len .ExportNetworks }}
-	{{ if ne $EXPORT 0 }}
-	export filter {
-		if {{$v.GenerateFilter}} then
-			accept;
-		else reject;
+
+	ipv4 {
+	  import all;
+		{{ $EXPORT := len .ExportNetworks }}
+		{{ if ne $EXPORT 0 }}
+		export filter {
+			if {{$v.GenerateFilter}} then
+				accept;
+			else reject;
+		};
+		{{ end }}
 	};
-	{{ end }}
+
+	ipv6 {
+	  import all;
+		{{ $EXPORT := len .ExportNetworks }}
+		{{ if ne $EXPORT 0 }}
+		export filter {
+			if {{$v.GenerateFilter}} then
+				accept;
+			else reject;
+		};
+		{{ end }}
+	};
 }
 {{ end }}
 {{ end }}

--- a/cmd/minirouter/bird.go
+++ b/cmd/minirouter/bird.go
@@ -313,7 +313,7 @@ var birdTmpl = `
 
 router id {{ .RouterID }};
 
-protocol kernel_ipv4 {
+protocol kernel kernel_ipv4 {
   scan time 60;
 
   ipv4 {
@@ -324,7 +324,7 @@ protocol kernel_ipv4 {
 	learn;
 }
 
-protocol kernel_ipv6 {
+protocol kernel kernel_ipv6 {
   scan time 60;
 
   ipv6 {
@@ -345,7 +345,7 @@ protocol device {
 {{ $DOSTATIC := len .Static4 }}
 {{ if ne $DOSTATIC 0 }}
 #static routes
-protocol static_ipv4 {
+protocol static static_ipv4 {
 	check link;
 
   ipv4 {
@@ -361,7 +361,7 @@ protocol static_ipv4 {
 {{ $DOSTATIC := len .Static6 }}
 {{ if ne $DOSTATIC 0 }}
 #static routes
-protocol static_ipv6 {
+protocol static static_ipv6 {
 	check link;
 
   ipv6 {

--- a/cmd/minirouter/bird.go
+++ b/cmd/minirouter/bird.go
@@ -19,12 +19,14 @@ const (
 )
 
 type Bird struct {
-	Static      map[string]string
-	NamedStatic map[string]map[string]string
-	OSPF        map[string]*OSPF
-	BGP         map[string]*BGP
-	RouterID    string
-	ExportOSPF  bool
+	Static4      map[string]string
+	Static6      map[string]string
+	NamedStatic4 map[string]map[string]string
+	NamedStatic6 map[string]map[string]string
+	OSPF         map[string]*OSPF
+	BGP          map[string]*BGP
+	RouterID     string
+	ExportOSPF   bool
 }
 
 var (
@@ -69,12 +71,14 @@ func init() {
 	})
 	birdID = getRouterID()
 	birdData = &Bird{
-		Static:      make(map[string]string),
-		NamedStatic: make(map[string]map[string]string),
-		OSPF:        make(map[string]*OSPF),
-		BGP:         make(map[string]*BGP),
-		RouterID:    birdID,
-		ExportOSPF:  false,
+		Static4:      make(map[string]string),
+		Static6:      make(map[string]string),
+		NamedStatic4: make(map[string]map[string]string),
+		NamedStatic6: make(map[string]map[string]string),
+		OSPF:         make(map[string]*OSPF),
+		BGP:          make(map[string]*BGP),
+		RouterID:     birdID,
+		ExportOSPF:   false,
 	}
 }
 
@@ -85,11 +89,13 @@ func handleBird(c *minicli.Command, r chan<- minicli.Responses) {
 	log.Debugln("bird: Parsing command")
 	if c.BoolArgs["flush"] {
 		birdData = &Bird{
-			Static:      make(map[string]string),
-			NamedStatic: make(map[string]map[string]string),
-			OSPF:        make(map[string]*OSPF),
-			BGP:         make(map[string]*BGP),
-			RouterID:    birdID,
+			Static4:      make(map[string]string),
+			Static6:      make(map[string]string),
+			NamedStatic4: make(map[string]map[string]string),
+			NamedStatic6: make(map[string]map[string]string),
+			OSPF:         make(map[string]*OSPF),
+			BGP:          make(map[string]*BGP),
+			RouterID:     birdID,
 		}
 	} else if c.BoolArgs["commit"] {
 		birdConfig()
@@ -105,12 +111,21 @@ func handleBird(c *minicli.Command, r chan<- minicli.Responses) {
 		if name == "null" && nh == "" {
 			log.Warnln("skipping unnamed static route: next hop not provided")
 		} else if name == "null" {
-			birdData.Static[network] = nh
-		} else {
-			if birdData.NamedStatic[name] == nil {
-				birdData.NamedStatic[name] = make(map[string]string)
+			if isIPv4(nh) {
+				birdData.Static4[network] = nh
+			} else if isIPv6(nh) {
+				birdData.Static6[network] = nh
 			}
-			birdData.NamedStatic[name][network] = nh
+		} else if isIPv4(nh) {
+			if birdData.NamedStatic4[name] == nil {
+				birdData.NamedStatic4[name] = make(map[string]string)
+			}
+			birdData.NamedStatic4[name][network] = nh
+		} else if isIPv6(nh) {
+			if birdData.NamedStatic6[name] == nil {
+				birdData.NamedStatic6[name] = make(map[string]string)
+			}
+			birdData.NamedStatic6[name][network] = nh
 		}
 	} else if c.BoolArgs["ospf"] {
 		area := c.StringArgs["area"]
@@ -298,7 +313,7 @@ var birdTmpl = `
 
 router id {{ .RouterID }};
 
-protocol kernel {
+protocol kernel_ipv4 {
   scan time 60;
 
   ipv4 {
@@ -306,10 +321,18 @@ protocol kernel {
     export all;   # Actually insert routes into the kernel routing table
   };
 
+	learn;
+}
+
+protocol kernel_ipv6 {
+  scan time 60;
+
   ipv6 {
     import none;
     export all;   # Actually insert routes into the kernel routing table
   };
+
+	learn;
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
@@ -319,25 +342,66 @@ protocol device {
   scan time 60;
 }
 
-{{ $DOSTATIC := len .Static }}
+{{ $DOSTATIC := len .Static4 }}
 {{ if ne $DOSTATIC 0 }}
 #static routes
-protocol static {
+protocol static_ipv4 {
 	check link;
-{{ range $network, $nh := .Static }}
+
+  ipv4 {
+    import all;
+  };
+
+{{ range $network, $nh := .Static4 }}
 	route {{ $network }} via {{ $nh }};
 {{ end }}
 }
 {{ end }}
 
-{{ $DOSTATIC := len .NamedStatic }}
+{{ $DOSTATIC := len .Static6 }}
 {{ if ne $DOSTATIC 0 }}
-#Named static routes
-{{ range $name, $network := .NamedStatic }}
-protocol static static_{{$name}}{
+#static routes
+protocol static_ipv6 {
+	check link;
+
+  ipv6 {
+    import all;
+  };
+
+{{ range $network, $nh := .Static6 }}
+	route {{ $network }} via {{ $nh }};
+{{ end }}
+}
+{{ end }}
+
+{{ $DOSTATIC := len .NamedStatic4 }}
+{{ if ne $DOSTATIC 0 }}
+#Named IPv4 static routes
+{{ range $name, $network := .NamedStatic4 }}
+protocol static static_{{$name}}_ipv4 {
+	check link;
+
   ipv4 {
     import all;
   };
+
+{{ range $net, $nh := $network }}
+	{{ if ne $nh "" }}
+	route {{ $net }} via {{ $nh }};
+	{{ else }}
+	route {{ $net }} reject;
+	{{ end }}
+{{ end }}
+}
+{{ end }}
+{{ end }}
+
+{{ $DOSTATIC := len .NamedStatic6 }}
+{{ if ne $DOSTATIC 0 }}
+#Named IPv6 static routes
+{{ range $name, $network := .NamedStatic6 }}
+protocol static static_{{$name}}_ipv6 {
+	check link;
 
   ipv6 {
     import all;
@@ -371,19 +435,6 @@ protocol ospf {
 		{{ end }}
 	};
 
-	ipv6 {
-		import all;
-		{{ if .ExportOSPF}}
-		export filter {
-			{{ range $v := .OSPF }}
-			{{ range $f , $options := $v.Filternetworks }}
-			if proto = "static_{{ $f }}" then
-				accept;
-			{{ end }}
-			{{ end }}
-		};
-		{{ end }}
-	};
   {{ range $v := .OSPF }}
 	area {{ $v.Area }} {
 		{{ $DONETWORK := len $v.Prefixes }}
@@ -418,18 +469,6 @@ protocol bgp {{ $v.ProcessName }} {
 	{{ end }}
 
 	ipv4 {
-	  import all;
-		{{ $EXPORT := len .ExportNetworks }}
-		{{ if ne $EXPORT 0 }}
-		export filter {
-			if {{$v.GenerateFilter}} then
-				accept;
-			else reject;
-		};
-		{{ end }}
-	};
-
-	ipv6 {
 	  import all;
 		{{ $EXPORT := len .ExportNetworks }}
 		{{ if ne $EXPORT 0 }}


### PR DESCRIPTION
Starting with bird v2 (at least from what I can tell), the config file changed such that each protocol supported channels. This allowed a single bird executable to work for both IPv4 and IPv6 (among other things).

Note that this came about because:

1. minirouter can no longer run on Ubuntu Noble due to outdated glibc
2. updating to a more recent distro no longer has the bird v1 package
3. installing bird v2 or bird v3 leads to bird failing to start due to config file issues
4. installing bird v2 or bird v3 also causes an error due to the bird6 command missing

As written, this fix supports IPv4 and IPv6 for static routes (named and unnamed), but only supports IPv4 for OSPF and BGP.

> [!WARNING]
> THIS NEEDS TESTING! I'm only using bird for unnamed static routes right now, so I have not tested that this works properly for named static routes, OSPF, or BGP via bird. As such, I will try to test when I can unless someone else has time to test.

At a minimum, this will allow bird to start properly. Note that bird not starting because of the invalid config file does not prevent minirouter from running properly.