### PR TITLE
fix(namespace): guard nil active namespace

### DIFF
--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -913,10 +913,17 @@ func GetNamespace() *Namespace {
 	namespaceLock.Lock()
 	defer namespaceLock.Unlock()
 
-	_, ok := namespaces[namespace]
-	if namespace == DefaultNamespace && !ok {
-		// recreate automatically
-		namespaces[namespace] = NewNamespace(namespace)
+	// If the active namespace no longer exists, fall back to the default
+	// rather than returning nil, which callers dereference.
+	if _, ok := namespaces[namespace]; !ok {
+		if namespace != DefaultNamespace {
+			log.Warn("active namespace %v no longer exists, reverting to %v", namespace, DefaultNamespace)
+			namespace = DefaultNamespace
+		}
+
+		if _, ok := namespaces[DefaultNamespace]; !ok {
+			namespaces[DefaultNamespace] = NewNamespace(DefaultNamespace)
+		}
 	}
 
 	return namespaces[namespace]


### PR DESCRIPTION
## Description ##
When the active namespace is missing, `GetNamespace` now falls back to the default namespace (recreating it if needed) instead of returning `nil`. This is a band aid to avoid panics. 

## Motivation and context ##
Previously a panic occurred when a namespace didn't exist: 
```log
2027/08/31 23:59:59 WARN namespace.go:969: unexpected namespace, `minimega` != `experimenty`, when reverting to `experimentx`
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x85071e]

  goroutine 13466 [running]:
  main.cliNamespace(0xc000cdeae0, 0x0?)
          /minimega/cmd/minimega/namespace_cli.go:163 +0x13e
  github.com/sandia-minimega/minimega/v2/pkg/minicli.ProcessCommand.func1()
          /minimega/pkg/minicli/minicli.go:173 +0x196
  created by github.com/sandia-minimega/minimega/v2/pkg/minicli.ProcessCommand
          /minimega/pkg/minicli/minicli.go:160 +0xca
```

## Testing ##
I tested this with many concurrent phenix experiments (where I originally encountered this issue) and did not see any issues.

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
Unsure if I like this fix as it could lead to unexpected behavior. The real issue is how we got to this situation, but I'm not sure if the default namespace is better than a panic.
