### PR TITLE
fix(qemu-nbd): claim device on check

### DIFF
--- a/internal/nbd/nbd.go
+++ b/internal/nbd/nbd.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
@@ -18,6 +19,10 @@ import (
 
 var (
 	ErrNoDeviceAvailable = errors.New("no available nbds found")
+
+	// nbdLock serializes device selection and connection so concurrent
+	// callers can't claim the same device.
+	nbdLock sync.Mutex
 )
 
 const (
@@ -103,32 +108,45 @@ func GetDevice() (string, error) {
 // ConnectImage exports a image using the NBD protocol using the qemu-nbd. If
 // successful, returns the NBD device.
 func ConnectImage(image string) (string, error) {
-	var nbdPath string
 	var err error
 
 	for i := 0; i < maxConnectRetries; i++ {
+		var nbdPath string
+
+		// Hold the lock across selection and connection so a concurrent caller
+		// can't grab the same device between the check and qemu-nbd -c.
+		nbdLock.Lock()
+
 		nbdPath, err = GetDevice()
-		if err != ErrNoDeviceAvailable {
-			break
+		if err != nil {
+			nbdLock.Unlock()
+
+			if err != ErrNoDeviceAvailable {
+				return "", err
+			}
+
+			log.Debug("all nbds in use, sleeping before retrying")
+			time.Sleep(time.Second * 10)
+
+			continue
 		}
 
-		log.Debug("all nbds in use, sleeping before retrying")
-		time.Sleep(time.Second * 10)
+		log.Debug("connect nbd: %v -> %v", image, nbdPath)
+
+		out, cerr := processWrapper("qemu-nbd", "-c", nbdPath, image)
+
+		nbdLock.Unlock()
+
+		if cerr == nil {
+			return nbdPath, nil
+		}
+
+		// The device was likely claimed since the check; try the next one.
+		err = fmt.Errorf("unable to connect to nbd: %v", out)
+		log.Debug("nbd connect failed, retrying: %v", err)
 	}
 
-	if err != nil {
-		return "", err
-	}
-
-	log.Debug("connect nbd: %v -> %v", image, nbdPath)
-
-	// connect it to qemu-nbd
-	out, err := processWrapper("qemu-nbd", "-c", nbdPath, image)
-	if err != nil {
-		return "", fmt.Errorf("unable to connect to nbd: %v", out)
-	}
-
-	return nbdPath, nil
+	return "", err
 }
 
 // DisconnectDevice disconnects a given NBD using qemu-nbd.


### PR DESCRIPTION
## Description ##
Serialize NBD device selection and connection behind a package mutex held across `GetDevice` and `qemu-nbd -c`, and retry the next device if the connect fails.

## Motivation and context ##
`GetDevice` reports a device as free, but `ConnectImage` only connects it afterwards, with nothing reserving it in between. Two concurrent disk operations can therefore select the same device and one `qemu-nbd -c` fails. Holding the lock through the connect (the point at which the device gains a pid/lock file) closes that window; retrying on failure also covers a lost race against an external user.

## Testing ##
Tested in the same heavy-use scenario where write contention was encountered - no issue.

## Checklist ##
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [X] I have included no proprietary/sensitive information in my code.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [X] I have tested my code using the methods described above.
- [X] All GitHub Actions are passing.

## Additional Notes ##
N/A
