### PR TITLE
fix(ufs): only log unexpected accept errors

### DIFF
--- a/internal/ron/ufs.go
+++ b/internal/ron/ufs.go
@@ -51,7 +51,12 @@ func (s *Server) ListenUFS(uuid string) (int, error) {
 		for {
 			conn, err := l.Accept()
 			if err != nil {
-				log.Error("accept failed: %v", err)
+				// the listener is closed by DisconnectUFS during teardown
+				if errors.Is(err, net.ErrClosed) {
+					log.Debug("ufs listener closed")
+				} else {
+					log.Error("accept failed: %v", err)
+				}
 
 				c.Lock()
 				defer c.Unlock()


### PR DESCRIPTION
## Description ##
In the UFS listener's accept loop, log the expected listener-closed case (`net.ErrClosed`) at debug and reserve error for unexpected failures.

## Motivation and context ##
Noisy / misleading logs.

## Testing ##
Tested in several large phenix experiments.

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- ~I have made corresponding changes to the documentation.~
- [X] I have tested my code using the methods described above.
- [X] All GitHub Actions are passing.

## Additional Notes ##
N/A
