### PR TITLE
fix(qemu): fix AHCI disk and hugepage arguments

### DIFF
--- a/cmd/minimega/kvm.go
+++ b/cmd/minimega/kvm.go
@@ -1425,7 +1425,10 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 			}
 
 			args = append(args, "-device")
-			args = append(args, fmt.Sprintf("ide-drive,drive=ahci-drive-%v,bus=ahci.%v", ahciBusSlot, ahciBusSlot))
+			// "ide-drive" was removed in QEMU 6.0; "ide-hd" is the modern
+			// replacement for attaching a disk (as opposed to "ide-cd" for
+			// a CD-ROM) to an AHCI/IDE bus.
+			args = append(args, fmt.Sprintf("ide-hd,drive=ahci-drive-%v,bus=ahci.%v", ahciBusSlot, ahciBusSlot))
 
 			driveParams = fmt.Sprintf("id=ahci-drive-%v,file=%v,media=disk,if=none", ahciBusSlot, path)
 

--- a/cmd/minimega/kvm.go
+++ b/cmd/minimega/kvm.go
@@ -1555,7 +1555,7 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 
 	// hook for hugepage support
 	if vm.hugepagesMountPath != "" {
-		args = append(args, "-mem-info")
+		args = append(args, "-mem-path")
 		args = append(args, vm.hugepagesMountPath)
 	}
 


### PR DESCRIPTION
## Summary

Fix two issues I found while evaluating if minimega could use latest QEMU release.

- use `ide-hd` instead of the removed `ide-drive` device for AHCI disks
- use QEMU's supported `-mem-path` option for hugepage-backed guest memory, instead of the `-mem-path` option, which as far as I can tell never existed.

## Why

`ide-drive` was [deprecated in QEMU 4.2](https://qemu.weilnetz.de/doc/5.2/system/deprecated.html#ide-drive-since-4-2) and removed in QEMU 6.0, preventing AHCI-attached disks from launching on current QEMU versions. 

The hugepage path was passed with the unsupported `-mem-info` option instead of `-mem-path`.

## Validation

Tests pass. I don't have a way to test these codepaths directly on a running experiment.