### PR TITLE
feat(minimega): add `-abssnapshot` flag

### DIFF
--- a/cmd/minimega/disk_cli.go
+++ b/cmd/minimega/disk_cli.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,6 +16,8 @@ import (
 	"github.com/sandia-minimega/minimega/v2/pkg/minicli"
 	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
 )
+
+var backingType = "relative"
 
 var diskCLIHandlers = []minicli.Handler{
 	{
@@ -83,7 +86,7 @@ The 'recursive' flag can be set to print out full details for all backing images
 	},
 	{
 		HelpShort: "creates a new disk 'dst' backed by 'image'",
-		HelpLong: `
+		HelpLong: fmt.Sprintf(`
 Creates a new qcow2 image 'dst' backed by 'image'.
 
 Example of taking a snapshot of a disk:
@@ -95,13 +98,13 @@ snapshot will be stored in the 'files' directory. Snapshots are always created
 in the 'files' directory.
 
 Users may use paths relative to the 'files' directory or absolute paths for inputs; 
-however, the backing path will always be relative to the new image.`,
+however, the backing path will always be %s to the new image.`, backingType),
 		Patterns: []string{"disk snapshot <image> [dst image]"},
 		Call:     wrapSimpleCLI(cliDiskSnapshot),
 	},
 	{
 		HelpShort: "rebases the disk onto a different backing image",
-		HelpLong: `
+		HelpLong: fmt.Sprintf(`
 Rebases the image 'image' onto a new backing file 'backing'.
 Using 'rebase' will write any differences between the original backing file and the new backing file to 'image'.
 
@@ -116,7 +119,7 @@ The 'backing' argument can be omitted, causing all backing data to be written to
 		disk rebase myimage.qcow2
 		
 Users may use paths relative to the 'files' directory or absolute paths for inputs; 
-however, the backing path will always be relative to the rebased image.`,
+however, the backing path will always be %s to the rebased image.`, backingType),
 		Patterns: []string{
 			"disk <rebase,> <image> [backing file]",
 			"disk <set-backing,> <image> [backing file]",

--- a/cmd/minimega/main.go
+++ b/cmd/minimega/main.go
@@ -55,6 +55,7 @@ var (
 	f_pipe        = flag.String("pipe", "", "read/write to or from a named pipe")
 	f_headnode    = flag.String("headnode", "", "mesh node to send all logs to and get all files from")
 	f_hashfiles   = flag.Bool("hashfiles", false, "hash files to be served by iomeshage")
+	f_absSnapshot = flag.Bool("abssnapshot", false, "use absolute paths to backing images when creating snapshots")
 
 	f_e         = flag.Bool("e", false, "execute command on running minimega")
 	f_attach    = flag.Bool("attach", false, "attach the minimega command line to a running instance of minimega")
@@ -98,6 +99,10 @@ func main() {
 	// see containerShim()
 	if flag.NArg() > 1 && flag.Arg(0) == CONTAINER_MAGIC {
 		containerShim()
+	}
+
+	if *f_absSnapshot {
+		backingType = "absolute" // used for command help messages
 	}
 
 	cliSetup()
@@ -218,7 +223,7 @@ func main() {
 	}
 
 	// attempt to set up the base path
-	if err := os.MkdirAll(*f_base, os.FileMode(0770)); err != nil {
+	if err := os.MkdirAll(*f_base, os.FileMode(0o770)); err != nil {
 		log.Fatal("mkdir base path: %v", err)
 	}
 

--- a/docker/start-minimega.sh
+++ b/docker/start-minimega.sh
@@ -8,20 +8,20 @@ set -o pipefail
 #     2. Variables in /etc/default/minimega
 #     3. A set of defaults in this script
 if [[ -f "/etc/default/minimega" ]]; then
-    # Check if any variables are already set
-    while IFS='=' read -r key value; do
-        # Skip empty lines and comments
-        if [[ -n "$key" && -n "$value" && "$key" != \#* ]]; then
-            # Remove surrounding quotes
-            value="${value%\"}"
-            value="${value#\"}"
+  # Check if any variables are already set
+  while IFS='=' read -r key value; do
+    # Skip empty lines and comments
+    if [[ -n "$key" && -n "$value" && "$key" != \#* ]]; then
+      # Remove surrounding quotes
+      value="${value%\"}"
+      value="${value#\"}"
 
-            # Only set the variable if it is not already set
-            if [[ -z "${!key}" ]]; then
-                export "${key}=${value}"
-            fi
-        fi
-    done < <(grep -v '^#' "/etc/default/minimega")
+      # Only set the variable if it is not already set
+      if [[ -z "${!key}" ]]; then
+        export "${key}=${value}"
+      fi
+    fi
+  done < <(grep -v '^#' "/etc/default/minimega")
 fi
 
 # Final default assignment (if these are not set already)
@@ -41,6 +41,7 @@ fi
 : "${MM_FORCE:=true}"
 : "${MM_RECOVER:=false}"
 : "${MM_CGROUP:=/sys/fs/cgroup}"
+: "${MM_ABSSNAPSHOT:=false}"
 : "${MM_APPEND:=}"
 
 : "${OVS_APPEND:=}"
@@ -49,8 +50,8 @@ fi
 # Start Open vSwitch
 /usr/share/openvswitch/scripts/ovs-ctl start ${OVS_APPEND} |& tee -a ${MM_LOGFILE}
 if [ ${PIPESTATUS[0]} -ne 0 ]; then
-    echo "failed to start Open vSwitch" | tee -a ${MM_LOGFILE}
-    exit 1
+  echo "failed to start Open vSwitch" | tee -a ${MM_LOGFILE}
+  exit 1
 fi
 
 # Ensure Open vSwitch is available
@@ -60,40 +61,40 @@ START=$(date +%s)
 
 echo "waiting for Open vSwitch to become available (timeout: ${TIMEOUT}s)..." | tee -a ${MM_LOGFILE}
 while true; do
-    current=$(date +%s)
-    elapsed=$((current - START))
+  current=$(date +%s)
+  elapsed=$((current - START))
 
-    if [[ "$elapsed" -ge "$TIMEOUT" ]]; then
-        echo "failed to connect to Open vSwitch" | tee -a ${MM_LOGFILE}
-        exit 1
-    fi
+  if [[ "$elapsed" -ge "$TIMEOUT" ]]; then
+    echo "failed to connect to Open vSwitch" | tee -a ${MM_LOGFILE}
+    exit 1
+  fi
 
-    if ovs-vsctl show &>/dev/null; then
-        break
-    else
-        sleep $INTERVAL
-    fi
+  if ovs-vsctl show &>/dev/null; then
+    break
+  else
+    sleep $INTERVAL
+  fi
 done
 
 # Check if there are bridge:port values to add
 if [[ -v "OVS_HOST_IFACE" ]]; then
-    iface=(${OVS_HOST_IFACE//:/ })
-    bridge=${iface[0]}
+  iface=(${OVS_HOST_IFACE//:/ })
+  bridge=${iface[0]}
 
-    if [[ -n "${bridge}" ]]; then
-        echo -e "\tadding '${bridge}' bridge..." | tee -a ${MM_LOGFILE}
-        /usr/bin/ovs-vsctl --may-exist add-br ${bridge}
-        ip link set dev ${bridge} up
-    fi
+  if [[ -n "${bridge}" ]]; then
+    echo -e "\tadding '${bridge}' bridge..." | tee -a ${MM_LOGFILE}
+    /usr/bin/ovs-vsctl --may-exist add-br ${bridge}
+    ip link set dev ${bridge} up
+  fi
 
-    if [[ -n "${iface[1]}" ]]; then
-        ports=(${iface[1]//,/ })
+  if [[ -n "${iface[1]}" ]]; then
+    ports=(${iface[1]//,/ })
 
-        for port in "${ports[@]}"; do
-            echo -e "\tadding '${port}' port to '${bridge}' bridge..." | tee -a ${MM_LOGFILE}
-            /usr/bin/ovs-vsctl --may-exist add-port ${bridge} ${port}
-        done
-    fi
+    for port in "${ports[@]}"; do
+      echo -e "\tadding '${port}' port to '${bridge}' bridge..." | tee -a ${MM_LOGFILE}
+      /usr/bin/ovs-vsctl --may-exist add-port ${bridge} ${port}
+    done
+  fi
 fi
 
 echo "starting miniweb..." | tee -a ${MM_LOGFILE}
@@ -102,17 +103,18 @@ echo "miniweb started on ${MINIWEB_HOST}:${MINIWEB_PORT}" | tee -a ${MM_LOGFILE}
 
 echo "starting minimega..." | tee -a ${MM_LOGFILE}
 /opt/minimega/bin/minimega \
-    -nostdin \
-    -force=${MM_FORCE} \
-    -recover=${MM_RECOVER} \
-    -base=${MM_BASE} \
-    -filepath=${MM_FILEPATH} \
-    -broadcast=${MM_BROADCAST} \
-    -vlanrange=${MM_VLANRANGE} \
-    -port=${MM_PORT} \
-    -degree=${MM_DEGREE} \
-    -context=${MM_CONTEXT} \
-    -level=${MM_LOGLEVEL} \
-    -logfile=${MM_LOGFILE} \
-    -cgroup=${MM_CGROUP} \
-    ${MM_APPEND}
+  -nostdin \
+  -force=${MM_FORCE} \
+  -recover=${MM_RECOVER} \
+  -base=${MM_BASE} \
+  -filepath=${MM_FILEPATH} \
+  -broadcast=${MM_BROADCAST} \
+  -vlanrange=${MM_VLANRANGE} \
+  -port=${MM_PORT} \
+  -degree=${MM_DEGREE} \
+  -context=${MM_CONTEXT} \
+  -level=${MM_LOGLEVEL} \
+  -logfile=${MM_LOGFILE} \
+  -cgroup=${MM_CGROUP} \
+  -abssnapshot=${MM_ABSSNAPSHOT} \
+  ${MM_APPEND}


### PR DESCRIPTION
<!-- Use the title to describe PR changes using the conventional commit format -->
<!-- Remember this title will end up as the merge commit subject -->

## Description ##
The new `-abssnapshot` flag, which defaults to false for backwards compatibility, reverts back to using absolute paths for backing images.

This has to be an install-wide flag due to internal functions (like KVM launch) calling `diskSnapshot` without user input.

See comments in PR #1545 for additional details.

## Motivation and context ##
A previous PR updated the disk snapshot and rebase commands to use relative file paths for parent backing images. This works in some environments, but ends up breaking other (existing) environments.

## Testing ##
I ran this branch of minimega with phenix and tested both use cases that were failing before (new VM backing image and VM snapshots). These use cases now work as expected.

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
N/A