### PR TITLE
fix(namespace): resolve namespace per command, not via a mutable global

### DIFF
--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -906,7 +906,7 @@ func cliCCTestConn(ns *Namespace, c *minicli.Command, resp *minicli.Response) er
 // cliCCMount needs to collect mounts from both the local ccMounts for the
 // namespace and across the cluster.
 func cliCCMount(c *minicli.Command, respChan chan<- minicli.Responses) {
-	ns := GetNamespace()
+	ns := resolveNamespace(c)
 
 	// makeResponse creates a response from the namespace's ccMounts
 	makeResponse := func() *minicli.Response {
@@ -951,7 +951,7 @@ func cliCCMount(c *minicli.Command, respChan chan<- minicli.Responses) {
 }
 
 func cliCCMountUUID(c *minicli.Command, respChan chan<- minicli.Responses) {
-	ns := GetNamespace()
+	ns := resolveNamespace(c)
 
 	resp := &minicli.Response{Host: hostname}
 
@@ -1178,7 +1178,7 @@ func cliCCClear(ns *Namespace, c *minicli.Command, resp *minicli.Response) error
 }
 
 func cliCCClearMount(c *minicli.Command, respChan chan<- minicli.Responses) {
-	ns := GetNamespace()
+	ns := resolveNamespace(c)
 
 	resp := &minicli.Response{Host: hostname}
 

--- a/cmd/minimega/cli.go
+++ b/cmd/minimega/cli.go
@@ -98,7 +98,7 @@ func registerHandlers(name string, handlers []minicli.Handler) {
 // reduces boilerplate code with minicli handlers.
 func wrapSimpleCLI(fn wrappedCLIFunc) minicli.CLIFunc {
 	return func(c *minicli.Command, respChan chan<- minicli.Responses) {
-		ns := GetNamespace()
+		ns := resolveNamespace(c)
 
 		resp := &minicli.Response{Host: hostname}
 		if err := fn(ns, c, resp); err != nil {
@@ -130,7 +130,7 @@ func wrapBroadcastCLI(fn wrappedCLIFunc) minicli.CLIFunc {
 	localFunc := wrapSimpleCLI(fn)
 
 	return func(c *minicli.Command, respChan chan<- minicli.Responses) {
-		ns := GetNamespace()
+		ns := resolveNamespace(c)
 
 		// Wrapped commands have two behaviors:
 		//   `fan out` -- send the command to all hosts in the active namespace
@@ -169,7 +169,7 @@ func wrapVMTargetCLI(fn wrappedCLIFunc) minicli.CLIFunc {
 	localFunc := wrapSimpleCLI(fn)
 
 	return func(c *minicli.Command, respChan chan<- minicli.Responses) {
-		ns := GetNamespace()
+		ns := resolveNamespace(c)
 
 		// See note in wrapBroadcastCLI.
 		if c.Source != "" {
@@ -411,6 +411,7 @@ func namespaceCommands(ns *Namespace, cmd *minicli.Command) []*minicli.Command {
 
 	for _, cmd2 := range cmds {
 		cmd2.SetSource(ns.Name)
+		cmd2.SetNamespace(ns.Name)
 		cmd2.SetRecord(false)
 		cmd2.SetPreprocess(cmd.Preprocess)
 	}

--- a/cmd/minimega/command_meshage.go
+++ b/cmd/minimega/command_meshage.go
@@ -31,8 +31,15 @@ func meshageHandler() {
 
 			// Copy the flags at each level of nested command
 			for c, c2 := cmd, &mCmd.Command; c != nil && c2 != nil; {
+				// Namespace is used to create one, so validate it here
+				if c2.Namespace != "" && !validName.MatchString(c2.Namespace) {
+					log.Error("invalid namespace from mesh: `%s`", c2.Namespace)
+					return
+				}
+
 				c.Record = c2.Record
 				c.Source = c2.Source
+				c.Namespace = c2.Namespace
 				c.Preprocess = c2.Preprocess
 				c, c2 = c.Subcommand, c2.Subcommand
 			}

--- a/cmd/minimega/misc_cli.go
+++ b/cmd/minimega/misc_cli.go
@@ -191,7 +191,7 @@ func cliRead(c *minicli.Command, respChan chan<- minicli.Responses) {
 		return
 	}
 
-	ns := GetNamespace()
+	ns := resolveNamespace(c)
 
 	resp := &minicli.Response{Host: hostname}
 

--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -922,6 +922,16 @@ func GetNamespace() *Namespace {
 	return namespaces[namespace]
 }
 
+// resolveNamespace returns the namespace a command must run in: the one tagged
+// on the command itself, if any, otherwise the process-wide active namespace.
+func resolveNamespace(c *minicli.Command) *Namespace {
+	if c != nil && c.Namespace != "" {
+		return GetOrCreateNamespace(c.Namespace)
+	}
+
+	return GetNamespace()
+}
+
 // GetOrCreateNamespace returns the specified namespace, creating one if it
 // doesn't already exist.
 func GetOrCreateNamespace(name string) *Namespace {
@@ -953,23 +963,6 @@ func SetNamespace(name string) error {
 
 	namespace = name
 	return nil
-}
-
-// RevertNamespace reverts the active namespace (which should match curr) back
-// to the old namespace.
-func RevertNamespace(old, curr *Namespace) {
-	namespaceLock.Lock()
-	defer namespaceLock.Unlock()
-
-	log.Debug("reverting to namespace: %v", old)
-
-	// This is very odd and should *never* happen unless something has gone
-	// horribly wrong.
-	if namespace != curr.Name {
-		log.Warn("unexpected namespace, `%v` != `%v`, when reverting to `%v`", namespace, curr, old)
-	}
-
-	namespace = old.Name
 }
 
 func DestroyNamespace(name string) error {

--- a/cmd/minimega/namespace_cli.go
+++ b/cmd/minimega/namespace_cli.go
@@ -143,9 +143,6 @@ var nsCliHandlers = map[string]minicli.CLIFunc{
 func cliNamespace(c *minicli.Command, respChan chan<- minicli.Responses) {
 	resp := &minicli.Response{Host: hostname}
 
-	// Get the active namespace
-	ns := GetNamespace()
-
 	if name, ok := c.StringArgs["name"]; ok {
 		// check the name is sane
 		if !validName.MatchString(name) {
@@ -154,20 +151,13 @@ func cliNamespace(c *minicli.Command, respChan chan<- minicli.Responses) {
 			return
 		}
 
-		ns2 := GetOrCreateNamespace(name)
+		// validates the name and creates the namespace if it is new
+		GetOrCreateNamespace(name)
 
 		if c.Subcommand != nil {
-			// If we're not already in the desired namespace, change to it
-			// before running the command and then revert back afterwards. If
-			// we're already in the namespace, just run the command.
-			if ns.Name != name {
-				if err := SetNamespace(name); err != nil {
-					resp.Error = err.Error()
-					respChan <- minicli.Responses{resp}
-					return
-				}
-				defer RevertNamespace(ns, ns2)
-			}
+			// Tag the subcommand (rather than switching the active namespace
+			// around it)
+			c.Subcommand.SetNamespace(name)
 
 			// we don't want to see both:
 			// 		namespace foo vm info
@@ -469,7 +459,6 @@ func cliNamespaceBridge(ns *Namespace, c *minicli.Command, resp *minicli.Respons
 		}
 	}
 
-	// LOCK: This is a CLI handler.
 	if err := consume(runCommands(cmds...)); err != nil {
 		return err
 	}
@@ -501,12 +490,11 @@ func cliNamespaceDelBridge(ns *Namespace, c *minicli.Command, resp *minicli.Resp
 		cmds = append(cmds, cmd)
 	}
 
-	// LOCK: This is a CLI handler.
 	return consume(runCommands(cmds...))
 }
 
 func cliNamespaceSave(c *minicli.Command, respChan chan<- minicli.Responses) {
-	ns := GetNamespace()
+	ns := resolveNamespace(c)
 
 	resp := &minicli.Response{Host: hostname}
 
@@ -587,7 +575,6 @@ func cliClearNamespace(c *minicli.Command, respChan chan<- minicli.Responses) {
 			cmds = append(cmds, cmd)
 		}
 
-		// LOCK: This is a CLI handler.
 		if err := consume(runCommands(cmds...)); err != nil {
 			respChan <- errResp(err)
 			return
@@ -654,7 +641,7 @@ func cliNamespaceRun(c *minicli.Command, respChan chan<- minicli.Responses) {
 		}
 	}
 
-	ns := GetNamespace()
+	ns := resolveNamespace(c)
 
 	res := minicli.Responses{}
 

--- a/cmd/minimega/namespace_race_test.go
+++ b/cmd/minimega/namespace_race_test.go
@@ -1,0 +1,171 @@
+// Copyright 2015-2023 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/sandia-minimega/minimega/v2/pkg/minicli"
+)
+
+// registerNamespace inserts a bare namespace into the registry. NewNamespace
+// reaches into meshageNode, which only exists in a running daemon, and none of
+// these tests need a functional namespace -- only a registered name.
+func registerNamespace(t *testing.T, name string) {
+	t.Helper()
+
+	namespaceLock.Lock()
+	defer namespaceLock.Unlock()
+
+	if _, ok := namespaces[name]; !ok {
+		namespaces[name] = &Namespace{Name: name}
+	}
+}
+
+// TestResolveNamespaceFallsBackToActive covers the compatibility half of the
+// contract: a command carrying no namespace of its own must resolve exactly as
+// it always did, via the process-wide active namespace. The interactive CLI,
+// raw `mesh send` and scripts that rely on ambient state all depend on this.
+func TestResolveNamespaceFallsBackToActive(t *testing.T) {
+	registerNamespace(t, DefaultNamespace)
+
+	defer func() { _ = SetNamespace(DefaultNamespace) }()
+
+	registerNamespace(t, "ambient")
+
+	if err := SetNamespace("ambient"); err != nil {
+		t.Fatalf("SetNamespace: %v", err)
+	}
+
+	if got := resolveNamespace(nil).Name; got != "ambient" {
+		t.Errorf("resolveNamespace(nil) = %q, want %q", got, "ambient")
+	}
+
+	untagged := &minicli.Command{Original: "vm info"}
+
+	if got := resolveNamespace(untagged).Name; got != "ambient" {
+		t.Errorf("untagged command resolved to %q, want %q", got, "ambient")
+	}
+}
+
+// TestResolveNamespacePrefersTheTag covers the other half: once a command has
+// been told which namespace it belongs to, the active namespace is irrelevant.
+func TestResolveNamespacePrefersTheTag(t *testing.T) {
+	registerNamespace(t, DefaultNamespace)
+
+	defer func() { _ = SetNamespace(DefaultNamespace) }()
+
+	registerNamespace(t, "ambient")
+	registerNamespace(t, "tagged")
+
+	if err := SetNamespace("ambient"); err != nil {
+		t.Fatalf("SetNamespace: %v", err)
+	}
+
+	cmd := &minicli.Command{Original: "vm info", Namespace: "tagged"}
+
+	if got := resolveNamespace(cmd).Name; got != "tagged" {
+		t.Errorf("tagged command resolved to %q, want %q", got, "tagged")
+	}
+}
+
+// TestSetNamespaceTagsNestedSubcommands guards the fan-out path. A command is
+// only safe if every level of it carries the tag: wrapBroadcastCLI recompiles
+// the local leg from scratch and dispatches it separately, so a tag that stops
+// at the top level leaves the leg that does the actual work resolving through
+// the racy global.
+func TestSetNamespaceTagsNestedSubcommands(t *testing.T) {
+	inner := &minicli.Command{Original: "vm info"}
+	middle := &minicli.Command{Original: "namespace bar vm info", Subcommand: inner}
+	outer := &minicli.Command{Original: "namespace foo ...", Subcommand: middle}
+
+	outer.SetNamespace("foo")
+
+	for i, c := range []*minicli.Command{outer, middle, inner} {
+		if c.Namespace != "foo" {
+			t.Errorf("level %d namespace = %q, want %q", i, c.Namespace, "foo")
+		}
+	}
+}
+
+// TestConcurrentNamespaceResolution is the regression test. Before commands
+// carried their own namespace, `namespace <name> <cmd>` resolved by setting the
+// process-global active namespace, running, and setting it back -- while
+// cmdProcessor ran every command in its own goroutine. Concurrent clients
+// therefore read each other's namespace and executed against the wrong one,
+// which minimega itself logs as "unexpected namespace ... when reverting to".
+//
+// Here many goroutines resolve tagged commands for distinct namespaces while
+// another goroutine churns the active namespace underneath them. Every
+// resolution must still return the namespace its command named.
+func TestConcurrentNamespaceResolution(t *testing.T) {
+	registerNamespace(t, DefaultNamespace)
+
+	defer func() { _ = SetNamespace(DefaultNamespace) }()
+
+	const (
+		workers    = 8
+		iterations = 200
+	)
+
+	names := make([]string, workers)
+
+	for i := range names {
+		names[i] = fmt.Sprintf("race-ns-%d", i)
+		registerNamespace(t, names[i])
+	}
+
+	var (
+		resolvers sync.WaitGroup
+		churn     sync.WaitGroup
+		done      = make(chan struct{})
+	)
+
+	// Churn the active namespace, standing in for unrelated concurrent clients.
+	churn.Add(1)
+
+	go func() {
+		defer churn.Done()
+
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			default:
+				_ = SetNamespace(names[i%len(names)])
+			}
+		}
+	}()
+
+	errs := make(chan error, workers*iterations)
+
+	for _, name := range names {
+		resolvers.Add(1)
+
+		go func(name string) {
+			defer resolvers.Done()
+
+			cmd := &minicli.Command{Original: "vm info", Namespace: name}
+
+			for range iterations {
+				if got := resolveNamespace(cmd).Name; got != name {
+					errs <- fmt.Errorf("resolved to %q, want %q", got, name)
+					return
+				}
+			}
+		}(name)
+	}
+
+	resolvers.Wait()
+	close(done)
+	churn.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}

--- a/cmd/minimega/vmconfig.go
+++ b/cmd/minimega/vmconfig.go
@@ -70,7 +70,7 @@ type BaseConfig struct {
 	// Set a host where the VM should be scheduled.
 	//
 	// Note: Cannot specify Schedule and Colocate in the same config.
-	Schedule string `validate:"validSchedule" suggest:"wrapHostnameSuggest(true, false, false)"`
+	Schedule string `validate:"ns.validSchedule" suggest:"wrapHostnameSuggest(true, false, false)"`
 
 	// Colocate this VM with another VM that has already been launched or is
 	// queued for launching.
@@ -347,7 +347,7 @@ func (vm *BaseConfig) ReadFieldConfig(r io.Reader, field, namespace string) erro
 	return nil
 }
 
-func validSchedule(vmConfig VMConfig, s string) error {
+func (ns *Namespace) validSchedule(vmConfig VMConfig, s string) error {
 	if vmConfig.Colocate != "" && s != "" {
 		return errors.New("cannot specify schedule and colocate in the same config")
 	}
@@ -357,8 +357,6 @@ func validSchedule(vmConfig VMConfig, s string) error {
 	}
 
 	// check if s is in the namespace
-	ns := GetNamespace()
-
 	if !ns.Hosts[s] {
 		return fmt.Errorf("host is not in namespace: %v", s)
 	}

--- a/cmd/minimega/vmconfiger_cli.go
+++ b/cmd/minimega/vmconfiger_cli.go
@@ -817,7 +817,7 @@ Note: Cannot specify Schedule and Colocate in the same config.
 				return nil
 			}
 
-			if err := validSchedule(ns.vmConfig, c.StringArgs["value"]); err != nil {
+			if err := ns.validSchedule(ns.vmConfig, c.StringArgs["value"]); err != nil {
 				return err
 			}
 

--- a/cmd/minimega/vms.go
+++ b/cmd/minimega/vms.go
@@ -611,7 +611,6 @@ func globalVMs(ns *Namespace) []VM {
 	// Collected VMs
 	vms := []VM{}
 
-	// LOCK: see func description.
 	for resps := range runCommands(cmds...) {
 		for _, resp := range resps {
 			if resp.Error != "" {

--- a/pkg/minicli/command.go
+++ b/pkg/minicli/command.go
@@ -32,6 +32,11 @@ type Command struct {
 	// from. Setting and using this is entirely up to developers using minicli.
 	Source string
 
+	// Namespace names the namespace this command must run in, regardless of
+	// which namespace happens to be active when it is dispatched. This is not
+	// required.
+	Namespace string
+
 	// exact tracks whether the command was formed from prefixes or not, can be
 	// used to break ties if there is ambiguity.
 	exact bool
@@ -53,6 +58,15 @@ func (c *Command) SetSource(source string) {
 
 	if c.Subcommand != nil {
 		c.Subcommand.SetSource(source)
+	}
+}
+
+// SetNamespace sets the Namespace field for a command and all nested subcommands.
+func (c *Command) SetNamespace(namespace string) {
+	c.Namespace = namespace
+
+	if c.Subcommand != nil {
+		c.Subcommand.SetNamespace(namespace)
 	}
 }
 


### PR DESCRIPTION
<!-- Use the title to describe PR changes using the conventional commit format -->
<!-- Remember this title will end up as the merge commit subject -->

## Description ##
Commands now carry the namespace they belong to:
* minicli.Command gains a Namespace field and SetNamespace, alongside Source.
* cliNamespace tags the subcommand instead of switching the global. The argument-only form still sets it - that is the intended interactive behaviour and is untouched.
* wrapSimpleCLI, wrapBroadcastCLI and wrapVMTargetCLI resolve via resolveNamespace(c), which falls back to the active namespace when a command carries no tag. Everything untagged - the interactive CLI, raw `mesh send`, scripts relying on ambient state - behaves exactly as before.
* namespaceCommands tags both fan-out legs. The local leg is recompiled from scratch, so without this the leg that does the real work still resolved through the global and nothing would have been fixed.
* cliRead resolves the same way, so `namespace X read foo.mm` keeps prefixing the script's unprefixed lines with X.
* cliCCMount, cliCCMountUUID, cliCCClearMount, cliNamespaceSave and cliNamespaceRun likewise; validSchedule now takes the namespace its caller already resolved rather than re-deriving its own.
*  meshage command handling copies Namespace with the other per-command flags.

RevertNamespace is gone with its only caller. wrapSuggest and cliLocal keep reading the active namespace: tab completion has no command to resolve against, and the other two are the interactive prompt.

Also drops four stale `// LOCK:` comments referring to the cmdLock bed39328 removed.

## Motivation and context ##
`namespace <name> <command>` set the process-global active namespace, ran the subcommand, and set it back. That was safe while a package-level cmdLock serialized every command, but bed39328 ("Use channel instead of mutex to serialize cli and meshage commands") replaced that mutex with cmdChannel and cmdProcessor's `go func(cmd commands)`, so commands now run concurrently and each wrapper resolves its namespace by reading that same global. Two clients issuing `namespace a ...` and `namespace b ...` at the same time therefore read each other's namespace. 

## Testing ##
Using phenix I ran 5 experiments in parallel with heavy concurrent miniccc usage (scorch). Simultaneously I started and stopped a large experiment.

## Checklist ##
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->
- [X] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [X] I have included no proprietary/sensitive information in my code. 
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [ ] All GitHub Actions are passing.

## Additional Notes ##
This diff is AI generated, human reviewed and tested.