### PR TITLE
feat: Allow the `gobuilder` image to be specified via build argument

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,10 @@
-# To specify an alternate base image: --build-arg BASE_IMAGE="some/other/image:tag"
+# To specify an alternate base image: --build-arg BASE_IMAGE="some/other/base_image:tag"
+# To specify an alternate Go image: --build-arg GO_IMAGE="some/other/go_image:tag"
 ARG BASE_IMAGE="ubuntu:22.04"
+ARG GO_IMAGE="golang:1.24.13"
 
 # -- go builder --
-FROM golang:1.24.13 AS gobuilder
+FROM ${GO_IMAGE} AS gobuilder
 
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get install -y libpcap-dev


### PR DESCRIPTION
## Description ##
Adds a configurable `GO_IMAGE` build argument for the Go builder image, defaulting to `golang:1.24.13`.

## Motivation and context ##
This change allows the Go builder image to be overridden at build time without modifying the Dockerfile, while preserving the existing default behavior.

## Testing ##
Verified the Dockerfile still uses `golang:1.24.13` by default. The image can be overridden with:

```sh
docker build --build-arg GO_IMAGE=<custom-go-image> .
```

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [ ] All GitHub Actions are passing.