### PR TITLE
fix(ron): track Once command delivery per client

### DIFF
--- a/internal/ron/command.go
+++ b/internal/ron/command.go
@@ -67,8 +67,11 @@ type Command struct {
 	// once, or if it should be sent after client reconnections.
 	Once bool
 
-	// Sent tracks whether or not this command has been sent already. Only used
-	// when Once is enabled.
+	// Sent is deprecated and unused. Once delivery is tracked per client by
+	// the server (Server.onceSent); a single global bool could be consumed by
+	// a send that never reached the client the Filter named, permanently
+	// suppressing the command for its intended target. The field is retained
+	// so the gob type transmitted to miniccc agents is unchanged.
 	Sent bool
 
 	// plumber connections

--- a/internal/ron/once_test.go
+++ b/internal/ron/once_test.go
@@ -1,0 +1,305 @@
+package ron
+
+import (
+	"encoding/gob"
+	"io"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// testClient is a minimal miniccc stand-in: it performs the RON handshake and
+// records every command ID the server sends it.
+type testClient struct {
+	uuid string
+	conn net.Conn
+	enc  *gob.Encoder
+	dec  *gob.Decoder
+
+	got chan int
+}
+
+func newTestClient(t *testing.T, sock, uuid, hostname string) *testClient {
+	t.Helper()
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial %v: %v", sock, err)
+	}
+
+	if _, err := io.WriteString(conn, "RON"); err != nil {
+		t.Fatalf("write magic: %v", err)
+	}
+
+	var buf [3]byte
+	for string(buf[:]) != "RON" {
+		buf[0], buf[1] = buf[1], buf[2]
+		if _, err := conn.Read(buf[2:]); err != nil {
+			t.Fatalf("read magic: %v", err)
+		}
+	}
+
+	c := &testClient{
+		uuid: uuid,
+		conn: conn,
+		enc:  gob.NewEncoder(conn),
+		dec:  gob.NewDecoder(conn),
+		got:  make(chan int, 128),
+	}
+
+	// handshake message
+	m := &Message{
+		Type:    MESSAGE_CLIENT,
+		UUID:    uuid,
+		Version: "v1",
+		Client: &Client{
+			UUID:     uuid,
+			Hostname: hostname,
+			Arch:     "amd64",
+			OS:       "linux",
+			Version:  "v1",
+		},
+	}
+	if err := c.enc.Encode(m); err != nil {
+		t.Fatalf("handshake encode: %v", err)
+	}
+
+	// server echoes the handshake back
+	var ack Message
+	if err := c.dec.Decode(&ack); err != nil {
+		t.Fatalf("handshake decode: %v", err)
+	}
+
+	t.Cleanup(func() { _ = conn.Close() })
+
+	go func() {
+		for {
+			var m Message
+			if err := c.dec.Decode(&m); err != nil {
+				close(c.got)
+				return
+			}
+
+			if m.Type != MESSAGE_COMMAND {
+				continue
+			}
+
+			for id := range m.Commands {
+				c.got <- id
+			}
+		}
+	}()
+
+	return c
+}
+
+// received drains everything the client has been sent so far.
+func (c *testClient) received(d time.Duration) []int {
+	var ids []int
+
+	deadline := time.After(d)
+	for {
+		select {
+		case id, ok := <-c.got:
+			if !ok {
+				return ids
+			}
+			ids = append(ids, id)
+		case <-deadline:
+			return ids
+		}
+	}
+}
+
+func contains(ids []int, want int) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// newTestServer returns a ron server listening on a unix socket. It is torn
+// down by closing the listener only -- Server.Destroy blocks until every client
+// disconnects, which is not what these tests want.
+func newTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	s, err := NewServer(dir, "", nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	s.UseVMs = false
+
+	sock := filepath.Join(dir, "ron.sock")
+	if err := s.ListenUnix(sock); err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = s.CloseUnix(sock)
+		s.setDestroyed()
+	})
+
+	return s, sock
+}
+
+const (
+	uuidTarget    = "6468268f-97cf-410a-8652-4f84da0b8ce7"
+	uuidBystander = "11111111-2222-3333-4444-555555555555"
+)
+
+// addCommand inserts a command exactly as NewCommand does, but without the
+// asynchronous broadcast, so a test can drive the send ordering itself.
+func addCommand(s *Server, c *Command) int {
+	s.commandLock.Lock()
+	defer s.commandLock.Unlock()
+
+	s.commandCounter++
+	c.ID = s.commandCounter
+	s.commands[c.ID] = c
+
+	return c.ID
+}
+
+// TestOnceNotConsumedByOtherClientHandshake is the observed production failure,
+// with the interleaving forced rather than raced for. A Once command filtered
+// to one VM is created; before NewCommand's broadcast runs, another VM finishes
+// its handshake and clientHandler issues that client's own sendCommands. With a
+// single global Sent bool, that per-client send consumes the command without
+// delivering it to anyone -- the filter does not match the bystander -- and the
+// broadcast then skips it forever.
+func TestOnceNotConsumedByOtherClientHandshake(t *testing.T) {
+	s, sock := newTestServer(t)
+
+	target := newTestClient(t, sock, uuidTarget, "rtr-edge")
+	newTestClient(t, sock, uuidBystander, "bystander")
+
+	// let both handshakes settle
+	time.Sleep(300 * time.Millisecond)
+	target.received(200 * time.Millisecond)
+
+	id := addCommand(s, &Command{
+		Command: []string{"bash", "/tmp/run.sh"},
+		Once:    true,
+		Filter:  &Filter{UUID: uuidTarget},
+	})
+
+	// the bystander's handshake send lands first
+	s.sendCommands(uuidBystander)
+
+	// ...then NewCommand's broadcast
+	s.sendCommands("")
+
+	if ids := target.received(time.Second); !contains(ids, id) {
+		t.Fatalf("target never received Once command %v (got %v) -- it was consumed by a send to a client its filter did not match", id, ids)
+	}
+}
+
+// TestOnceNotResentAfterReconnect is the guard on the documented intent: a
+// client that disconnects and reconnects must not be sent the Once command a
+// second time.
+func TestOnceNotResentAfterReconnect(t *testing.T) {
+	s, sock := newTestServer(t)
+
+	c1 := newTestClient(t, sock, uuidTarget, "rtr-edge")
+
+	s.NewCommand(&Command{
+		Command: []string{"bash", "/tmp/run.sh"},
+		Once:    true,
+		Filter:  &Filter{UUID: uuidTarget},
+	})
+
+	if ids := c1.received(time.Second); !contains(ids, 1) {
+		t.Fatalf("target did not get Once command 1, got %v", ids)
+	}
+
+	// drop the connection and wait for the server to notice
+	_ = c1.conn.Close()
+	for i := 0; i < 100 && s.HasClient(uuidTarget); i++ {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if s.HasClient(uuidTarget) {
+		t.Fatal("server never removed the disconnected client")
+	}
+
+	// same UUID reconnects -- a fresh client struct with maxCommandID == 0
+	c2 := newTestClient(t, sock, uuidTarget, "rtr-edge")
+
+	if ids := c2.received(time.Second); contains(ids, 1) {
+		t.Fatalf("Once command 1 was re-sent after reconnect (got %v)", ids)
+	}
+}
+
+// TestOnceDeliveredToLateJoiner covers the broader-filter case: a Once command
+// that matches several clients must still reach a client that was not yet
+// connected when the command was created.
+func TestOnceDeliveredToLateJoiner(t *testing.T) {
+	s, sock := newTestServer(t)
+
+	early := newTestClient(t, sock, uuidBystander, "early")
+
+	s.NewCommand(&Command{
+		Command: []string{"bash", "/tmp/run.sh"},
+		Once:    true,
+		Filter:  &Filter{OS: "linux"},
+	})
+
+	if ids := early.received(time.Second); !contains(ids, 1) {
+		t.Fatalf("early client did not get Once command 1, got %v", ids)
+	}
+
+	late := newTestClient(t, sock, uuidTarget, "late")
+
+	if ids := late.received(time.Second); !contains(ids, 1) {
+		t.Fatalf("late joiner never received Once command 1 (got %v)", ids)
+	}
+}
+
+// TestClearCommandsResetsOnceRecords guards the ID-reuse hazard: ClearCommands
+// resets the ID counter, so retained delivery records would suppress the new
+// commands that reuse those IDs.
+func TestClearCommandsResetsOnceRecords(t *testing.T) {
+	s, sock := newTestServer(t)
+
+	c := newTestClient(t, sock, uuidTarget, "rtr-edge")
+
+	s.NewCommand(&Command{Command: []string{"first"}, Once: true, Filter: &Filter{UUID: uuidTarget}})
+	if ids := c.received(time.Second); !contains(ids, 1) {
+		t.Fatalf("did not get first Once command, got %v", ids)
+	}
+
+	s.ClearCommands()
+
+	// new command reuses ID 1
+	s.NewCommand(&Command{Command: []string{"second"}, Once: true, Filter: &Filter{UUID: uuidTarget}})
+	if ids := c.received(time.Second); !contains(ids, 1) {
+		t.Fatalf("Once command reusing ID 1 after ClearCommands was suppressed (got %v)", ids)
+	}
+}
+
+// TestDeleteCommandFreesOnceRecords checks the cleanup path.
+func TestDeleteCommandFreesOnceRecords(t *testing.T) {
+	s, sock := newTestServer(t)
+
+	c := newTestClient(t, sock, uuidTarget, "rtr-edge")
+
+	id := s.NewCommand(&Command{Command: []string{"x"}, Once: true, Filter: &Filter{UUID: uuidTarget}})
+	c.received(500 * time.Millisecond)
+
+	if !s.onceDelivered(id, uuidTarget) {
+		t.Fatal("delivery was not recorded")
+	}
+
+	if err := s.DeleteCommand(id); err != nil {
+		t.Fatalf("DeleteCommand: %v", err)
+	}
+
+	if s.onceDelivered(id, uuidTarget) {
+		t.Fatal("delivery record leaked after DeleteCommand")
+	}
+}

--- a/internal/ron/server.go
+++ b/internal/ron/server.go
@@ -57,6 +57,24 @@ type Server struct {
 	vms        map[string]VM      // map of uuid -> VM
 	clientLock sync.Mutex         // lock for clients and vms
 
+	// onceSent records, per Once command ID, the set of client UUIDs that the
+	// command has actually been written to. It replaces Command.Sent as the
+	// gate for Once delivery: Sent was a single global bool, so a send that
+	// never reached the client named by the command's Filter (a concurrent
+	// per-client send during another client's handshake, a client that was not
+	// yet in s.clients, or a failed write) would consume the command for
+	// everyone and the intended target would never receive it.
+	//
+	// Entries deliberately outlive the client: they are NOT removed by
+	// removeClient or the reaper, which is what keeps a rebooted VM from
+	// re-running a Once command. They are freed when the command they refer to
+	// is deleted or when the command list is cleared.
+	onceSent map[int]map[string]bool
+	// onceSentLock synchronizes access to onceSent. It is a separate lock
+	// because onceSent is read and written from the parallel per-client
+	// goroutines in route, which run while clientLock is held.
+	onceSentLock sync.Mutex
+
 	path string // path for serving files
 
 	// subpath is an optional path parameter that will always be used when
@@ -82,6 +100,7 @@ func NewServer(path, subpath string, plumber *miniplumber.Plumber) (*Server, err
 		conns:         make(map[string]net.Conn),
 		listeners:     make(map[string]net.Listener),
 		commands:      make(map[int]*Command),
+		onceSent:      make(map[int]map[string]bool),
 		clients:       make(map[string]*client),
 		vms:           make(map[string]VM),
 		path:          path,
@@ -488,6 +507,7 @@ func (s *Server) DeleteCommand(id int) error {
 
 	if _, ok := s.commands[id]; ok {
 		delete(s.commands, id)
+		s.forgetOnce(id)
 		return nil
 	} else {
 		return fmt.Errorf("command %v not found", id)
@@ -507,6 +527,7 @@ func (s *Server) DeleteCommands(prefix string) error {
 		if c.Prefix == prefix {
 			matched = true
 			delete(s.commands, id)
+			s.forgetOnce(id)
 		}
 	}
 
@@ -530,6 +551,11 @@ func (s *Server) ClearCommands() {
 
 	s.commandCounter = 0
 	s.commands = make(map[int]*Command)
+
+	// The ID counter is reset, so command IDs are about to be reused. Any
+	// retained Once delivery records would silently suppress the *new*
+	// commands that reuse those IDs, so they must all go.
+	s.forgetAllOnce()
 
 	for _, c := range s.clients {
 		c.maxCommandID = 0
@@ -928,6 +954,11 @@ func (s *Server) removeClient(uuid string) {
 		close(c.cancelHeartbeat)
 
 		delete(s.clients, uuid)
+
+		// note: s.onceSent is intentionally left alone. A Once command must
+		// not be re-sent to this UUID if it reconnects, so its delivery record
+		// has to outlive the connection. The records are freed when the
+		// commands themselves are deleted or cleared.
 	}
 }
 
@@ -943,14 +974,65 @@ func (s *Server) sendCommands(uuid string) {
 		UUID:     uuid,
 	}
 
+	// Include every command, Once or not. Whether a Once command still needs
+	// to go to a particular client is decided per client in route, which is
+	// the only place that knows both the client and the command's Filter.
+	// Filtering here on a single global Sent bool cannot be correct: the
+	// message built here may be routed to one client (during that client's
+	// handshake) or to every client, and in neither case does inclusion in the
+	// message imply delivery to the client the Filter names.
 	for k, v := range s.commands {
-		if !v.Once || !v.Sent {
-			m.Commands[k] = v.Copy()
-			v.Sent = true
-		}
+		m.Commands[k] = v.Copy()
 	}
 
 	s.route(m)
+}
+
+// onceDelivered reports whether the Once command with the given ID has already
+// been written to the client with the given UUID.
+func (s *Server) onceDelivered(id int, uuid string) bool {
+	s.onceSentLock.Lock()
+	defer s.onceSentLock.Unlock()
+
+	return s.onceSent[id][uuid]
+}
+
+// markOnceDelivered records that the Once commands with the given IDs were
+// successfully written to the client with the given UUID.
+func (s *Server) markOnceDelivered(ids []int, uuid string) {
+	if len(ids) == 0 {
+		return
+	}
+
+	s.onceSentLock.Lock()
+	defer s.onceSentLock.Unlock()
+
+	for _, id := range ids {
+		if s.onceSent[id] == nil {
+			s.onceSent[id] = make(map[string]bool)
+		}
+
+		s.onceSent[id][uuid] = true
+	}
+}
+
+// forgetOnce drops the delivery records for commands that no longer exist.
+// Callers must hold commandLock.
+func (s *Server) forgetOnce(ids ...int) {
+	s.onceSentLock.Lock()
+	defer s.onceSentLock.Unlock()
+
+	for _, id := range ids {
+		delete(s.onceSent, id)
+	}
+}
+
+// forgetAllOnce drops every delivery record. Callers must hold commandLock.
+func (s *Server) forgetAllOnce() {
+	s.onceSentLock.Lock()
+	defer s.onceSentLock.Unlock()
+
+	s.onceSent = make(map[int]map[string]bool)
 }
 
 // NewFilesSendCommand creates a command to send to clients to read the listed
@@ -1025,9 +1107,13 @@ func (s *Server) sendFile(c *client, filename string) error {
 // route an outgoing message to one or all clients, according to UUID
 func (s *Server) route(m *Message) {
 	var maxCommandID int
-	for i := range m.Commands {
+	var hasOnce bool
+	for i, cmd := range m.Commands {
 		if i > maxCommandID {
 			maxCommandID = i
+		}
+		if cmd.Once {
+			hasOnce = true
 		}
 	}
 
@@ -1041,10 +1127,19 @@ func (s *Server) route(m *Message) {
 			return
 		}
 
-		if c.maxCommandID == maxCommandID {
+		// The command ID watermark alone cannot decide this when Once commands
+		// are in play: it advances to the highest ID in the message even for
+		// commands this client did not match, so a client can be at the
+		// watermark and still be owed a Once command. When there are no Once
+		// commands the old fast path is exact, so keep it.
+		if c.maxCommandID == maxCommandID && !hasOnce {
 			log.Info("no commands for %v", uuid)
 			return
 		}
+
+		// onceIDs collects the Once commands placed in this client's message,
+		// so they can be recorded as delivered only if the write succeeds.
+		var onceIDs []int
 
 		if m.Type == MESSAGE_COMMAND {
 			if s.UseVMs {
@@ -1077,9 +1172,27 @@ func (s *Server) route(m *Message) {
 
 			// filter the commands to relevant ones
 			for i, cmd := range m.Commands {
-				if c.Matches(cmd.Filter) && i > c.maxCommandID {
-					m2.Commands[i] = cmd
+				if !c.Matches(cmd.Filter) {
+					continue
 				}
+
+				if cmd.Once {
+					// Once commands are gated on the per-client delivery
+					// record instead of the watermark. The watermark is reset
+					// on reconnect (so it cannot enforce Once across
+					// reconnects) and it advances past commands that were
+					// never written to this client (so it wrongly suppresses
+					// them). The record does both jobs correctly.
+					if s.onceDelivered(i, uuid) {
+						continue
+					}
+
+					onceIDs = append(onceIDs, i)
+				} else if i <= c.maxCommandID {
+					continue
+				}
+
+				m2.Commands[i] = cmd
 			}
 
 			c.maxCommandID = maxCommandID
@@ -1098,7 +1211,13 @@ func (s *Server) route(m *Message) {
 			} else {
 				log.Info("unable to send message to %v: %v", uuid, err)
 			}
+
+			// the client never got the message, so do not burn the Once
+			// commands in it -- they must be offered again on reconnect
+			return
 		}
+
+		s.markOnceDelivered(onceIDs, uuid)
 	}
 
 	// handleUUID doesn't modify the clients map so we can allow parallel reads


### PR DESCRIPTION
`Once` delivery was gated on a single global `Command.Sent`, set when the command was copied into an outgoing message rather than when a client actually received it.

Any send would burn it for everyone:

- a handshake catch-up send (`sendCommands(c.UUID)`) for a client the command's `Filter` did not match
- a broadcast that skipped a client not yet in `s.clients`
- a write that failed

The client the `Filter` named then never received the command, and nothing ever reset the flag. `sendCommands` sets `Sent` at message-construction time, but `route` decides delivery per client afterwards — so inclusion in a message never implied delivery to the intended target.

Record delivery per client instead (`Server.onceSent`), and only once the write succeeds. Records outlive the connection, so a reconnecting VM still does not re-run a `Once` command, and are freed when the command is deleted or the command list is cleared (IDs are reused after a reset).

`Command.Sent` is retained but unused so the gob type sent to `miniccc` agents is unchanged.

### Tests

`internal/ron/once_test.go` covers both legs plus the intent guard. Against the parent commit:

```
--- FAIL: TestOnceNotConsumedByOtherClientHandshake
    target never received Once command 1 (got []) -- consumed by a send to a
    client its filter did not match
--- FAIL: TestOnceDeliveredToLateJoiner
    late joiner never received Once command 1 (got [])
```

Both pass with this change. `TestOnceNotResentAfterReconnect` passes before and after, confirming the documented "not re-sent after client reconnections" behaviour is preserved.

### Not addressed here

`c.maxCommandID` is still advanced before `sendMessage`, so a failed write can permanently drop a *non*-`Once` command. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)