### PR TITLE
feat(cc): add send-to destination for file transfers

### DIFF
--- a/cmd/miniccc/commands.go
+++ b/cmd/miniccc/commands.go
@@ -28,7 +28,7 @@ func processCommand(cmd *ron.Command) {
 
 	// get any files needed for the command
 	if len(cmd.FilesSend) != 0 {
-		recvFiles(cmd.FilesSend)
+		recvFiles(cmd.FilesSend, cmd.FilesSendDir)
 	}
 
 	// kill processes before starting new ones

--- a/cmd/miniccc/files.go
+++ b/cmd/miniccc/files.go
@@ -43,14 +43,24 @@ func sendFile(ID int, filename string) error {
 
 // recvFiles retrieves a list of files from the ron server by requesting each
 // one individually.
-func recvFiles(files []string) {
+func recvFiles(files []string, destination string) {
 	start := time.Now()
 	var size int64
+	destDir := filepath.Join(*f_path, "files")
+
+	if destination != "" {
+		if filepath.IsAbs(destination) {
+			destDir = destination
+		} else {
+			destDir = filepath.Join(destDir, destination)
+		}
+	}
+	destDir = filepath.Clean(destDir)
 
 	for _, v := range files {
 		log.Info("requesting file %v", v)
 
-		dst := filepath.Join(*f_path, "files", v)
+		dst := filepath.Join(destDir, v)
 
 		if _, err := os.Stat(dst); err == nil {
 			// file exists (TODO: overwrite?)

--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -44,6 +44,11 @@ send a file 'foo' and display the contents on a remote VM:
 	cc send foo
 	cc exec cat foo
 
+You can override the default destination directory on clients when sending
+files:
+
+	cc send-to /opt/myfiles foo
+
 Files to be sent must be in the filepath directory, as set by the -filepath
 flag when launching minimega.
 
@@ -130,6 +135,7 @@ For more documentation, see the article "Command and Control API Tutorial".`,
 			"cc <prefix,> [prefix]",
 
 			"cc <send,> <file>...",
+			"cc <send-to,> <destination> <file>...",
 			"cc <recv,> <file>...",
 			"cc <exec,> <command>...",
 			"cc <exec-once,> <command>...",
@@ -212,6 +218,7 @@ var ccCliSubHandlers = map[string]wrappedCLIFunc{
 	"exitcode":        cliCCExitCode,
 	"rtunnel":         cliCCTunnel,
 	"send":            cliCCFileSend,
+	"send-to":         cliCCFileSendTo,
 	"tunnel":          cliCCTunnel,
 	"listen":          cliCCListen,
 	"test-conn":       cliCCTestConn,
@@ -510,7 +517,19 @@ func cliCCFilter(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 
 // send
 func cliCCFileSend(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	return cliCCFileSendWithDestination(ns, c, resp, "")
+}
+
+// send-to
+func cliCCFileSendTo(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	return cliCCFileSendWithDestination(ns, c, resp, c.StringArgs["destination"])
+}
+
+func cliCCFileSendWithDestination(ns *Namespace, c *minicli.Command, resp *minicli.Response, destination string) error {
 	files := make([]string, len(c.ListArgs["file"]))
+	if destination != "" {
+		destination = filepath.Clean(destination)
+	}
 
 	// Ensure each file to be sent to the VM is present locally before sending.
 	for i, file := range c.ListArgs["file"] {
@@ -550,6 +569,7 @@ func cliCCFileSend(ns *Namespace, c *minicli.Command, resp *minicli.Response) er
 	if err != nil {
 		return err
 	}
+	cmd.FilesSendDir = destination
 
 	resp.Data = ns.NewCommand(cmd)
 	return nil

--- a/doc/content/articles/tutorials/cc.article
+++ b/doc/content/articles/tutorials/cc.article
@@ -159,6 +159,11 @@ We can also send globs (wildcard) of files, using the * operator. For example:
 Files will appear in the `files` subdirectory in the client's base directory.
 By default, this is `/tmp/miniccc/files`.
 
+If you need the files somewhere else on the client, specify a destination
+directory explicitly:
+
+	minimega$ cc send-to /opt/myfiles foo.bash
+
 At this point we can both send and execute a file on the client. Let's execute
 the script we sent a moment ago:
 

--- a/internal/ron/command.go
+++ b/internal/ron/command.go
@@ -35,6 +35,9 @@ type Command struct {
 	// Files to transfer to the client. Any path given in a file specified
 	// here will be rooted at <BASE>/files
 	FilesSend []string
+	// Optional destination directory for FilesSend on the client. If empty,
+	// clients use their default files directory.
+	FilesSendDir string
 
 	// Files to transfer back to the master
 	FilesRecv []string
@@ -148,6 +151,7 @@ func (c *Command) Copy() *Command {
 	c2.CheckedIn = append(c2.CheckedIn, c.CheckedIn...)
 
 	c2.FilesSend = append(c2.FilesSend, c.FilesSend...)
+	c2.FilesSendDir = c.FilesSendDir
 	c2.FilesRecv = append(c2.FilesRecv, c.FilesRecv...)
 
 	if c.Filter != nil {


### PR DESCRIPTION
## Summary

Adds a new `cc send-to` command to the minimega CLI that enables operators to specify a destination directory on miniccc clients when sending files.

## What changed

- **ron Command type**: Added `FilesSendDir` field to specify optional destination directory for file transfers
- **miniccc client**: Updated `recvFiles()` to resolve destination paths (supports both absolute and relative paths)
- **minimega CLI**: Introduced new `cc send-to <dest> <file>...` command and refactored file send logic into `cliCCFileSendWithDestination()`
- **Documentation**: Updated cc.article tutorial with send-to usage example

## Design notes

- Relative destination paths are resolved under the client's default files directory (`/tmp/miniccc/files` by default)
- Absolute paths are used as-is, allowing operators to send files to arbitrary locations on clients
- Empty destination string maintains backward compatibility with existing `cc send` behavior

## Reviewer notes

- All changes are backward compatible
- Command and Control (cc) API surface expanded with new CLI subcommand
- Ready for integration testing