### PR TITLE
fix: resolve RPM build failure and update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build Binaries
-on: 
+on:
   push:
   workflow_call:
   release:
@@ -11,7 +11,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             path: minimega
         - name: Build
@@ -25,13 +25,13 @@ jobs:
           if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
           run: tar -czvf minimega-$( cat minimega/VERSION | cut -d'=' -f2 )-binaries.tar.gz minimega
         - name: Upload artifact
-          uses: actions/upload-artifact@v4.0.0
+          uses: actions/upload-artifact@v7.0.1
           if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
           with:
             name: minimega-binaries
             path: ./*.tar.gz
         - name: Upload python package
-          uses: actions/upload-artifact@v4.0.0
+          uses: actions/upload-artifact@v7.0.1
           if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
           with:
             name: minimega-python-dist

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,5 +1,5 @@
 name: DEB Build
-on: 
+on:
   push:
   workflow_call:
 
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
       run: |
@@ -17,11 +17,10 @@ jobs:
     - name: Build Deb package
       id: deb
       run: |
-        chmod +x ./packaging/debian/build.bash
         ./packaging/debian/build.bash
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.0.0
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: minimega-deb
         path: ./*.deb

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: binary-build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/download-artifact@v5
       with:
         name: minimega-python-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: minimega
       - name: Get Version

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,5 +1,5 @@
 name: RPM Build
-on: 
+on:
   push:
   workflow_call:
 
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
       run: |
@@ -17,11 +17,10 @@ jobs:
     - name: Build RPM package
       id: rpm
       run: |
-        chmod +x ./packaging/rpm/build.bash
         ./packaging/rpm/build.bash
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.0.0
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: minimega-rpm
         path: ./packaging/rpm/rpmbuild/RPMS/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,14 +10,18 @@ doc/content/articles/minirouter_api.article
 lib/dist
 lib/MANIFEST
 lib/minimega.py
+lib/minimega.egg-info/
 tests/*.got
 tests/*/*.got
 .DS_Store*
+
+# Debian and RPM packaging temp files
 *.deb
 *.changes
 *.buildinfo
 *.ddeb
 *.rpm
+/minimega.service
 packaging/debian/.debhelper/
 packaging/debian/debhelper-build-stamp
 packaging/debian/files
@@ -33,4 +37,3 @@ packaging/debian/minimega/DEBIAN/postrm
 packaging/debian/minimega/DEBIAN/prerm
 packaging/debian/tmp/
 packaging/debian/minimega/
-lib/minimega.egg-info/

--- a/LICENSES/LICENSE.pty
+++ b/LICENSES/LICENSE.pty
@@ -1,1 +1,1 @@
-../vendor/github.com/kr/pty/License
+../vendor/github.com/kr/pty/LICENSE

--- a/packaging/rpm/build.bash
+++ b/packaging/rpm/build.bash
@@ -3,7 +3,6 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 MM=$SCRIPT_DIR/../..
-FILES=$SCRIPT_DIR/minmega
 
 # substitute version for control file
 source $MM/VERSION

--- a/packaging/rpm/rpmbuild/SPECS/minimega.spec.base
+++ b/packaging/rpm/rpmbuild/SPECS/minimega.spec.base
@@ -41,11 +41,11 @@ and can scale to run on massive clusters with virtually no setup.
 **Note:** This package requires the EPEL repository to be enabled, as it depends on the `ntfs-3g` package, which is only available in EPEL.
 
 %build
-MM="../../../../"
+MM="../../../.."
 (cd $MM && ./scripts/build.bash && ./scripts/doc.bash)
 
 %install
-MM="../../../../"
+MM="../../../.."
 
 rm -rf $RPM_BUILD_ROOT
 rm -rf %{_rpmdir}/*


### PR DESCRIPTION
# fix: resolve RPM build failure and update GitHub Actions

## Description

Update the symlink to resolve an RPM build failure. Additionally, upgrade GitHub Action versions and a few minor cleanups.

Failure: https://github.com/sandia-minimega/minimega/actions/runs/27234365045/job/80422382009

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
~~- [ ] I have made corresponding changes to the documentation.~~
- [x] I have tested my code using the methods described above.
- [ ] All GitHub Actions are passing.

