### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,61 @@
+# https://editorconfig.org/
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+
+[*.py]
+max_line_length = 88
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+insert_final_newline = unset
+
+[Makefile]
+indent_style = tab
+insert_final_newline = true
+
+[*.{ps1,bat}]
+end_of_line = crlf
+
+[*.{xml,xslt}]
+indent_size = 2
+
+[*.{md,mdx}]
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,jsx,ts,tsx}]
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Dockerfile*]
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.lua]
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.toml]
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing to minimega! We welcome contribution
   - [Reporting Issues](#reporting-issues)
   - [Suggesting Enhancements](#suggesting-enhancements)
   - [Submitting Code](#submitting-code)
+    - [EditorConfig](#editorconfig)
 - [License](#license)
 
 ## Getting Started
@@ -115,6 +116,24 @@ We welcome suggestions for improvements! Please open an issue to discuss your id
     ```
     
 5. **Open a Pull Request**: Go to the original repository and open a [pull request](https://github.com/sandia-minimega/minimega/pulls). Provide a clear description of your changes and reference any related issues.
+
+### EditorConfig
+
+Use EditorConfig support in your editor so basic formatting rules are applied automatically when `.editorconfig` files are present in the tree.
+
+In Visual Studio Code ([VSCode](https://code.visualstudio.com/)):
+
+1. Install the [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) extension.
+2. Open the `minimega` repository in VS Code.
+3. Make sure the extension is enabled for your workspace.
+
+Quick verification:
+
+1. Open a file in a directory that has an `.editorconfig`.
+2. Edit whitespace (for example indentation or trailing spaces) and save.
+3. Confirm the file is formatted according to that directory's rules.
+
+EditorConfig complements language-native formatters such as `gofmt`; continue to run language-specific formatters and tests before opening a pull request.
 
 ## License
 By contributing to this project, you agree that your contributions will be licensed under the [GNU General Public License v3.0](https://github.com/sandia-minimega/minimega/blob/master/LICENSE) License.

--- a/doc/content/articles/contributing.article
+++ b/doc/content/articles/contributing.article
@@ -39,6 +39,24 @@ codebase, you should adhere to the style in that particular section of code.
 minimega is growing rapidly and often times newer code is more well thought out
 (or not) than older code.
 
+* EditorConfig
+
+Use EditorConfig support in your editor so basic formatting rules are applied
+automatically when `.editorconfig` files are present in the tree.
+
+If you use VS Code, install the
+[[https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig][EditorConfig for VS Code]]
+extension and ensure it is enabled for your workspace.
+
+Quick verification:
+
+- Open a file in a directory that has an `.editorconfig`.
+- Edit whitespace (for example indentation or trailing spaces) and save.
+- Confirm the file follows the directory's EditorConfig rules.
+
+EditorConfig complements language-native formatters such as `gofmt`; continue
+to run language-specific formatters and tests before opening a pull request.
+
 * Tests
 
 Add unit tests using Go's unit test framework whenever possible. If your code


### PR DESCRIPTION
# chore: add editorconfig

## Description

Add [editorconfig](https://editorconfig.org/). This is already present in sceptre-phenix, adding to other repos now.

## Motivation and context ##

EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs.

## Testing ##

Works with my local editor.

## Checklist ##
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
~~- [ ] I have made corresponding changes to the documentation.~~
- [x] I have tested my code using the methods described above.
- [ ] All GitHub Actions are passing.

## Additional Notes ##

N/A
