### PR TITLE
feat(android): Adding the explicit saving of Android VM configurations

### DIFF
--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -698,9 +698,11 @@ func (n *Namespace) processVMBonds(vals []string) error {
 	return nil
 }
 
-// Save creates a snapshot of a namespace so that it can be restored later.
-// Both a state file and hard disk file (disk) are created for each
-// VM in the namespace. If dir is not an absolute path, it will be a
+// Save creates a restorable namespace launch script and saves runtime state for
+// VM types that support minimega save semantics. KVM VMs have state and disk
+// files saved. Container and Android VMs are saved as configuration only.
+// Android Emulator runtime state, AVD data changes, and guest-side network
+// configuration are not captured. If dir is not an absolute path, it will be a
 // subdirectory of iomBase.
 func (n *Namespace) Save(dir string) error {
 	var useIOM bool
@@ -802,12 +804,26 @@ func (n *Namespace) Save(dir string) error {
 			fmt.Fprintf(f, "vm config disks %s\n", diskConfigs.String())
 
 		} else if vm.GetType() == CONTAINER {
-			log.Warn("Skipping save for container: %q\n", vm.GetName())
+			log.Warn("Saving configuration only for container: %q\n", vm.GetName())
 			fmt.Fprintf(f, "clear vm config\n")
 
 			if err := vm.WriteConfig(f); err != nil {
 				return err
 			}
+		} else if vm.GetType() == ANDROID {
+			log.Warn("Saving configuration only for Android VM: %q\n", vm.GetName())
+
+			fmt.Fprintf(f, "# Android VM %q is saved as configuration only.\n", vm.GetName())
+			fmt.Fprintf(f, "# Android Emulator runtime state, AVD data changes, guest IP addresses,\n")
+			fmt.Fprintf(f, "# guest policy routing, and guest firewall state are not captured.\n")
+
+			fmt.Fprintf(f, "clear vm config\n")
+
+			if err := vm.WriteConfig(f); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("namespace save does not support VM type %v for VM %q", vm.GetType(), vm.GetName())
 		}
 
 		fmt.Fprintf(f, "vm launch %v %q\n\n", vm.GetType(), vm.GetName())

--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -697,9 +697,11 @@ func (n *Namespace) processVMBonds(vals []string) error {
 	return nil
 }
 
-// Save creates a snapshot of a namespace so that it can be restored later.
-// Both a state file and hard disk file (disk) are created for each
-// VM in the namespace. If dir is not an absolute path, it will be a
+// Save creates a restorable namespace launch script and saves runtime state for
+// VM types that support minimega save semantics. KVM VMs have state and disk
+// files saved. Container and Android VMs are saved as configuration only.
+// Android Emulator runtime state, AVD data changes, and guest-side network
+// configuration are not captured. If dir is not an absolute path, it will be a
 // subdirectory of iomBase.
 func (n *Namespace) Save(dir string) error {
 	var useIOM bool
@@ -801,12 +803,26 @@ func (n *Namespace) Save(dir string) error {
 			fmt.Fprintf(f, "vm config disks %s\n", diskConfigs.String())
 
 		} else if vm.GetType() == CONTAINER {
-			log.Warn("Skipping save for container: %q\n", vm.GetName())
+			log.Warn("Saving configuration only for container: %q\n", vm.GetName())
 			fmt.Fprintf(f, "clear vm config\n")
 
 			if err := vm.WriteConfig(f); err != nil {
 				return err
 			}
+		} else if vm.GetType() == ANDROID {
+			log.Warn("Saving configuration only for Android VM: %q\n", vm.GetName())
+
+			fmt.Fprintf(f, "# Android VM %q is saved as configuration only.\n", vm.GetName())
+			fmt.Fprintf(f, "# Android Emulator runtime state, AVD data changes, guest IP addresses,\n")
+			fmt.Fprintf(f, "# guest policy routing, and guest firewall state are not captured.\n")
+
+			fmt.Fprintf(f, "clear vm config\n")
+
+			if err := vm.WriteConfig(f); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("namespace save does not support VM type %v for VM %q", vm.GetType(), vm.GetName())
 		}
 
 		fmt.Fprintf(f, "vm launch %v %q\n\n", vm.GetType(), vm.GetName())

--- a/cmd/minimega/namespace_cli.go
+++ b/cmd/minimega/namespace_cli.go
@@ -67,8 +67,12 @@ Display or modify the active namespace.
 - bridge    : create a bridge, defaults to GRE mesh between hosts
 - del-bridge: destroy a bridge
 - snapshot  : **DEPRECATED**: Use 'ns save'
-- save      : Save all VMs in the namespace or print save progress
+- save      : Save all supported VMs in the namespace or print save progress
 - run       : run a command on all nodes in the namespace
+
+Note: namespace save records Android VM configuration so Android VMs can be
+relaunched, but it does not capture Android Emulator runtime state, AVD data
+changes, guest IP addresses, guest policy routing, or guest firewall state.
 `,
 		Patterns: []string{
 			"ns <hosts,>",

--- a/cmd/minimega/vm_cli.go
+++ b/cmd/minimega/vm_cli.go
@@ -375,7 +375,11 @@ filename provided. If no filename is provided, the state and disk image will be 
 On success, a call to 'vm save' a VM will return immediately. You can check the
 status of in-flight saves by invoking 'vm save' with no arguments.
 
-Note: This will overwrite any prior saved files.`,
+Note: This will overwrite any prior saved files.
+
+Note: vm save is currently supported for KVM VMs only. Android VM save is not
+supported because Android Emulator snapshot/AVD state is managed separately
+from minimega's KVM migration state.`,
 		Patterns: []string{
 			"vm save",
 			"vm save <vm name>",
@@ -836,9 +840,16 @@ func cliVMSave(ns *Namespace, c *minicli.Command, resp *minicli.Response) error 
 		return nil
 	}
 
-	vm, err := ns.FindKvmVM(c.StringArgs["vm"])
-	if err != nil {
-		return err
+	target := c.StringArgs["vm"]
+
+	found := ns.FindVM(target)
+	if found == nil {
+		return vmNotFound(target)
+	}
+
+	vm, ok := found.(*KvmVM)
+	if !ok {
+		return fmt.Errorf("vm save is only supported for KVM VMs; %q is type %v", found.GetName(), found.GetType())
 	}
 
 	fname := c.StringArgs["filename"]

--- a/cmd/minimega/vm_cli.go
+++ b/cmd/minimega/vm_cli.go
@@ -423,7 +423,11 @@ filename provided. If no filename is provided, the state and disk image will be 
 On success, a call to 'vm save' a VM will return immediately. You can check the
 status of in-flight saves by invoking 'vm save' with no arguments.
 
-Note: This will overwrite any prior saved files.`,
+Note: This will overwrite any prior saved files.
+
+Note: vm save is currently supported for KVM VMs only. Android VM save is not
+supported because Android Emulator snapshot/AVD state is managed separately
+from minimega's KVM migration state.`,
 		Patterns: []string{
 			"vm save",
 			"vm save <vm name>",
@@ -963,9 +967,16 @@ func cliVMSave(ns *Namespace, c *minicli.Command, resp *minicli.Response) error 
 		return nil
 	}
 
-	vm, err := ns.FindKvmVM(c.StringArgs["vm"])
-	if err != nil {
-		return err
+	target := c.StringArgs["vm"]
+
+	found := ns.FindVM(target)
+	if found == nil {
+		return vmNotFound(target)
+	}
+
+	vm, ok := found.(*KvmVM)
+	if !ok {
+		return fmt.Errorf("vm save is only supported for KVM VMs; %q is type %v", found.GetName(), found.GetType())
 	}
 
 	fname := c.StringArgs["filename"]


### PR DESCRIPTION
## Description ##

This PR adds support for saving Android VM configurations during `ns save`, and improves error handling for `vm save` when targeting non-KVM VMs.

Android VMs are now included in the namespace save output as configuration-only entries. The generated launch script records the VM config and a `vm launch` command so Android VMs can be relaunched from a saved namespace. Inline comments in the script warn that Android Emulator runtime state, AVD data changes, guest IP addresses, guest policy routing, and guest firewall state are **not** captured. Container VMs already had configuration-only save support; the log message for containers is updated from "Skipping save" to "Saving configuration only" for consistency. An explicit error is now returned for any unrecognized VM type rather than silently falling through.

## Motivation and context ##

Prior to this change, running `ns save` on a namespace containing Android VMs would silently skip them entirely, producing a launch script that omitted those VMs. Additionally, running `vm save` on an Android VM returned a confusing "VM not found" error because the code only searched the KVM VM list.

This change ensures that Android VMs are preserved in namespace save output so they can be relaunched, and provides clear feedback to users about what is and is not captured. The distinction matters because Android Emulator state (AVD snapshots, guest-side network configuration) is managed outside minimega's KVM migration mechanism.

## Testing ##

- Verify `ns save` on a namespace containing KVM, container, and Android VMs produces a launch script with configuration entries for all three VM types.
- Verify the saved script includes the warning comments for Android VMs.
- Verify `vm save <android-vm>` returns the error: `vm save is only supported for KVM VMs; "<name>" is type android`.
- Verify `vm save <kvm-vm>` continues to work as before.
- Verify `ns save` returns an error if an unsupported VM type is encountered (the new `else` branch).

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.