### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default owners
+* @GhostofGoes @sdelliot @jacdavi @aherna
+
+# Repository directories
+/cmd/       @activeshadow @jacdavi @sdelliot
+/docker/    @activeshadow @glattercj @GhostofGoes @sdelliot @jacdavi
+/internal/  @activeshadow @jacdavi @glattercj
+/lib/       @jacdavi @sdelliot @GhostofGoes
+/packaging/ @sdelliot
+/pkg/       @activeshadow @jacdavi
+/scripts/   @sdelliot @jacdavi @activeshadow
+/web/       @jacdavi @sdelliot @activeshadow


### PR DESCRIPTION
# chore: add CODEOWNERS

## Description

Initial stab at a CODEOWNERS file. 

Looking for feedback on:
- is this something desired/good idea?
- any names to add/remove?
- any specific areas that should be more specific about owners?

## Motivation and context

CODEOWNERS provides guidance on who has "ownership" of an area of code and can answer questions or review PRs.

## Testing ##
N/A

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
~~- [ ] I have made corresponding changes to the documentation.~~
- [x] I have tested my code using the methods described above.
- [ ] All GitHub Actions are passing.

## Additional Notes ##
N/A