### PR TITLE
feat(capture): stop packet capture by VM interface

### DIFF
--- a/cmd/minimega/capture.go
+++ b/cmd/minimega/capture.go
@@ -220,14 +220,19 @@ func (c *captures) StopAll() error {
 	})
 }
 
-// StopVM stops capture for VM (wildcard supported).
-func (c *captures) StopVM(s string) error {
+// StopVM stops captures for a VM (wildcard supported for VM name). If iface
+// is non-nil, only the capture for that interface index is stopped; otherwise
+// all captures for the VM are stopped.
+func (c *captures) StopVM(s string, iface *int) error {
 	var found bool
 
 	err := c.stop(func(v capture) bool {
 		switch v := v.(type) {
 		case *pcapVMCapture:
 			r := v.VM.GetName() == s || s == Wildcard
+			if iface != nil {
+				r = r && v.Interface == *iface
+			}
 			found = r || found
 			return r
 		}

--- a/cmd/minimega/capture_cli.go
+++ b/cmd/minimega/capture_cli.go
@@ -35,7 +35,7 @@ var captureCLIHandlers = []minicli.Handler{
 		HelpShort: "capture experiment data for a VM",
 		Patterns: []string{
 			"capture <pcap,> vm <vm name> <interface index> <filename>",
-			"capture <pcap,> <delete,> vm <vm name>",
+			"capture <pcap,> <delete,> vm <vm name> [interface index]",
 		},
 		Call:    wrapVMTargetCLI(cliCaptureVM),
 		Suggest: wrapVMSuggest(VM_ANY_STATE, false),
@@ -79,11 +79,15 @@ capture, use the delete commands:
 	capture netflow delete bridge <bridge>
 	capture pcap delete bridge <bridge>
 	capture pcap delete vm <name>
+	capture pcap delete vm <name> <interface index>
 
 To stop all captures of a particular kind, replace <bridge> or <vm> with "all".
 If a VM has multiple interfaces and there are multiple captures running,
 calling "capture pcap delete vm <name>" stops all the captures for that VM. To
-stop all captures of all types, use "clear capture".
+stop only the capture for a single interface, specify the interface index,
+e.g. "capture pcap delete vm <name> 0" stops the capture for interface 0
+without affecting captures on other interfaces of the same VM. To stop all
+captures of all types, use "clear capture".
 
 Notes with namespaces:
  * Capturing traffic directly from the bridge (as PCAP or netflow) is not
@@ -245,9 +249,19 @@ func cliCaptureVM(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 	iface := c.StringArgs["interface"]
 	fname := c.StringArgs["filename"]
 
-	// stopping capture for one or all VMs
+	// stopping capture for one or all VMs, optionally scoped to a single
+	// interface index
 	if c.BoolArgs["delete"] {
-		return ns.captures.StopVM(name)
+		if iface != "" {
+			num, err := strconv.Atoi(iface)
+			if err != nil {
+				return fmt.Errorf("invalid interface: `%v`", iface)
+			}
+
+			return ns.captures.StopVM(name, &num)
+		}
+
+		return ns.captures.StopVM(name, nil)
 	}
 
 	// capture VM:interface -> pcap

--- a/tests/capture
+++ b/tests/capture
@@ -42,3 +42,21 @@ namespace bar capture
 namespace foo capture pcap vm car 1 /dev/null
 namespace foo capture pcap vm bar 0 /dev/null
 namespace foo capture pcap delete vm bar
+
+# Stop a capture for a single VM interface without affecting the others
+namespace foo vm config net A B
+namespace foo vm launch kvm multi
+namespace foo capture pcap vm multi 0 /dev/null
+namespace foo capture pcap vm multi 1 /dev/null
+namespace foo capture
+namespace foo capture pcap delete vm multi 0
+namespace foo capture
+namespace foo capture pcap delete vm multi 1
+namespace foo capture
+
+# Deleting a nonexistent interface capture should fail
+namespace foo capture pcap vm multi 0 /dev/null
+namespace foo capture pcap delete vm multi 5
+namespace foo capture
+namespace foo capture pcap delete vm multi 0
+namespace foo capture

--- a/tests/capture.want
+++ b/tests/capture.want
@@ -60,3 +60,29 @@ E: no such interface 1 for car
 E: vm not found: bar
 ## namespace foo capture pcap delete vm bar
 E: vm not found: bar
+
+## # Stop a capture for a single VM interface without affecting the others
+## namespace foo vm config net A B
+## namespace foo vm launch kvm multi
+## namespace foo capture pcap vm multi 0 /dev/null
+## namespace foo capture pcap vm multi 1 /dev/null
+## namespace foo capture
+bridge      | type | interface | mode | compress | path
+mega_bridge | pcap | multi:0   |      |          | /dev/null
+mega_bridge | pcap | multi:1   |      |          | /dev/null
+## namespace foo capture pcap delete vm multi 0
+## namespace foo capture
+bridge      | type | interface | mode | compress | path
+mega_bridge | pcap | multi:1   |      |          | /dev/null
+## namespace foo capture pcap delete vm multi 1
+## namespace foo capture
+
+## # Deleting a nonexistent interface capture should fail
+## namespace foo capture pcap vm multi 0 /dev/null
+## namespace foo capture pcap delete vm multi 5
+E: vm not found: multi
+## namespace foo capture
+bridge      | type | interface | mode | compress | path
+mega_bridge | pcap | multi:0   |      |          | /dev/null
+## namespace foo capture pcap delete vm multi 0
+## namespace foo capture


### PR DESCRIPTION
## Description ##
Adds `<interface index>` to `capture pcap delete vm <name>`, allowing a single VM interface's packet capture to be stopped without affecting captures on the VM's other interfaces. 

Example: 

```shell
capture pcap vm router 0 /tmp/pcap0.pcap
capture pcap vm router 1 /tmp/pcap1.pcap
capture pcap delete vm router 0
capture pcap delete vm router 1
```

Adds `captures.StopVMInterface` to implement the interface-scoped stop, and updates the `capture` CLI help text.

## Motivation and context ##
Closes #1447. Previously, `capture pcap delete vm <name>` stopped all captures for a VM, with no way to target a single interface.

## Testing ##

- Tested by hand with creating two captures on a VM, generating traffic on both interfaces, watching size of PCAP files increase, running `capture pcap vm delete <vm> <iface>`, then watching the relevant PCAP stop growing in size. Seems to be working!
- `.want` files are AI's best guess. `./scripts/test.bash` ran on a minimega node just fine.

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
None.