### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 minimega
 ========
 
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sandia-minimega/minimega)
+
 minimega is a tool for launching and managing virtual machines. It can run on
 your laptop or distributed across a cluster. minimega is fast, easy to deploy,
 and can scale to run on massive clusters with virtually no setup.


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/sandia-minimega/minimega) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.