### PR TITLE
feat (miniccc): add backup for getting UUID

### DIFF
--- a/cmd/miniccc/uuid_windows.go
+++ b/cmd/miniccc/uuid_windows.go
@@ -18,7 +18,11 @@ import (
 func getUUID() string {
 	out, err := exec.Command("wmic", "path", "win32_computersystemproduct", "get", "uuid").CombinedOutput()
 	if err != nil {
-		log.Fatal("wmic run: %v", err)
+		// Try powershell fallback
+		out, err = exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", "Get-CimInstance -ClassName Win32_ComputerSystemProduct | Select-Object -ExpandProperty UUID").CombinedOutput()
+		if err != nil {
+			log.Fatal("unable to get UUID: %v", err)
+		}
 	}
 
 	// string must be in the form:


### PR DESCRIPTION
## Description ##
Add fallback to `powershell` command for getting the system UUID.

## Motivation and context ##
For newer versions of Windows, [Microsoft deprecated the `wmic` tool](https://learn.microsoft.com/en-us/windows-server/get-started/removed-deprecated-features-windows-server?tabs=ws25), so this call fatally errors. Adding a backup method using Powershell ensures compatibility across Windows versions.

## Testing ##
Testing using Windows Server 2025.
<img width="1100" height="67" alt="image" src="https://github.com/user-attachments/assets/01143e41-d650-4d49-81e2-832b88c635e8" />


## Checklist ##
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] I have tested my code using the methods described above.
- [X] All GitHub Actions are passing.

## Additional Notes ##
n/a