### PR TITLE
fix(minimega): add diskInject mount retries

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,6 @@
 # please keep this list alphabetized by last name
 
+Nicholas Blair <nblair2@nlr.gov>
 Steven Cheng <scheng@sandia.gov>
 Devin Cook <devcook@sandia.gov>
 Miles Crabill <mcrabil@sandia.gov>


### PR DESCRIPTION
## Description ##
This PR addresses stability issues in `diskInject` by implementing a retry loop for the initial mount command. It allows the operation to recover from failures caused by NBD partition device nodes not being immediately ready for I/O after creation.

## Motivation and context ##
When moving from Ubuntu 22.04.X --> 24.04.2 I found issues when starting many VMs (>100) at the same time. The specific symptom was an error at line 366 (NTFS mount failure), which was actually a side effect of the standard ext4/xfs mount failing at line 355 due to the device being busy or not fully initialized. On newer kernels, the timing for NBD block device node generation appears to have changed, leading to failures under high contention. This fix aligns with existing retry logic when searching for partitions.

## Testing ##
I tested several large start files repeatedly and found no issues.

## Checklist ##
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- ~I have made corresponding changes to the documentation.~
- [x] I have tested my code using the methods described above.
- [X] All GitHub Actions are passing.

## Additional Notes ##
N/A