### PR TITLE
chore(ci): add tests workflow for GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+on:
+  push:
+  pull_request:
+  workflow_call:
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libpcap-dev
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: ./scripts/test.bash


### PR DESCRIPTION
## Description ##
Adds a GitHub Actions workflow (`.github/workflows/test.yml`) that runs `scripts/test.bash` on `ubuntu-latest`.

## Motivation and context ##
minimega had no CI workflow executing its test suite. This adds automated test coverage on push/PR, matching the pattern of the existing `build.yml`/`deb.yml`/`rpm.yml` workflows.

## Testing ##
The workflow passes wheeee.

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
Considering all the other workflows, I'm rather surprised tests were never being run.
