### PR TITLE
test(vm-net): add test coverage for qinq, defaults, and errors

### DIFF
--- a/cmd/minimega/netconfig_test.go
+++ b/cmd/minimega/netconfig_test.go
@@ -19,11 +19,19 @@ func TestParseNetConfig(t *testing.T) {
 		"foo,virtio-net-pci",
 		"foo,de:ad:be:ef:ca:fe",
 		"foo,de:ad:be:ef:ca:fe,virtio-net-pci",
+		"foo,qinq",
+		"foo,virtio-net-pci,qinq",
+		"foo,de:ad:be:ef:ca:fe,qinq",
+		"foo,de:ad:be:ef:ca:fe,virtio-net-pci,qinq",
 
 		"my_bridge,foo",
 		"my_bridge,foo,virtio-net-pci",
 		"my_bridge,foo,de:ad:be:ef:ca:fe",
 		"my_bridge,foo,de:ad:be:ef:ca:fe,virtio-net-pci",
+		"my_bridge,foo,qinq",
+		"my_bridge,foo,virtio-net-pci,qinq",
+		"my_bridge,foo,de:ad:be:ef:ca:fe,qinq",
+		"my_bridge,foo,de:ad:be:ef:ca:fe,virtio-net-pci,qinq",
 	}
 
 	for _, s := range examples {
@@ -35,6 +43,66 @@ func TestParseNetConfig(t *testing.T) {
 		got := r.String()
 		if got != s {
 			t.Fatalf("unequal: `%v` != `%v`", s, got)
+		}
+	}
+}
+
+// TestParseNetConfigDefaults ensures that ParseNetConfig fills in the
+// default bridge and driver when they are not specified in the netspec,
+// since "vm net add" and "vm config net" both rely on these defaults.
+func TestParseNetConfigDefaults(t *testing.T) {
+	nics := map[string]bool{
+		"e1000":          true,
+		"virtio-net-pci": true,
+	}
+
+	r, err := ParseNetConfig("foo", nics)
+	if err != nil {
+		t.Fatalf("unable to parse `foo`: %v", err)
+	}
+
+	if r.Bridge != DefaultBridge {
+		t.Fatalf("expected default bridge %q, got %q", DefaultBridge, r.Bridge)
+	}
+	if r.Driver != DefaultKVMDriver {
+		t.Fatalf("expected default driver %q, got %q", DefaultKVMDriver, r.Driver)
+	}
+	if r.MAC != "" {
+		t.Fatalf("expected no mac, got %q", r.MAC)
+	}
+	if r.QinQ {
+		t.Fatalf("expected qinq to be false")
+	}
+}
+
+// TestParseNetConfigErrors covers netspecs that should be rejected as
+// malformed, e.g. too many fields or fields that can't be unambiguously
+// disambiguated into bridge/vlan/mac/driver/qinq.
+func TestParseNetConfigErrors(t *testing.T) {
+	nics := map[string]bool{
+		"e1000":          true,
+		"virtio-net-pci": true,
+	}
+
+	examples := []string{
+		// 3 fields: neither qinq, mac, nor driver in the disambiguating
+		// positions
+		"my_bridge,foo,bar",
+		// 4 fields: last two fields aren't a recognized (mac,driver) or
+		// (driver,qinq) or (mac,qinq) combination
+		"my_bridge,foo,bar,baz",
+		"foo,bar,baz,qux",
+		// 5 fields: doesn't match bridge,vlan,mac,driver,qinq
+		"my_bridge,foo,bar,virtio-net-pci,qinq",
+		"my_bridge,foo,de:ad:be:ef:ca:fe,bar,qinq",
+		"my_bridge,foo,de:ad:be:ef:ca:fe,virtio-net-pci,bar",
+		// 6+ fields are always malformed
+		"a,b,c,d,e,f",
+	}
+
+	for _, s := range examples {
+		if _, err := ParseNetConfig(s, nics); err == nil {
+			t.Fatalf("expected error parsing malformed netspec `%v`", s)
 		}
 	}
 }


### PR DESCRIPTION
## Description ##
Expands `cmd/minimega/netconfig_test.go` (`TestParseNetConfig`) with additional coverage for `ParseNetConfig`, the parser backing `vm net add` and `vm config net`:
- qinq round-trips for every existing field-count combination
- new `TestParseNetConfigDefaults`: verifies minimal netspecs (vlan only) get the default bridge/driver filled in, with no MAC/QinQ set
- new `TestParseNetConfigErrors`: verifies malformed netspecs (ambiguous 3/4/5-field combos, 6+ fields) are rejected with an error

No production code was changed.

## Motivation and context ##
Closes #1438. `vm net add` netspec parsing had no tests for its error paths or for default value population, and `qinq` wasn't exercised in the round-trip table.

## Testing ##
`cmd/minimega` requires cgo (libpcap, Linux headers), so tests were run in a `golang:1.24` Linux container with `libpcap-dev` installed:
```
go vet ./cmd/minimega/...   # clean
go test ./cmd/minimega/...  # ok, all tests pass
```
`gofmt -l` reports no issues on the changed file.

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. (not applicable; test-only change)
- [x] I have tested my code using the methods described above.
- [ ] All GitHub Actions are passing. (pending CI run on this PR)

## Additional Notes ##
Full integration coverage of `vm net add` already exists in `tests/vm_add_nic` (minitest requiring real QEMU/KVM); this PR focuses on the previously-uncovered unit-level parsing logic.