### PR TITLE
feat(vm): add native Android VM launch and lifecycle support

### DIFF
--- a/cmd/minimega/android.go
+++ b/cmd/minimega/android.go
@@ -1,0 +1,652 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sandia-minimega/minimega/v2/internal/bridge"
+	"github.com/sandia-minimega/minimega/v2/internal/qmp"
+	"github.com/sandia-minimega/minimega/v2/internal/ron"
+	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
+)
+
+const (
+	MinAndroidConsolePort = 5554
+
+	// Highest console port minimega will use as the base of a console/ADB pair.
+	// The ADB port is console+1. The default Android emulator range is 5554 to 5682
+	// allowing for 64 concurrent virtual devices per host as detailed in:
+	// https://developer.android.com/studio/run/emulator-commandline
+	MaxAndroidConsolePort = 5680
+	MaxAndroidVMsPerHost  = (MaxAndroidConsolePort-MinAndroidConsolePort)/2 + 1
+)
+
+type AndroidVM struct {
+	*BaseVM       // embed
+	KVMConfig     // embed; reused for backend QEMU argument construction
+	AndroidConfig // embed
+
+	ConsolePort int
+	ADBPort     int
+
+	serial string
+	cmd    *exec.Cmd
+	q      qmp.Conn
+}
+
+// Ensure that AndroidVM implements the VM interface.
+var _ VM = (*AndroidVM)(nil)
+
+var (
+	androidPortMu       sync.Mutex
+	androidReservedPort = map[int]bool{}
+)
+
+func NewAndroid(name, namespace string, config VMConfig) (*AndroidVM, error) {
+	vm := new(AndroidVM)
+
+	vm.BaseVM = NewBaseVM(name, namespace, config)
+	vm.Type = ANDROID
+
+	vm.KVMConfig = config.KVMConfig.Copy()
+	vm.AndroidConfig = config.AndroidConfig.Copy()
+
+	if vm.AVDName == "" {
+		return nil, errors.New("unable to create android VM without a configured android-avd")
+	}
+
+	return vm, nil
+}
+
+func (vm *AndroidVM) Config() *BaseConfig {
+	return &vm.BaseConfig
+}
+
+func (vm *AndroidVM) Copy() VM {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	vm2 := new(AndroidVM)
+
+	// Make shallow copies of all fields.
+	*vm2 = *vm
+
+	// Make deep copies.
+	vm2.BaseVM = vm.BaseVM.copy()
+	vm2.KVMConfig = vm.KVMConfig.Copy()
+	vm2.AndroidConfig = vm.AndroidConfig.Copy()
+
+	return vm2
+}
+
+func (vm *AndroidVM) Launch() error {
+	defer vm.lock.Unlock()
+
+	return vm.launch()
+}
+
+// setRecoverableErrorf records an Android runtime error without changing the VM
+// state. This is used for errors where the emulator process may still be alive,
+// so the VM should remain in a killable state.
+func (vm *AndroidVM) setRecoverableErrorf(format string, args ...interface{}) error {
+	err := fmt.Errorf(format, args...)
+
+	log.Error("android vm %v: %v", vm.ID, err)
+	vm.Tags["error"] = err.Error()
+
+	return err
+}
+
+func (vm *AndroidVM) Recover(id string, pid int) error {
+	// Full Android recovery is intentionally deferred.
+	vm.ID, _ = strconv.Atoi(id)
+	vm.Pid = pid
+	vm.instancePath = filepath.Join(*f_base, id)
+
+	vm.lock.Unlock()
+	return nil
+}
+
+func (vm *AndroidVM) Start() error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	if vm.State&VM_RUNNING != 0 {
+		return nil
+	}
+
+	if vm.State == VM_QUIT || vm.State == VM_ERROR {
+		log.Info("relaunching android VM: %v", vm.ID)
+
+		vm.kill = make(chan bool)
+
+		if err := vm.launch(); err != nil {
+			return err
+		}
+	}
+
+	log.Info("starting android VM: %v", vm.ID)
+
+	if err := vm.q.Start(); err != nil {
+		return vm.setRecoverableErrorf("unable to start android VM: %v", err)
+	}
+
+	vm.setState(VM_RUNNING)
+
+	return nil
+}
+
+func (vm *AndroidVM) Stop() error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	if vm.State != VM_RUNNING {
+		return vmNotRunning(strconv.Itoa(vm.ID))
+	}
+
+	log.Info("stopping android VM: %v", vm.ID)
+
+	if err := vm.q.Stop(); err != nil {
+		return vm.setRecoverableErrorf("unable to stop android VM: %v", err)
+	}
+
+	vm.setState(VM_PAUSED)
+
+	return nil
+}
+
+func (vm *AndroidVM) Flush() error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	for _, net := range vm.Networks {
+		// Android networking is currently unsupported, so Android VMs may have
+		// configured networks without created taps. Nothing to clean up.
+		if net.Tap == "" {
+			continue
+		}
+
+		// Handle already disconnected taps differently since they are not
+		// assigned to any bridges.
+		if net.VLAN == DisconnectedVLAN {
+			if err := bridge.DestroyTap(net.Tap); err != nil {
+				log.Error("leaked tap %v: %v", net.Tap, err)
+			}
+
+			continue
+		}
+
+		br, err := getBridge(net.Bridge)
+		if err != nil {
+			return err
+		}
+
+		if err := br.DestroyTap(net.Tap); err != nil {
+			log.Error("leaked tap %v: %v", net.Tap, err)
+		}
+	}
+
+	return vm.BaseVM.Flush()
+}
+
+func (vm *AndroidVM) String() string {
+	return fmt.Sprintf("%s:%d:android", hostname, vm.ID)
+}
+
+func (vm *AndroidVM) Info(field string) (string, error) {
+	// Let BaseVM answer generic fields first.
+	if v, err := vm.BaseVM.Info(field); err == nil {
+		return v, nil
+	}
+
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	switch field {
+	case "android_avd":
+		return vm.AVDName, nil
+	case "android_console_port":
+		return strconv.Itoa(vm.ConsolePort), nil
+	case "android_adb_port":
+		return strconv.Itoa(vm.ADBPort), nil
+	case "android_serial":
+		return vm.serial, nil
+	case "pid":
+		return strconv.Itoa(vm.Pid), nil
+	}
+
+	// Prefer Android-specific config fields, then fall back to KVM config fields.
+	if v, err := vm.AndroidConfig.Info(field); err == nil {
+		return v, nil
+	}
+
+	return vm.KVMConfig.Info(field)
+}
+
+func (vm *AndroidVM) Conflicts(vm2 VM) error {
+	switch vm2 := vm2.(type) {
+	case *AndroidVM:
+		return vm.conflictsAndroid(vm2)
+	case *KvmVM:
+		vm.lock.Lock()
+		defer vm.lock.Unlock()
+
+		if err := vm.conflictsKVMDisks(vm2.KVMConfig.Disks, vm2.Snapshot); err != nil {
+			return err
+		}
+		return vm.BaseVM.conflicts(vm2.BaseVM)
+	case *ContainerVM:
+		return vm.BaseVM.conflicts(vm2.BaseVM)
+	}
+
+	return errors.New("unknown VM type")
+}
+
+func (vm *AndroidVM) conflictsAndroid(vm2 *AndroidVM) error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	if err := vm.conflictsKVMDisks(vm2.KVMConfig.Disks, vm2.Snapshot); err != nil {
+		return err
+	}
+
+	return vm.BaseVM.conflicts(vm2.BaseVM)
+}
+
+func (vm *AndroidVM) conflictsKVMDisks(disks DiskConfigs, snapshot bool) error {
+	for _, d := range vm.Disks {
+		for _, d2 := range disks {
+			if d.Path == d2.Path && (!vm.Snapshot || !snapshot) {
+				return fmt.Errorf("disk conflict with android vm %v: %v", vm.Name, d)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (vm *AndroidVM) Screenshot(size int) ([]byte, error) {
+	return nil, errors.New("cannot take screenshot of android VM yet")
+}
+
+func (vm *AndroidVM) Connect(cc *ron.Server, reconnect bool) error {
+	// Android guest-agent/backchannel support is intentionally deferred.
+	return nil
+}
+
+func (vm *AndroidVM) Disconnect(cc *ron.Server) error {
+	// Android guest-agent/backchannel support is intentionally deferred.
+	return nil
+}
+
+func (vm *AndroidVM) ProcStats() (map[int]*ProcStats, error) {
+	if vm.Pid <= 0 {
+		return nil, errors.New("android VM has no PID")
+	}
+
+	p, err := GetProcStats(vm.Pid)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[int]*ProcStats{vm.Pid: p}, nil
+}
+
+func (vm *AndroidVM) WriteConfig(w io.Writer) error {
+	if err := vm.BaseConfig.WriteConfig(w); err != nil {
+		return err
+	}
+
+	if err := vm.KVMConfig.WriteConfig(w); err != nil {
+		return err
+	}
+
+	return vm.AndroidConfig.WriteConfig(w)
+}
+
+// launch is the low-level Android launch function.
+// Caller must hold vm.lock.
+func (vm *AndroidVM) launch() error {
+	log.Info("launching android vm: %v", vm.ID)
+
+	if vm.State == VM_BUILDING {
+		if err := os.MkdirAll(vm.instancePath, os.FileMode(0700)); err != nil {
+			return fmt.Errorf("unable to create VM dir: %v", err)
+		}
+
+		if err := vm.createInstancePathAlias(); err != nil {
+			return vm.setErrorf("createInstancePathAlias: %v", err)
+		}
+	}
+
+	mustWrite(vm.path("name"), vm.Name)
+
+	// From this point forward, vm.setErrorf() is safe because the instance
+	// directory exists and the state file can be written.
+	if err := validateAndroidLaunchConfig(vm.AndroidConfig); err != nil {
+		return vm.setErrorf("android config invalid: %v", err)
+	}
+
+	emulator, err := findAndroidTool(vm.EmulatorPath, "emulator")
+	if err != nil {
+		return vm.setErrorf("android emulator not found: %v", err)
+	}
+
+	// adb is not strictly required to exec the emulator, but validating it here
+	// catches common broken Android runtime configurations early.
+	if _, err := findAndroidTool(vm.ADBPath, "adb"); err != nil {
+		return vm.setErrorf("android adb not found: %v", err)
+	}
+
+	// Android emulator tap/network support is deferred. Avoid creating taps
+	// and then failing later with obscure /dev/net/tun errors.
+	if len(vm.Networks) > 0 || len(vm.Bonds) > 0 {
+		return vm.setErrorf("android VM networking is not supported yet")
+	}
+
+	if vm.State == VM_BUILDING {
+		// Android reuses KVMConfig/qemuArgs for backend QEMU arguments, so apply
+		// the same disk snapshot behavior as KVM VMs.
+		if vm.Snapshot {
+			for i, d := range vm.Disks {
+				dst := vm.path(fmt.Sprintf("disk-%v.qcow2", i))
+				if err := diskSnapshot(d.Path, dst); err != nil {
+					return vm.setErrorf("unable to snapshot %v: %v", d, err)
+				}
+
+				vm.Disks[i].SnapshotPath = dst
+			}
+		}
+	}
+
+	console, adb, err := reserveAndroidPortPair(vm.ConsoleBasePort)
+	if err != nil {
+		return vm.setErrorf("unable to reserve android console/adb port pair: %v", err)
+	}
+
+	vm.ConsolePort = console
+	vm.ADBPort = adb
+	vm.serial = fmt.Sprintf("emulator-%d", console)
+
+	logFilePath := vm.path("android-emulator.log")
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		releaseAndroidPortPair(console)
+		return vm.setErrorf("unable to open android emulator log: %v", err)
+	}
+
+	args := vm.emulatorArgs(logFilePath)
+	log.Debug("android emulator args for vm %v: %#v", vm.ID, args)
+
+	cmd := &exec.Cmd{
+		Path:   emulator,
+		Args:   append([]string{emulator}, args...),
+		Env:    vm.androidEnv(),
+		Stdout: logFile,
+		Stderr: logFile,
+	}
+
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		releaseAndroidPortPair(console)
+		return vm.setErrorf("unable to start android emulator: %v", err)
+	}
+
+	vm.cmd = cmd
+	vm.Pid = cmd.Process.Pid
+
+	log.Info("android vm %v has pid %v", vm.ID, vm.Pid)
+
+	waitChan := vm.waitForExit(cmd, logFile, console)
+
+	if err := vm.connectQMP(); err != nil {
+		cmd.Process.Kill()
+		return vm.setErrorf("unable to connect to android QMP socket: %v", err)
+	}
+
+	go vm.qmpLogger()
+
+	vm.waitToKill(cmd, waitChan)
+
+	return nil
+}
+
+func (vm *AndroidVM) emulatorArgs(logFilePath string) []string {
+	args := []string{
+		"-avd", vm.AVDName,
+		"-port", strconv.Itoa(vm.ConsolePort),
+		"-stdouterr-file", logFilePath,
+	}
+
+	if vm.NoWindow {
+		args = append(args, "-no-window")
+	}
+
+	if vm.WritableSystem {
+		args = append(args, "-writable-system")
+	}
+
+	args = append(args, vm.ExtraArgs...)
+
+	qemuArgs := vm.androidQEMUArgs()
+	if len(qemuArgs) > 0 {
+		args = append(args, "-qemu")
+		args = append(args, qemuArgs...)
+	}
+
+	return args
+}
+
+func (vm *AndroidVM) androidQEMUArgs() []string {
+	vmConfig := VMConfig{
+		BaseConfig:    vm.BaseConfig,
+		KVMConfig:     vm.KVMConfig,
+		AndroidConfig: vm.AndroidConfig,
+	}
+
+	args := vmConfig.qemuArgs(vm.ID, vm.instancePath)
+	args = vmConfig.applyQemuOverrides(args)
+
+	return filterAndroidQEMUArgs(args)
+}
+
+// filterAndroidQEMUArgs implements important argument filtering.
+// These are QEMU args generated by minimega that should not be
+// passed to the Android emulator backend through QEMU.
+func filterAndroidQEMUArgs(args []string) []string {
+	argsWithValuesToRemove := map[string]bool{
+		"-vnc": true,
+		"-vga": true,
+	}
+
+	var res []string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if argsWithValuesToRemove[arg] {
+			// Skip this arg and its value, if present.
+			if i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+
+		res = append(res, arg)
+	}
+
+	return res
+}
+
+func (vm *AndroidVM) androidEnv() []string {
+	env := os.Environ()
+
+	if vm.SDKPath != "" {
+		env = append(env, "ANDROID_SDK_ROOT="+vm.SDKPath)
+		env = append(env, "ANDROID_HOME="+vm.SDKPath)
+
+		paths := []string{
+			filepath.Join(vm.SDKPath, "emulator", "lib"),
+			filepath.Join(vm.SDKPath, "emulator", "lib64"),
+			filepath.Join(vm.SDKPath, "emulator", "lib64", "qt", "lib"),
+		}
+
+		if existing := os.Getenv("LD_LIBRARY_PATH"); existing != "" {
+			paths = append([]string{existing}, paths...)
+		}
+
+		env = append(env, "LD_LIBRARY_PATH="+strings.Join(paths, string(os.PathListSeparator)))
+	}
+
+	if vm.AVDDir != "" {
+		env = append(env, "ANDROID_AVD_HOME="+vm.AVDDir)
+	}
+
+	return env
+}
+
+func (vm *AndroidVM) connectQMP() (err error) {
+	delay := QMP_CONNECT_DELAY * time.Millisecond
+
+	for count := 0; count < QMP_CONNECT_RETRY; count++ {
+		vm.q, err = qmp.Dial(vm.path("qmp"))
+		if err == nil {
+			log.Debug("android qmp dial to %v successful", vm.ID)
+			return nil
+		}
+
+		log.Debug("android qmp dial to %v: %v, redialing in %v", vm.ID, err, delay)
+		time.Sleep(delay)
+	}
+
+	return errors.New("android qmp timeout")
+}
+
+func (vm *AndroidVM) waitForExit(cmd *exec.Cmd, logFile *os.File, consolePort int) chan struct{} {
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		defer logFile.Close()
+		defer releaseAndroidPortPair(consolePort)
+
+		err := cmd.Wait()
+
+		vm.lock.Lock()
+		defer vm.lock.Unlock()
+
+		// Check if the process quit for some reason other than being killed.
+		if err != nil && err.Error() != "signal: killed" {
+			vm.setErrorf("android emulator exited: %v", err)
+		} else if vm.State != VM_ERROR {
+			vm.setState(VM_QUIT)
+		}
+	}()
+
+	return done
+}
+
+func (vm *AndroidVM) waitToKill(cmd *exec.Cmd, done chan struct{}) {
+	go func() {
+		defer vm.cond.Signal()
+
+		select {
+		case <-done:
+			log.Info("android VM %v exited", vm.ID)
+		case <-vm.kill:
+			log.Info("killing android VM %v", vm.ID)
+
+			if cmd.Process != nil {
+				cmd.Process.Kill()
+			}
+
+			<-done
+		}
+	}()
+}
+
+func (vm *AndroidVM) qmpLogger() {
+	for v := vm.q.Message(); v != nil; v = vm.q.Message() {
+		log.Info("Android VM %v received asynchronous QMP message: %v", vm.ID, v)
+	}
+}
+
+func validateAndroidLaunchConfig(cfg AndroidConfig) error {
+	if cfg.AVDName == "" {
+		return errors.New("android-avd must be configured")
+	}
+
+	return checkAndroidDependencies(cfg)
+}
+
+func reserveAndroidPortPair(base uint64) (int, int, error) {
+	if err := validateAndroidConsoleBasePortValue(base); err != nil {
+		return 0, 0, err
+	}
+
+	start := MinAndroidConsolePort
+	if base != 0 {
+		start = int(base)
+	}
+
+	androidPortMu.Lock()
+	defer androidPortMu.Unlock()
+
+	for console := start; console <= MaxAndroidConsolePort; console += 2 {
+		adb := console + 1
+
+		if androidReservedPort[console] || androidReservedPort[adb] {
+			continue
+		}
+
+		if !tcpPortPairAvailable(console, adb) {
+			continue
+		}
+
+		androidReservedPort[console] = true
+		androidReservedPort[adb] = true
+
+		return console, adb, nil
+	}
+
+	return 0, 0, fmt.Errorf(
+		"no available android console/adb port pair in range %d-%d; "+
+			"each minimega host supports at most %d concurrent Android emulator VMs",
+		start,
+		MaxAndroidConsolePort+1,
+		MaxAndroidVMsPerHost,
+	)
+}
+
+func releaseAndroidPortPair(console int) {
+	androidPortMu.Lock()
+	defer androidPortMu.Unlock()
+
+	delete(androidReservedPort, console)
+	delete(androidReservedPort, console+1)
+}
+
+func tcpPortPairAvailable(console, adb int) bool {
+	consoleListener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", console))
+	if err != nil {
+		return false
+	}
+	defer consoleListener.Close()
+
+	adbListener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", adb))
+	if err != nil {
+		return false
+	}
+	defer adbListener.Close()
+
+	return true
+}

--- a/cmd/minimega/android_support.go
+++ b/cmd/minimega/android_support.go
@@ -43,10 +43,27 @@ type AndroidConfig struct {
 	// Default: true
 	NoWindow bool `config:"android-no-window"`
 
-	// Configure the base console port for Android emulator instances.
+	// Configure the preferred starting console port for Android emulator instances.
+	//
+	// This value is a hint, not a guaranteed assignment. minimega searches for the
+	// first available Android console/ADB port pair starting at this port. If the
+	// requested pair is already reserved or unavailable, the next valid pair is
+	// used.
+	//
+	// If set to 0, minimega starts searching at the beginning of the valid Android
+	// emulator console port range. Console ports are even ports in the range
+	// 5554-5680, and the corresponding ADB port is console+1.
+	//
+	// If nonzero, this value must be an even port in the valid console port range.
+	// Starting later in the range reduces the number of candidate port pairs.
+	//
+	// The valid range contains 64 console/ADB port pairs, so a single minimega
+	// host can run at most 64 Android emulator VMs concurrently, and fewer if some
+	// ports in the range are already in use. In a multi-host namespace, this limit
+	// applies independently to each host.
 	//
 	// Default: 0
-	ConsoleBasePort uint64 `config:"android-console-base-port"`
+	ConsoleBasePort uint64 `config:"android-console-base-port" validate:"validateAndroidConsoleBasePort"`
 
 	// Additional raw arguments to append to the Android emulator command line.
 	ExtraArgs []string `config:"android-extra-args"`
@@ -103,12 +120,32 @@ func findAndroidTool(path, name string) (string, error) {
 	return exec.LookPath(name)
 }
 
-func validateAndroidConfig(cfg AndroidConfig) error {
-	if cfg.ConsoleBasePort < 1024 {
-		return fmt.Errorf("android-console-base-port must be >= 1024")
+func validateAndroidConsoleBasePortValue(port uint64) error {
+	if port == 0 {
+		return nil
+	}
+
+	if port%2 != 0 {
+		return fmt.Errorf("android-console-base-port must be 0 or an even port")
+	}
+
+	if port < MinAndroidConsolePort || port > MaxAndroidConsolePort {
+		return fmt.Errorf(
+			"android-console-base-port must be 0 or an even port in range %d-%d",
+			MinAndroidConsolePort,
+			MaxAndroidConsolePort,
+		)
 	}
 
 	return nil
+}
+
+func validateAndroidConsoleBasePort(_ VMConfig, port uint64) error {
+	return validateAndroidConsoleBasePortValue(port)
+}
+
+func validateAndroidConfig(cfg AndroidConfig) error {
+	return validateAndroidConsoleBasePortValue(cfg.ConsoleBasePort)
 }
 
 func androidAVDExists(cfg AndroidConfig) error {

--- a/cmd/minimega/container.go
+++ b/cmd/minimega/container.go
@@ -783,6 +783,8 @@ func (vm *ContainerVM) Conflicts(vm2 VM) error {
 		return vm.ConflictsContainer(vm2)
 	case *KvmVM:
 		return vm.BaseVM.conflicts(vm2.BaseVM)
+	case *AndroidVM:
+		return vm.BaseVM.conflicts(vm2.BaseVM)
 	}
 
 	return errors.New("unknown VM type")

--- a/cmd/minimega/kvm.go
+++ b/cmd/minimega/kvm.go
@@ -513,9 +513,26 @@ func (vm *KvmVM) Conflicts(vm2 VM) error {
 		return vm.ConflictsKVM(vm2)
 	case *ContainerVM:
 		return vm.BaseVM.conflicts(vm2.BaseVM)
+	case *AndroidVM:
+		return vm.ConflictsAndroid(vm2)
 	}
 
 	return errors.New("unknown VM type")
+}
+
+func (vm *KvmVM) ConflictsAndroid(vm2 *AndroidVM) error {
+	vm.lock.Lock()
+	defer vm.lock.Unlock()
+
+	for _, d := range vm.Disks {
+		for _, d2 := range vm2.Disks {
+			if d.Path == d2.Path && (!vm.Snapshot || !vm2.Snapshot) {
+				return fmt.Errorf("disk conflict with android vm %v: %v", vm2.Name, d)
+			}
+		}
+	}
+
+	return vm.BaseVM.conflicts(vm2.BaseVM)
 }
 
 // ConflictsKVM tests whether vm and vm2 share a disk and returns an

--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -1083,6 +1083,7 @@ func NewHostStats() *HostStats {
 		h.MemCommit += mem
 		h.NetworkCommit += net
 		h.VMs += ns.VMs.Count()
+		h.AndroidVMs += ns.VMs.CountTypeState(ANDROID, VM_KILLABLE)
 
 		// update if limit is unlimited or we're not unlimited and we're less
 		// than the previous limit

--- a/cmd/minimega/recovery.go
+++ b/cmd/minimega/recovery.go
@@ -59,6 +59,19 @@ func recover() error {
 
 			f.Close()
 
+			// Android recovery is intentionally unsupported for now. Android VMs do not
+			// expose the KVM VNC shim and require Android-specific runtime reconstruction,
+			// so do not treat them as KVM VMs during recovery.
+			if androidConfigured(cfg.AndroidConfig) {
+				log.Warn(
+					"skipping recovery of Android VM %s (ID: %s, PID: %d): Android recovery is not supported",
+					name,
+					vm.VMID,
+					vm.PID,
+				)
+				continue
+			}
+
 			if len(cfg.Networks) > 0 {
 				body, err = ioutil.ReadFile(filepath.Join(*f_base, vm.VMID, "taps"))
 				if err != nil {

--- a/cmd/minimega/scheduler.go
+++ b/cmd/minimega/scheduler.go
@@ -45,8 +45,21 @@ func (s *Scheduler) Schedule() (map[string][]*QueuedVMs, error) {
 
 	if len(s.hosts) == 1 {
 		log.Warn("only one host in namespace, scheduling all VMs on it")
+
+		host := s.hosts[0]
+		androidCount := host.AndroidVMs + androidQueuedVMCount(s.queue)
+
+		if androidCount > MaxAndroidVMsPerHost {
+			return nil, fmt.Errorf(
+				"cannot schedule %d Android VMs on host %s; each host supports at most %d concurrent Android VMs",
+				androidCount,
+				host.Name,
+				MaxAndroidVMsPerHost,
+			)
+		}
+
 		res := map[string][]*QueuedVMs{
-			s.hosts[0].Name: s.queue,
+			host.Name: s.queue,
 		}
 		return res, nil
 	}
@@ -103,12 +116,10 @@ func (s *Scheduler) Schedule() (map[string][]*QueuedVMs, error) {
 		}
 
 		for _, name := range q.Names {
-			// least loaded host is at position zero
-			host := s.hosts[0]
-
-			if v := q.Schedule; v != "" {
-				// find the specified host
-				host = s.findHostStats(v)
+			host, err := s.chooseHost(q, name)
+			if err != nil {
+				s.dumpSchedule()
+				return nil, err
 			}
 
 			if err := s.add(host, name, q); err != nil {
@@ -157,6 +168,138 @@ func (s *Scheduler) findHostStats(host string) *HostStats {
 	return nil
 }
 
+// CanFit enforces host-specific capacity constraints for queued VMs.
+func (h *HostStats) CanFit(q *QueuedVMs) error {
+	if q.VMType == ANDROID {
+		return h.CanFitAndroidSlots(1)
+	}
+
+	return nil
+}
+
+// CanFitAndroidSlots reports whether this host has room for the requested
+// number of additional Android VMs.
+func (h *HostStats) CanFitAndroidSlots(slots int) error {
+	if slots <= 0 {
+		return nil
+	}
+
+	if h.AndroidVMs+slots > MaxAndroidVMsPerHost {
+		return fmt.Errorf(
+			"host %s has insufficient Android VM slots: need %d, %d/%d already assigned",
+			h.Name,
+			slots,
+			h.AndroidVMs,
+			MaxAndroidVMsPerHost,
+		)
+	}
+
+	return nil
+}
+
+// androidSlotsFor returns the number of Android VM slots required to schedule
+// name from q, including any floating VMs recursively colocated with name.
+func (s *Scheduler) androidSlotsFor(q *QueuedVMs, name string) int {
+	seen := map[string]bool{
+		name: true,
+	}
+
+	var slots int
+	if q.VMType == ANDROID {
+		slots++
+	}
+
+	return slots + s.androidSlotsForColocated(name, seen)
+}
+
+func (s *Scheduler) androidSlotsForColocated(anchor string, seen map[string]bool) int {
+	var slots int
+
+	for _, q := range s.colocated[anchor] {
+		for _, name := range q.Names {
+			if seen[name] {
+				continue
+			}
+
+			seen[name] = true
+
+			if q.VMType == ANDROID {
+				slots++
+			}
+
+			slots += s.androidSlotsForColocated(name, seen)
+		}
+	}
+
+	return slots
+}
+
+func (s *Scheduler) chooseHost(q *QueuedVMs, name string) (*HostStats, error) {
+	androidSlots := s.androidSlotsFor(q, name)
+
+	if q.Schedule != "" {
+		host := s.findHostStats(q.Schedule)
+		if host == nil {
+			return nil, fmt.Errorf("VM scheduled on unknown host: `%v`", q.Schedule)
+		}
+
+		if err := host.CanFitAndroidSlots(androidSlots); err != nil {
+			return nil, err
+		}
+
+		return host, nil
+	}
+
+	// Preserve existing behavior for VMs/groups that do not require Android
+	// capacity: use the heap root.
+	if androidSlots == 0 {
+		return s.hosts[0], nil
+	}
+
+	// For groups requiring Android capacity, still prefer the least-loaded host
+	// if it has enough room for the whole colocated group.
+	if err := s.hosts[0].CanFitAndroidSlots(androidSlots); err == nil {
+		return s.hosts[0], nil
+	}
+
+	// The least-loaded host cannot fit the Android portion of this group, so
+	// find the least-loaded host that can.
+	var best *HostStats
+
+	for _, host := range s.hosts {
+		if err := host.CanFitAndroidSlots(androidSlots); err != nil {
+			continue
+		}
+
+		if best == nil || s.hostSortBy(host, best) {
+			best = host
+		}
+	}
+
+	if best == nil {
+		return nil, fmt.Errorf(
+			"no host has available Android VM slots for colocated group requiring %d Android slot(s); "+
+				"each host supports at most %d concurrent Android VMs",
+			androidSlots,
+			MaxAndroidVMsPerHost,
+		)
+	}
+
+	return best, nil
+}
+
+func androidQueuedVMCount(queue []*QueuedVMs) int {
+	var count int
+
+	for _, q := range queue {
+		if q.VMType == ANDROID {
+			count += len(q.Names)
+		}
+	}
+
+	return count
+}
+
 // add a VM to the given host, checking and adjusting limits if necessary
 func (s *Scheduler) add(host *HostStats, name string, q *QueuedVMs) error {
 	limit := int(q.Coschedule)
@@ -176,8 +319,12 @@ func (s *Scheduler) add(host *HostStats, name string, q *QueuedVMs) error {
 		}
 	}
 
+	if err := host.CanFit(q); err != nil {
+		return err
+	}
+
 	// update commit based on this VM's specs
-	host.increment(q.VMConfig)
+	host.increment(q.VMConfig, q.VMType)
 
 	// schedule all floating VMs on this host as well
 	for _, q := range s.colocated[name] {
@@ -313,11 +460,15 @@ func (q *QueuedVMs) Less(q2 *QueuedVMs) bool {
 	return len(q.Names) > len(q2.Names)
 }
 
-func (s *HostStats) increment(config VMConfig) {
+func (s *HostStats) increment(config VMConfig, vmType VMType) {
 	s.VMs += 1
 	s.CPUCommit += config.VCPUs
 	s.MemCommit += config.Memory
 	s.NetworkCommit += len(config.Networks)
+
+	if vmType == ANDROID {
+		s.AndroidVMs += 1
+	}
 }
 
 // cpuCommit tests whether h1 < h2.

--- a/cmd/minimega/scheduler_test.go
+++ b/cmd/minimega/scheduler_test.go
@@ -587,3 +587,486 @@ func BenchmarkSchedule(b *testing.B) {
 		schedule(queue, hosts, cpuCommit)
 	}
 }
+
+func TestScheduleAndroidCapacity(t *testing.T) {
+	var names []string
+	for i := 0; i < MaxAndroidVMsPerHost+1; i++ {
+		names = append(names, strconv.Itoa(i))
+	}
+
+	queue := []*QueuedVMs{
+		{
+			Names:  names,
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(1, true)
+
+	if _, err := schedule(queue, hosts, cpuCommit); err == nil {
+		t.Error("expected scheduler to reject too many Android VMs for one host")
+	}
+}
+
+func TestScheduleAndroidCapacityMultiHost(t *testing.T) {
+	var names []string
+	for i := 0; i < MaxAndroidVMsPerHost*2; i++ {
+		names = append(names, strconv.Itoa(i))
+	}
+
+	queue := []*QueuedVMs{
+		{
+			Names:  names,
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(2, true)
+
+	s, err := schedule(queue, hosts, cpuCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for host, q := range s {
+		var count int
+		for _, queued := range q {
+			count += len(queued.Names)
+		}
+
+		if count > MaxAndroidVMsPerHost {
+			t.Fatalf("host %s scheduled %d Android VMs, limit is %d", host, count, MaxAndroidVMsPerHost)
+		}
+	}
+}
+
+func TestScheduleAndroidCapacityExistingVMs(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"new"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(1, true)
+	hosts[0].AndroidVMs = MaxAndroidVMsPerHost
+
+	if _, err := schedule(queue, hosts, cpuCommit); err == nil {
+		t.Error("expected scheduler to reject Android VM on full Android host")
+	}
+}
+
+func TestScheduleAndroidCapacitySingleHostExact(t *testing.T) {
+	var names []string
+	for i := 0; i < MaxAndroidVMsPerHost; i++ {
+		names = append(names, strconv.Itoa(i))
+	}
+
+	queue := []*QueuedVMs{
+		{
+			Names:  names,
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(1, true)
+
+	if _, err := schedule(queue, hosts, cpuCommit); err != nil {
+		t.Fatalf("expected exactly %d Android VMs to schedule on one host: %v", MaxAndroidVMsPerHost, err)
+	}
+}
+
+func TestScheduleAndroidCapacityExistingVMsExact(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"new"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(1, true)
+	hosts[0].AndroidVMs = MaxAndroidVMsPerHost - 1
+
+	if _, err := schedule(queue, hosts, cpuCommit); err != nil {
+		t.Fatalf("expected Android VM to fit in final slot: %v", err)
+	}
+}
+
+func TestScheduleAndroidSkipsAndroidFullLeastLoadedHost(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"android"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(2, true)
+
+	hosts[0].Name = "0"
+	hosts[0].CPUCommit = 0
+	hosts[0].MemCommit = 0
+	hosts[0].NetworkCommit = 0
+	hosts[0].AndroidVMs = MaxAndroidVMsPerHost
+
+	hosts[1].Name = "1"
+	hosts[1].CPUCommit = 100
+	hosts[1].MemCommit = 100
+	hosts[1].NetworkCommit = 100
+	hosts[1].AndroidVMs = 0
+
+	s, err := schedule(queue, hosts, cpuCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := countScheduledVMs(s["0"]); got != 0 {
+		t.Fatalf("expected no Android VMs scheduled on Android-full least-loaded host 0, got %d; schedule: %#v", got, s)
+	}
+
+	if got := countScheduledVMs(s["1"]); got != 1 {
+		t.Fatalf("expected Android VM scheduled on host 1, got %d; schedule: %#v", got, s)
+	}
+}
+
+func TestScheduleKVMUnaffectedByAndroidCapacity(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"kvm"},
+			VMType: KVM,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(2, true)
+
+	hosts[0].Name = "0"
+	hosts[0].CPUCommit = 0
+	hosts[0].MemCommit = 0
+	hosts[0].NetworkCommit = 0
+	hosts[0].AndroidVMs = MaxAndroidVMsPerHost
+
+	hosts[1].Name = "1"
+	hosts[1].CPUCommit = 100
+	hosts[1].MemCommit = 100
+	hosts[1].NetworkCommit = 100
+	hosts[1].AndroidVMs = 0
+
+	s, err := schedule(queue, hosts, cpuCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := countScheduledVMs(s["0"]); got != 1 {
+		t.Fatalf("expected KVM to schedule on least-loaded host 0 despite Android capacity, got schedule: %#v", s)
+	}
+
+	if got := countScheduledVMs(s["1"]); got != 0 {
+		t.Fatalf("expected no KVMs scheduled on host 1, got %d; schedule: %#v", got, s)
+	}
+}
+
+func countScheduledVMs(queue []*QueuedVMs) int {
+	var count int
+
+	for _, q := range queue {
+		count += len(q.Names)
+	}
+
+	return count
+}
+
+func TestScheduleAndroidPinnedToFullHostFails(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"android"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					Schedule:   "0",
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(2, true)
+	hosts[0].Name = "0"
+	hosts[0].AndroidVMs = MaxAndroidVMsPerHost
+	hosts[1].Name = "1"
+
+	if _, err := schedule(queue, hosts, cpuCommit); err == nil {
+		t.Fatal("expected pinned Android VM to fail on Android-full host")
+	}
+}
+
+func TestScheduleAndroidPinnedToNonFullHostSucceeds(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"android"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					Schedule:   "1",
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(2, true)
+	hosts[0].Name = "0"
+	hosts[0].AndroidVMs = MaxAndroidVMsPerHost
+	hosts[1].Name = "1"
+
+	s, err := schedule(queue, hosts, cpuCommit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(s["1"]) != 1 {
+		t.Fatalf("expected Android VM scheduled on pinned non-full host 1, got: %#v", s)
+	}
+}
+
+func TestScheduleAndroidCapacityMultiHostOverflow(t *testing.T) {
+	var names []string
+	for i := 0; i < MaxAndroidVMsPerHost*2+1; i++ {
+		names = append(names, strconv.Itoa(i))
+	}
+
+	queue := []*QueuedVMs{
+		{
+			Names:  names,
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(2, true)
+
+	if _, err := schedule(queue, hosts, cpuCommit); err == nil {
+		t.Fatalf("expected scheduling %d Android VMs on two hosts to fail", MaxAndroidVMsPerHost*2+1)
+	}
+}
+
+func TestScheduleAndroidColocateCapacityFails(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"anchor"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					Schedule:   "0",
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+		{
+			Names:  []string{"colocated"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					Colocate:   "anchor",
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := fakeHostData(1, true)
+	hosts[0].Name = "0"
+	hosts[0].AndroidVMs = MaxAndroidVMsPerHost - 1
+
+	if _, err := schedule(queue, hosts, cpuCommit); err == nil {
+		t.Fatal("expected colocated Android VMs to exceed remaining Android capacity")
+	}
+}
+
+func androidSchedulerHost(name string, cpu uint64, androidVMs int) *HostStats {
+	return &HostStats{
+		Name:          name,
+		CPUCommit:     cpu,
+		MemCommit:     cpu,
+		NetworkCommit: int(cpu),
+		CPUs:          1,
+		MemTotal:      1,
+		Limit:         -1,
+		AndroidVMs:    androidVMs,
+	}
+}
+
+func scheduledVMNames(qs []*QueuedVMs) map[string]bool {
+	names := map[string]bool{}
+
+	for _, q := range qs {
+		for _, name := range q.Names {
+			names[name] = true
+		}
+	}
+
+	return names
+}
+
+func TestScheduleAndroidColocatedGroupSkipsHostWithoutEnoughAndroidSlots(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"anchor"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+		{
+			Names:  []string{"buddy"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					Colocate:   "anchor",
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := []*HostStats{
+		// Least-loaded host, but it only has one Android slot available.
+		androidSchedulerHost("0", 0, MaxAndroidVMsPerHost-1),
+
+		// More-loaded host, but it has enough Android slots for the colocated group.
+		androidSchedulerHost("1", 100, 0),
+	}
+
+	s, err := schedule(queue, hosts, cpuCommit)
+	if err != nil {
+		t.Fatalf("expected scheduler to choose host with enough Android slots for colocated group: %v", err)
+	}
+
+	host0Names := scheduledVMNames(s["0"])
+	if host0Names["anchor"] || host0Names["buddy"] {
+		t.Fatalf("expected no colocated Android group members on host 0, got schedule: %#v", s)
+	}
+
+	host1Names := scheduledVMNames(s["1"])
+	if !host1Names["anchor"] || !host1Names["buddy"] {
+		t.Fatalf("expected both colocated Android VMs on host 1, got schedule: %#v", s)
+	}
+}
+
+func TestScheduleNonAndroidAnchorWithAndroidColocateSkipsAndroidFullHost(t *testing.T) {
+	queue := []*QueuedVMs{
+		{
+			Names:  []string{"anchor"},
+			VMType: KVM,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+		{
+			Names:  []string{"android-buddy"},
+			VMType: ANDROID,
+			VMConfig: VMConfig{
+				BaseConfig: BaseConfig{
+					Colocate:   "anchor",
+					VCPUs:      1,
+					Memory:     1,
+					Coschedule: -1,
+				},
+			},
+		},
+	}
+
+	hosts := []*HostStats{
+		// Least-loaded host, but it has no Android capacity.
+		androidSchedulerHost("0", 0, MaxAndroidVMsPerHost),
+
+		// More-loaded host, but it can fit the Android colocated VM.
+		androidSchedulerHost("1", 100, 0),
+	}
+
+	s, err := schedule(queue, hosts, cpuCommit)
+	if err != nil {
+		t.Fatalf("expected scheduler to choose host with Android capacity for colocated group: %v", err)
+	}
+
+	host0Names := scheduledVMNames(s["0"])
+	if host0Names["anchor"] || host0Names["android-buddy"] {
+		t.Fatalf("expected no colocated group members on Android-full host 0, got schedule: %#v", s)
+	}
+
+	host1Names := scheduledVMNames(s["1"])
+	if !host1Names["anchor"] || !host1Names["android-buddy"] {
+		t.Fatalf("expected both colocated VMs on host 1, got schedule: %#v", s)
+	}
+}

--- a/cmd/minimega/stats.go
+++ b/cmd/minimega/stats.go
@@ -27,6 +27,7 @@ type HostStats struct {
 	MemTotal      int
 	MemUsed       int
 	VMs           int
+	AndroidVMs    int
 	Limit         int
 	CPUCommit     uint64
 	MemCommit     uint64
@@ -53,6 +54,7 @@ Report information about hosts in the current namespace:
 - tx         : TX bandwidth stats (MB/s)
 - uptime     : uptime
 - vms        : number of VMs
+- androidvms : number of active Android VMs counted against the per-host Android port limit
 - vmlimit    : limit based on coschedule values (-1 is no limit)
 
 All VM-based stats are computed across namespaces.`,
@@ -71,6 +73,7 @@ All VM-based stats are computed across namespaces.`,
 			"host <uptime,>",
 			"host <vms,>",
 			"host <vmlimit,>",
+			"host <androidvms,>",
 		},
 		Call: wrapBroadcastCLI(cliHost),
 	},
@@ -108,6 +111,8 @@ func (h *HostStats) Print(v string) string {
 		return strconv.Itoa(h.NetworkCommit)
 	case "vms":
 		return strconv.Itoa(h.VMs)
+	case "androidvms":
+		return strconv.Itoa(h.AndroidVMs)
 	case "vmlimit":
 		return strconv.Itoa(h.Limit)
 	case "uptime":
@@ -122,7 +127,7 @@ func (h *HostStats) Print(v string) string {
 // it's usually redundant in the tabular data unless .annotate is false.
 var hostInfoKeys = []string{
 	"cpus", "load", "memused", "memtotal", "rx", "tx", "vms", "vmlimit",
-	"cpucommit", "memcommit", "netcommit", "uptime",
+	"androidvms", "cpucommit", "memcommit", "netcommit", "uptime",
 }
 
 func cliHost(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/cmd/minimega/vm.go
+++ b/cmd/minimega/vm.go
@@ -31,6 +31,7 @@ const (
 	_ VMType = iota
 	KVM
 	CONTAINER
+	ANDROID
 )
 
 type VM interface {
@@ -146,6 +147,8 @@ var vmInfo = []string{
 	"vcpus", "disks", "snapshot", "initrd", "kernel", "cdrom", "save",
 	"append", "serial-ports", "virtio-ports", "vnc_port", "usb-use-xhci",
 	"tpm-socket", "bidirectional-copy-paste",
+	// android fields
+	"android_avd", "android_console_port", "android_adb_port", "android_serial",
 	// container fields
 	"filesystem", "hostname", "init", "preinit", "fifo", "volume",
 	"console_port",
@@ -168,6 +171,7 @@ func init() {
 	gob.Register([]VM{})
 	gob.Register(&KvmVM{})
 	gob.Register(&ContainerVM{})
+	gob.Register(&AndroidVM{})
 }
 
 func NewVM(name, namespace string, vmType VMType, config VMConfig) (VM, error) {
@@ -176,6 +180,8 @@ func NewVM(name, namespace string, vmType VMType, config VMConfig) (VM, error) {
 		return NewKVM(name, namespace, config)
 	case CONTAINER:
 		return NewContainer(name, namespace, config)
+	case ANDROID:
+		return NewAndroid(name, namespace, config)
 	}
 
 	return nil, errors.New("unknown VM type")
@@ -258,6 +264,8 @@ func (s VMType) String() string {
 		return "kvm"
 	case CONTAINER:
 		return "container"
+	case ANDROID:
+		return "android"
 	default:
 		return "???"
 	}
@@ -269,6 +277,8 @@ func ParseVMType(s string) (VMType, error) {
 		return KVM, nil
 	case "container":
 		return CONTAINER, nil
+	case "android":
+		return ANDROID, nil
 	default:
 		return 0, errors.New("invalid VMType")
 	}

--- a/cmd/minimega/vm_cli.go
+++ b/cmd/minimega/vm_cli.go
@@ -35,7 +35,7 @@ info include:
 - state*     : one of (building, running, paused, quit, error)
 - uptime     : amount of time since the VM was launched
 - namespace* : namespace the VM belongs to
-- type*      : one of (kvm, container)
+- type*      : one of (kvm, container, android)
 - uuid*      : QEMU system uuid
 - cc_active* : indicates whether cc is connected
 - vcpus      : the number of allocated CPUs
@@ -75,6 +75,14 @@ Additional fields are available for container-based VMs:
 - fifo         : number of fifo devices
 - console_port : port for console shim
 
+Additional fields are available for Android VMs:
+
+- android_avd          : Android Virtual Device name
+- android_console_port : Android emulator console port
+- android_adb_port     : Android emulator adb port
+- android_serial       : adb serial name, e.g. emulator-5554
+- pid                  : pid of Android emulator process
+
 The optional summary flag limits the columns to those denoted with a '*'.
 
 Examples:
@@ -101,6 +109,7 @@ supported VM types are:
 
 - kvm : QEMU-based vms
 - container: Linux containers
+- android : Android emulator-based VMs
 
 If you supply a name instead of a number of VMs, one VM with that name will be
 launched. You may also supply a range expression to launch VMs with a specific
@@ -119,11 +128,16 @@ example:
 
 If queueing is enabled (see "ns"), VMs will be queued for launching until "vm
 launch" is called with no additional arguments. This allows the scheduler to
-better allocate resources across the cluster.`,
+better allocate resources across the cluster.
+
+Android VMs use host-side emulator console/ADB port pairs. minimega currently
+uses 64 valid port pairs per host, so each host can run at most 64 Android VMs
+concurrently, and fewer if some of those ports are already in use.`,
 		Patterns: []string{
 			"vm launch",
 			"vm launch <kvm,> <name or count> [config]",
 			"vm launch <container,> <name or count> [config]",
+			"vm launch <android,> <name or count> [config]",
 		},
 		Call: wrapSimpleCLI(cliVMLaunch),
 	},
@@ -540,6 +554,7 @@ func init() {
 	gob.Register(VMs{})
 	gob.Register(&KvmVM{})
 	gob.Register(&ContainerVM{})
+	gob.Register(&AndroidVM{})
 }
 
 func cliVMApply(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/cmd/minimega/vmconfig_cli.go
+++ b/cmd/minimega/vmconfig_cli.go
@@ -55,7 +55,6 @@ Android-related generated config fields use the following names:
 	android-no-window
 	android-console-base-port
 	android-extra-args
-	android-require-kvm
 	android-writable-system
 
 These refer to host-side Android emulator runtime settings, not files served
@@ -323,6 +322,15 @@ func cliVMConfig(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 		case *ContainerVM:
 			ns.vmConfig.BaseConfig = vm.BaseConfig.Copy()
 			ns.vmConfig.ContainerConfig = vm.ContainerConfig.Copy()
+		case *AndroidVM:
+			ns.vmConfig.BaseConfig = vm.BaseVM.BaseConfig.Copy()
+			ns.vmConfig.KVMConfig = vm.KVMConfig.Copy()
+			ns.vmConfig.AndroidConfig = vm.AndroidConfig.Copy()
+
+			// Clear SnapshotPaths since we can't launch VMs with the same SnapshotPath.
+			for i := range ns.vmConfig.KVMConfig.Disks {
+				ns.vmConfig.KVMConfig.Disks[i].SnapshotPath = ""
+			}
 		}
 
 		// clear UUID since we can't launch VMs with the same UUID

--- a/cmd/minimega/vmconfiger_cli.go
+++ b/cmd/minimega/vmconfiger_cli.go
@@ -144,7 +144,24 @@ Default: true
 	},
 	{
 		HelpShort: "configures android-console-base-port",
-		HelpLong: `Configure the base console port for Android emulator instances.
+		HelpLong: `Configure the preferred starting console port for Android emulator instances.
+
+This value is a hint, not a guaranteed assignment. minimega searches for the
+first available Android console/ADB port pair starting at this port. If the
+requested pair is already reserved or unavailable, the next valid pair is
+used.
+
+If set to 0, minimega starts searching at the beginning of the valid Android
+emulator console port range. Console ports are even ports in the range
+5554-5680, and the corresponding ADB port is console+1.
+
+If nonzero, this value must be an even port in the valid console port range.
+Starting later in the range reduces the number of candidate port pairs.
+
+The valid range contains 64 console/ADB port pairs, so a single minimega
+host can run at most 64 Android emulator VMs concurrently, and fewer if some
+ports in the range are already in use. In a multi-host namespace, this limit
+applies independently to each host.
 
 Default: 0
 `,
@@ -160,6 +177,10 @@ Default: 0
 
 			i, err := strconv.ParseUint(c.StringArgs["value"], 10, 64)
 			if err != nil {
+				return err
+			}
+
+			if err := validateAndroidConsoleBasePort(ns.vmConfig, i); err != nil {
 				return err
 			}
 

--- a/cmd/minimega/vms.go
+++ b/cmd/minimega/vms.go
@@ -83,6 +83,21 @@ func (vms *VMs) Count() int {
 	return len(vms.m)
 }
 
+func (vms *VMs) CountTypeState(t VMType, mask VMState) int {
+	vms.mu.Lock()
+	defer vms.mu.Unlock()
+
+	var count int
+
+	for _, vm := range vms.m {
+		if vm.GetType() == t && vm.GetState()&mask != 0 {
+			count++
+		}
+	}
+
+	return count
+}
+
 // Limit is the lowest coschedule value for VMs (-1 is no limit)
 func (vms *VMs) Limit() int {
 	vms.mu.Lock()

--- a/cmd/minimega/vms_test.go
+++ b/cmd/minimega/vms_test.go
@@ -1,0 +1,111 @@
+package main
+
+import "testing"
+
+func testVM(vmType VMType, state VMState) VM {
+	base := &BaseVM{
+		Type:  vmType,
+		State: state,
+	}
+
+	switch vmType {
+	case KVM:
+		return &KvmVM{BaseVM: base}
+	case CONTAINER:
+		return &ContainerVM{BaseVM: base}
+	case ANDROID:
+		return &AndroidVM{BaseVM: base}
+	default:
+		panic("unknown VM type")
+	}
+}
+
+func TestVMsCountTypeStateEmpty(t *testing.T) {
+	vms := &VMs{
+		m: map[int]VM{},
+	}
+
+	if got := vms.CountTypeState(ANDROID, VM_KILLABLE); got != 0 {
+		t.Fatalf("expected 0 Android VMs, got %d", got)
+	}
+}
+
+func TestVMsCountTypeState(t *testing.T) {
+	vms := &VMs{
+		m: map[int]VM{
+			1: testVM(ANDROID, VM_BUILDING),
+			2: testVM(ANDROID, VM_RUNNING),
+			3: testVM(ANDROID, VM_PAUSED),
+			4: testVM(ANDROID, VM_QUIT),
+			5: testVM(ANDROID, VM_ERROR),
+
+			6: testVM(KVM, VM_RUNNING),
+			7: testVM(CONTAINER, VM_RUNNING),
+		},
+	}
+
+	tests := []struct {
+		name   string
+		vmType VMType
+		mask   VMState
+		want   int
+	}{
+		{
+			name:   "active android vms",
+			vmType: ANDROID,
+			mask:   VM_KILLABLE,
+			want:   3,
+		},
+		{
+			name:   "quit or error android vms",
+			vmType: ANDROID,
+			mask:   VM_QUIT | VM_ERROR,
+			want:   2,
+		},
+		{
+			name:   "all android vms",
+			vmType: ANDROID,
+			mask:   VM_ANY_STATE,
+			want:   5,
+		},
+		{
+			name:   "running kvm vms",
+			vmType: KVM,
+			mask:   VM_RUNNING,
+			want:   1,
+		},
+		{
+			name:   "running container vms",
+			vmType: CONTAINER,
+			mask:   VM_RUNNING,
+			want:   1,
+		},
+		{
+			name:   "zero mask matches nothing",
+			vmType: ANDROID,
+			mask:   0,
+			want:   0,
+		},
+		{
+			name:   "android running excludes paused",
+			vmType: ANDROID,
+			mask:   VM_RUNNING,
+			want:   1,
+		},
+		{
+			name:   "kvm does not count android",
+			vmType: KVM,
+			mask:   VM_KILLABLE,
+			want:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vms.CountTypeState(tt.vmType, tt.mask)
+			if got != tt.want {
+				t.Fatalf("expected %d, got %d", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description ##
This PR adds Android as a native minimega VM type backed by the Android Emulator runtime.

This builds off of PR #1614 by consuming those Android config fields in a first-class VM runtime.

Major changes include:

- Adds a new `ANDROID` VM type.
- Adds `AndroidVM` and `NewAndroid(...)`.
- Adds `vm launch android ...` CLI support.
- Adds Android VM info fields:
  - `android_avd`
  - `android_console_port`
  - `android_adb_port`
  - `android_serial`
- Launches Android Studio Emulator directly.
- Reuses the existing KVM/QEMU argument construction path for backend QEMU arguments.
- Passes generated backend QEMU arguments to Android Emulator via `-qemu`.
- Filters QEMU arguments that Android Emulator should not receive through `-qemu`, currently `-vnc` and `-vga`.
- Preserves QMP-based lifecycle behavior (`BUILDING`, `RUNNING`, `PAUSED`, `QUIT`) for Android VMs:
  - `vm stop` pauses the VM through QMP.
  - `vm start` resumes the VM through QMP.
  - `vm kill` terminates the emulator process.
  - `vm flush` removes the VM.
- Tracks Android VM PID, state, type, namespace, UUID, and runtime ports.
- Adds Android runtime environment setup at launch:
  - `ANDROID_SDK_ROOT`
  - `ANDROID_HOME`
  - `ANDROID_AVD_HOME`
  - Android Emulator library paths in `LD_LIBRARY_PATH`
- Adds validation for Android console base ports.
- Reserves Android console/ADB ports as pairs.
- Treats `android-console-base-port` as a preferred starting port / hint rather than a guaranteed fixed assignment.
- Limits Android console base ports to even ports in the supported Android Emulator range.
- Adds a per-host Android VM scheduling capacity based on the valid emulator console/ADB port-pair range.
- Adds Android VM accounting to host stats via `androidvms`.
- Updates scheduler behavior so Android VMs are not scheduled beyond the per-host Android port-pair capacity.
- Preserves existing scheduler behavior for non-Android VM types.
- Adds Android support to VM config clone.
- Adds cross-type conflict handling between Android, KVM, and container VMs.
- Adds unit tests for Android scheduler capacity handling and Android VM counting helpers.

Android networking, VM recovery, adb-specific minimega commands, save/migrate, screenshots, and Android guest orchestration are intentionally left for future PRs.

## Motivation and context ##
Android support was previously hacky at best and typically relied on non-standard mechanisms for launching Android VMs. However, by officially supporting the Android Studio Emulator, we can launch Android devices while leveraging existing minimega lifecycle and scheduling work. Furthermore, it eases researcher burden by enabling easier transitions between Android Studio and minimega.

This change moves Android support into minimega’s VM lifecycle by making Android a native VM type. Android VMs can now be launched, started, stopped, killed, flushed, inspected, and scheduled through the same core mechanisms used for other VM types.

The implementation preserves as much of the existing KVM launch flow as possible because Android Emulator uses a modified QEMU/KVM backend. `AndroidVM` reuses minimega’s existing QEMU argument generation and QMP lifecycle where appropriate, while launching the configured Android Emulator binary directly.

Android Emulator console/ADB ports are host-side resources. The supported emulator console range provides a finite number of usable console/ADB port pairs. This PR therefore also teaches the scheduler about the per-host Android VM capacity so obvious overcommit cases fail during scheduling rather than later during emulator launch.

This provides a foundation for future Android-specific features such as adb command primitives, networking support, recovery, screenshots, and FIREWHEEL orchestration integration.

## Testing ##
Testing was manually performed using the Android SDK, emulator, adb, and a Pixel 9a image.

Placeholder paths are used below:

- Android SDK: `/tmp/Android/Sdk`
- Android emulator: `/tmp/Android/Sdk/emulator/emulator`
- adb: `/tmp/Android/Sdk/platform-tools/adb`
- AVD directory: `/tmp/.android/avd`
- AVD name: `Pixel_9a`

### 1. Launched a single Android VM

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm launch android phone0
vm launch
vm start phone0
vm info
```

Confirmed:

- VM type was `android`.
- VM reached `RUNNING`.
- PID was populated.
- Android AVD, console port, adb port, and serial were shown in `vm info`.

### 2. Verified Android device access with adb and scrcpy

Confirmed:

- adb could see the emulator using the reported `android_serial`.
- scrcpy could connect to and control the Android device.

### 3. Tested Android lifecycle

```text
vm stop phone0
vm info
vm start phone0
vm info
vm kill phone0
vm info
vm flush phone0
vm info
```

Confirmed transitions:

- `RUNNING -> PAUSED`
- `PAUSED -> RUNNING`
- `RUNNING/PAUSED -> QUIT`
- `vm flush` removed the VM

### 4. Tested multiple Android VMs

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only
vm launch android phone[0-1]
vm launch
vm start all
.columns name,android_console_port,android_adb_port,android_serial,state vm info
```

Confirmed:

- Both Android VMs reached `RUNNING`.
- Ports were unique, e.g. `5554/5555` and `5556/5557`.
- adb and scrcpy worked.

### 5. Tested Android plus normal KVM VM coexistence

```text
clear vm config
vm config disks images/ubuntu-22.04-desktop-amd64.qcow2
vm config memory 4096
vm config vcpus 4
vm launch kvm ubuntu0
vm launch
vm start ubuntu0

clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only
vm launch android phone0
vm launch
vm start phone0
vm info
```

Confirmed:

- KVM VM and Android VM ran at the same time.
- Cross-type conflict checks did not fail.
- Lifecycle operations on one VM type did not affect the other.

### 6. Tested independent mixed lifecycle

```text
vm stop ubuntu0
vm start ubuntu0
vm kill phone0
vm kill ubuntu0
vm flush all
vm info
```

Confirmed:

- Both VM types could be managed independently.
- Both VM types could be flushed cleanly.

### 7. Tested miniweb compatibility with mixed KVM and Android workload

Confirmed:

- miniweb continued to work with Android VMs present.
- KVM VM display remained available through miniweb.
- Android display/control was validated through adb/scrcpy.
- miniweb still exposes a VNC connect option for Android VMs, but it does not work because Android VMs do not currently expose a minimega VNC shim. Future work could adjust this in miniweb, but that is intentionally left to a separate PR.

### 8. Tested invalid AVD handling

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd DoesNotExist
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm launch android badphone
vm launch
vm info
```

Confirmed:

- VM entered `ERROR`.
- Error tag reported missing AVD path.

### 9. Tested unsupported Android networking behavior

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config networks 101
vm launch android netphone
vm launch
vm info
```

Confirmed:

- VM entered `ERROR`.
- Error tag reported `android VM networking is not supported yet`.
- No Android emulator process was launched for this VM.
- No tap was created.

### 10. Tested invalid Android console port errors

Tested invalid Android console base ports. Android console base ports must be `0` or an even port in the valid range `5554-5680`.

Examples:

```text
clear vm config
vm config android-console-base-port 5555
vm config android-console-base-port 5552
vm config android-console-base-port 5682
```

Confirmed:

- Odd ports were rejected.
- Ports below the valid range were rejected.
- Ports above the valid range were rejected.

Also confirmed valid values:

```text
vm config android-console-base-port 0
vm config android-console-base-port 5554
vm config android-console-base-port 5680
```

### 11. Tested valid custom Android console base port

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only
vm config android-console-base-port 5570
vm launch android portphone
vm launch
vm start portphone
.columns name,android_console_port,android_adb_port,android_serial,state vm info
```

Confirmed:

- Console port `5570`.
- adb port `5571`.
- serial `emulator-5570`.
- VM reached `RUNNING`.
- adb/scrcpy worked on the custom port.

### 12. Tested Android port hint behavior

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only
vm config android-console-base-port 5556
vm launch android phone[0-1]
vm launch
vm start all
.columns name,android_console_port,android_adb_port,android_serial,state vm info
```

Confirmed:

- `android-console-base-port` is a hint / search starting point, not a guaranteed fixed assignment.
- The first VM received `5556/5557`.
- The second VM received the next available pair, `5558/5559`.

### 13. Tested Android config clone

```text
vm config clone phone0
vm launch android phone1
vm launch
vm start phone1
.columns name,type,uuid,android_console_port,android_adb_port,state vm info
```

Confirmed:

- Cloned Android config launched a second Android VM.
- UUIDs were unique.
- Android ports were unique.
- Both VMs reached `RUNNING`.

### 14. Tested single-host Android scheduler exact capacity dry-run

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only

ns queueing true
vm launch android phone[0-63]
ns schedule dry-run
ns schedule dump
```

Confirmed:

- Dry-run succeeded.
- All 64 Android VMs were assigned to the single host.


### 15. Tested single-host Android scheduler overflow dry-run

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only

ns queueing true
vm launch android phone[0-64]
ns schedule dry-run
```

Confirmed:

- Dry-run failed with an Android capacity error.
- The single-host scheduler shortcut did not bypass Android capacity checks.


### 16. Tested pinned Android scheduler exact capacity dry-run

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only
vm config schedule localhost

ns queueing true
vm launch android phone[0-63]
ns schedule dry-run
ns schedule dump
```

Confirmed:

- Dry-run succeeded.
- All 64 Android VMs were assigned to the pinned host.

### 17. Tested pinned Android scheduler overflow dry-run

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only
vm config schedule localhost

ns queueing true
vm launch android phone[0-64]
ns schedule dry-run
```

Confirmed:

- Dry-run failed with an Android capacity error for the pinned host.


### 18. Tested Android colocate exact capacity dry-run

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only

ns queueing true

vm config schedule localhost
vm launch android anchor

clear vm config schedule
vm config colocate anchor
vm launch android buddy[0-62]

ns schedule dry-run
ns schedule dump
```

Confirmed:

- Dry-run succeeded.
- `anchor` and `buddy[0-62]` were assigned to the same host.
- The total colocated Android VM count was exactly 64.

### 19. Tested Android colocate overflow dry-run

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only

ns queueing true

vm config schedule localhost
vm launch android anchor

clear vm config schedule
vm config colocate anchor
vm launch android buddy[0-63]

ns schedule dry-run
```

Confirmed:

- Dry-run failed because colocating all VMs on one host would require 65 Android slots.
- Colocated Android VMs are counted against the per-host Android capacity.

### 20. Tested late custom console base port launch-time exhaustion

```text
clear vm config
vm config android-sdk /tmp/Android/Sdk
vm config android-emulator /tmp/Android/Sdk/emulator/emulator
vm config android-adb /tmp/Android/Sdk/platform-tools/adb
vm config android-avd Pixel_9a
vm config android-avd-dir /tmp/.android/avd
vm config android-no-window true
vm config memory 4096
vm config vcpus 8
vm config android-extra-args -read-only
vm config android-console-base-port 5680

ns queueing true
vm launch android phone[0-1]
vm launch

.columns name,android_console_port,android_adb_port,android_serial,state,tags vm info
```

Confirmed:

- One VM could use the final valid console/ADB pair.
- The second VM failed at launch time because no later valid Android console/ADB port pair was available.
- The launch-time error was clear.

### 21. Unit tests

Added and ran unit tests for Android scheduler capacity and Android VM accounting behavior.

Covered scheduler behavior includes:

- Android capacity is enforced per host, not per namespace.
- Single-host Android capacity succeeds at exactly `MaxAndroidVMsPerHost`.
- Single-host Android capacity fails above `MaxAndroidVMsPerHost`.
- Multi-host scheduling can place up to `MaxAndroidVMsPerHost` Android VMs per host.
- Multi-host scheduling fails when queued Android VMs exceed total available host capacity.
- Existing Android VMs are counted against host Android capacity.
- Android scheduling skips an Android-full least-loaded host and selects another eligible host.
- Non-Android VM scheduling is unaffected by Android host capacity.
- Pinned Android scheduling succeeds on a host with capacity.
- Pinned Android scheduling fails on an Android-full host.
- Colocated Android VMs count against per-host Android capacity.

Added VM count helper tests verifying that only active Android VMs count against scheduler capacity:

- `BUILDING`
- `RUNNING`
- `PAUSED`

and that inactive Android VMs do not count:

- `QUIT`
- `ERROR`

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
Android networking is intentionally not enabled in this phase and will fail if an Android VM is launched with configured networks.

Android lifecycle currently relies on the Android Emulator accepting backend QEMU arguments through `-qemu`, including QMP setup. This was validated manually through `vm start` / `vm stop` lifecycle testing.

Android display/control is expected to be performed through adb/scrcpy in this phase. Android VMs do not expose a minimega VNC shim or miniweb graphical console.

Android Emulator console/ADB port capacity is enforced by the scheduler as a per-host limit. The launcher still performs final port-pair reservation and availability checks, so launch-time failures remain possible if ports are already used by non-minimega processes or if a custom `android-console-base-port` starts too late in the valid range.

Multi-host Android scheduling was not manually tested, but the scheduler behavior is covered by unit tests.