### PR TITLE
fix(ron): serialize heartbeat writes

### DIFF
--- a/internal/ron/server.go
+++ b/internal/ron/server.go
@@ -757,7 +757,7 @@ func (s *Server) handshake(conn net.Conn) (*client, error) {
 				case <-t.C:
 					log.Debug("sending HEARTBEAT to client %s", m.Client.UUID)
 					m := Message{Type: MESSAGE_HEARTBEAT, Version: "v1"}
-					c.enc.Encode(&m) // no need to worry about errors here
+					c.sendMessage(&m) // a loss of connection is detected elsewhere.
 				}
 			}
 		}()
@@ -765,14 +765,17 @@ func (s *Server) handshake(conn net.Conn) (*client, error) {
 		return nil, fmt.Errorf("client %s: %w", m.Client.UUID, errClientTooOld)
 	}
 
-	// TODO: if the client blocks, ron will hang... probably not good
-	if err := c.enc.Encode(&m); err != nil {
+	// set write deadline to prevent ron from hanging
+	conn.SetWriteDeadline(time.Now().Add(HEARTBEAT_RATE * time.Second))
+	if err := c.sendMessage(&m); err != nil {
 		// client disconnected before it read the full handshake
+		close(c.cancelHeartbeat)
 		if err != io.EOF {
 			log.Errorln(err)
 		}
 		return nil, err
 	}
+	conn.SetWriteDeadline(time.Time{})
 
 	c.Client = m.Client
 	if c.mangled {


### PR DESCRIPTION
<!-- Use the title to describe PR changes using the conventional commit format -->
<!-- Remember this title will end up as the merge commit subject -->

## Description ##
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
Send heartbeat via sendMessage so the write is serialized with UFS/ command/tunnel writes through writeMu. Calling c.enc.Encode directly races those writes on the shared gob.Encoder, which interleaves bytes and desyncs the client decoder. Under heavy load this caused client errors. Also add a write deadline to address the TODO.

## Motivation and context ##
Under heavy load, some miniccc heartbeats would become corrupted.

## Testing ##
Repeated same heavy-loading scenario - no issues.

## Checklist ##
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.
- [X] I have tested my code using the methods described above.
- [X] All GitHub Actions are passing.

## Additional Notes ##
N/A