### PR TITLE
fix(miniccc): fix UDP test-conn on Windows

### DIFF
--- a/cmd/miniccc/commands.go
+++ b/cmd/miniccc/commands.go
@@ -319,7 +319,7 @@ func testConnect(test *ron.ConnTest) (string, string) {
 						}
 					}
 
-					buf := make([]byte, 1)
+					buf := make([]byte, 4096)
 
 					if _, err := conn.Read(buf); err != nil {
 						return fmt.Sprintf("%s | fail", uri.Host), ""


### PR DESCRIPTION
## Description ##
The `cc test-conn udp` command incorrectly failed on Windows hosts with a `wsarecv` error when reading a UDP response into a 1-byte buffer.

## Motivation and context ##
Solves https://github.com/sandialabs/sceptre-phenix/issues/263

## Testing ##
Injected updated `miniccc.exe` and the tests that were previously failing now pass.

## Checklist ##
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~~[ ] I have commented my code, particularly in hard-to-understand areas.~~
- ~~[ ] I have made corresponding changes to the documentation.~~
- [X] I have tested my code using the methods described above.
- [X] All GitHub Actions are passing.

## Additional Notes ##
N/A