### PR TITLE
fix: Adjust python release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
           if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
           with:
             name: minimega-python-dist
-            path: ./lib/dist/
+            path: ./minimega/lib/dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build Binaries
 on: 
   push:
   workflow_call:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -20,17 +22,17 @@ jobs:
             ./scripts/all.bash
         # Only for release:
         - name: Tar
-          if: github.event_name == 'workflow_dispatch'
+          if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
           run: tar -czvf minimega-$( cat minimega/VERSION | cut -d'=' -f2 )-binaries.tar.gz minimega
         - name: Upload artifact
           uses: actions/upload-artifact@v4.0.0
-          if: github.event_name == 'workflow_dispatch'
+          if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
           with:
             name: minimega-binaries
             path: ./*.tar.gz
         - name: Upload python package
           uses: actions/upload-artifact@v4.0.0
-          if: github.event_name == 'workflow_dispatch'
+          if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
           with:
             name: minimega-python-dist
-            path: ./minimega/lib/dist/
+            path: ./lib/dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
           if: github.event_name == 'workflow_dispatch'
           with:
             name: minimega-python-dist
-            path: ./lib/dist/
+            path: ./minimega/lib/dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,8 +16,12 @@ permissions:
   contents: read
 
 jobs:
+  binary-build:
+    name: Build Binaries
+    uses: ./.github/workflows/build.yml
   deploy:
     runs-on: ubuntu-latest
+    needs: binary-build
     steps:
     - uses: actions/checkout@v4
     - uses: actions/download-artifact@v5

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/download-artifact@v5
       with:
         name: minimega-python-dist
-        path: .
+        path: dist
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,6 @@ jobs:
             minimega-binaries/*.tar.gz
             minimega-deb/*.deb
             minimega-rpm/**/*.rpm
+            minimega-python-dist/**/*.whl
           generate_release_notes: true
           fail_on_unmatched_files: true


### PR DESCRIPTION
<!-- Use the title to describe PR changes using the conventional commit format -->
<!-- Remember this title will end up as the merge commit subject -->

## Description ##
This fixes a few issues in the prior #1592 and ensures that a release will correctly push the associated python package.

## Testing ##
This was extensively tested on my own fork including pushing multiple (broken) releases.

## Checklist ##
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
<!-- Please provide any additional information or context for your pull request here. -->