### PR TITLE
build(packages): staticly link binaries

### DIFF
--- a/scripts/build.bash
+++ b/scripts/build.bash
@@ -40,7 +40,11 @@ echo "BUILD PACKAGES (linux)"
 for i in ${DIRECTORY_ARRAY[@]}; do
     for j in `ls $i | grep -v plumbing`; do
         echo $j
-        go install -ldflags="-s -w" $i/$j
+        if [[ "$j" == "miniccc" || "$j" == "protonuke" || "$j" == "minirouter" ]]; then
+            CGO_ENABLED=0 go install -ldflags="-s -w" $i/$j
+        else
+            go install -ldflags="-s -w" $i/$j
+        fi
         if [[ $? != 0 ]]; then
             exit 1
         fi
@@ -52,7 +56,7 @@ echo "BUILD PACKAGES (windows)"
 for i in ${DIRECTORY_ARRAY[@]}; do
     for j in `ls $i | grep -E "protonuke|miniccc"`; do
         echo $j
-        GOOS=windows go build -ldflags="-s -w" -o $ROOT_DIR/bin/$j.exe $i/$j
+        CGO_ENABLED=0 GOOS=windows go build -ldflags="-s -w" -o $ROOT_DIR/bin/$j.exe $i/$j
         if [[ $? != 0 ]]; then
             exit 1
         fi


### PR DESCRIPTION
## Description ##
Statically link packages with `CGO_ENABLED=0`.

## Motivation and context ##
Allows packages to run on hosts without any dependencies.

## Testing ##
TODO

## Checklist ##
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- ~I have commented my code, particularly in hard-to-understand areas.~
- ~I have made corresponding changes to the documentation.~
- [ ] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
N/A