### PR TITLE
fix: Add the -`abssnapshot` flag to the minimega config and service files

### DIFF
--- a/misc/daemon/minimega.conf
+++ b/misc/daemon/minimega.conf
@@ -57,3 +57,6 @@ MM_RECOVER=false
 
 # Path to control group (cgroup) mount location
 MM_CGROUP="/sys/fs/cgroup"
+
+# Use absolute paths for backing images
+MM_ABSSNAPSHOT=false

--- a/misc/daemon/minimega.service
+++ b/misc/daemon/minimega.service
@@ -20,7 +20,7 @@ EnvironmentFile=/etc/minimega/minimega.conf
 ExecStartPre=/bin/mkdir -p /etc/minimega/saved_vms/
 ExecStartPre=/bin/mkdir -p ${MM_RUN_PATH}
 # Starting minimega
-ExecStart=/usr/bin/minimega -nostdin=${MM_DAEMON} -force=${MM_FORCE} -recover=${MM_RECOVER} -base=${MM_BASE} -filepath=${MM_FILEPATH} -broadcast=${MM_BROADCAST} -vlanrange=${MM_VLANRANGE} -port=${MM_PORT} -degree=${MM_DEGREE} -context=${MM_CONTEXT} -level=${MM_LOGLEVEL} -logfile=${MM_LOGFILE} -cgroup=${MM_CGROUP} -panic=${MM_PANIC} -msa=${MM_MSA}
+ExecStart=/usr/bin/minimega -nostdin=${MM_DAEMON} -force=${MM_FORCE} -recover=${MM_RECOVER} -base=${MM_BASE} -filepath=${MM_FILEPATH} -broadcast=${MM_BROADCAST} -vlanrange=${MM_VLANRANGE} -port=${MM_PORT} -degree=${MM_DEGREE} -context=${MM_CONTEXT} -level=${MM_LOGLEVEL} -logfile=${MM_LOGFILE} -cgroup=${MM_CGROUP} -panic=${MM_PANIC} -msa=${MM_MSA} -abssnapshot=${MM_ABSSNAPSHOT}
 # After start options
 ExecStartPost=/bin/sleep 1
 ExecStartPost=/bin/chgrp -R minimega ${MM_RUN_PATH}


### PR DESCRIPTION
<!-- Use the title to describe PR changes using the conventional commit format -->
<!-- Remember this title will end up as the merge commit subject -->

## Description ##
This fix addresses a bug stemming from https://github.com/sandia-minimega/minimega/pull/1587 where the new `-abssnapshot` flag was not added to the `minimega.service` file and the associated `MM_ABSSNAPSHOT` environment variable was not added to `minimega.conf`.

## Motivation and context ##
This addresses consistency issues between those that run minimega via a docker container and those that run it as a systemd service.

## Testing ##
This was manually tested/verified on a minimega v3.0.0 instance.

## Checklist ##
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
<!-- Please provide any additional information or context for your pull request here. -->