### PR TITLE
feat(minimega): support bare-metal firmware guests

### DIFF
--- a/cmd/miniccc/client.go
+++ b/cmd/miniccc/client.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,7 +44,7 @@ type Process struct {
 }
 
 func NewClient() {
-	client.UUID = getUUID()
+	client.UUID = resolveClientUUID(*f_uuid, getUUID)
 	client.Arch = runtime.GOARCH
 	client.OS = runtime.GOOS
 	client.Version = version.Revision
@@ -52,6 +53,14 @@ func NewClient() {
 
 	client.commandChan = make(chan map[int]*ron.Command, 1024)
 	client.fileChan = make(chan *ron.Message, 1024)
+}
+
+func resolveClientUUID(configured string, discover func() string) string {
+	if uuid := strings.ToLower(strings.TrimSpace(configured)); uuid != "" {
+		return uuid
+	}
+
+	return discover()
 }
 
 func sendMessage(m *ron.Message) error {

--- a/cmd/miniccc/client_test.go
+++ b/cmd/miniccc/client_test.go
@@ -1,0 +1,29 @@
+// Copyright 2015-2023 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import "testing"
+
+func TestResolveClientUUIDUsesOverride(t *testing.T) {
+	discovered := false
+	got := resolveClientUUID(" A5BA6920-5BCF-4022-B8CF-015425F7B05C ", func() string {
+		discovered = true
+		return "unexpected"
+	})
+	if discovered {
+		t.Fatal("UUID discovery ran despite an explicit override")
+	}
+	if want := "a5ba6920-5bcf-4022-b8cf-015425f7b05c"; got != want {
+		t.Fatalf("unexpected UUID: got %q, want %q", got, want)
+	}
+}
+
+func TestResolveClientUUIDDiscoversDefault(t *testing.T) {
+	const want = "3b440429-067f-5b75-a0c3-f436519f8ccb"
+	got := resolveClientUUID("", func() string { return want })
+	if got != want {
+		t.Fatalf("unexpected UUID: got %q, want %q", got, want)
+	}
+}

--- a/cmd/miniccc/main_linux.go
+++ b/cmd/miniccc/main_linux.go
@@ -29,6 +29,7 @@ var (
 	f_parent  = flag.String("parent", "", "parent to connect to (if relay or client)")
 	f_path    = flag.String("path", "/tmp/miniccc", "path to store files in")
 	f_serial  = flag.String("serial", "", "use serial device instead of tcp")
+	f_uuid    = flag.String("uuid", "", "override the client UUID")
 	f_family  = flag.String("family", "tcp", "[tcp,unix] family to dial on")
 	f_tag     = flag.Bool("tag", false, "add a key value tag in minimega for this vm")
 	f_pipe    = flag.String("pipe", "", "read/write to or from a named pipe")

--- a/cmd/miniccc/main_windows.go
+++ b/cmd/miniccc/main_windows.go
@@ -30,6 +30,7 @@ var (
 	f_parent  = flag.String("parent", "", "parent to connect to (if relay or client)")
 	f_path    = flag.String("path", "/tmp/miniccc", "path to store files in")
 	f_serial  = flag.String("serial", "", "use serial device instead of tcp")
+	f_uuid    = flag.String("uuid", "", "override the client UUID")
 	f_family  = flag.String("family", "tcp", "[tcp,unix] family to dial on")
 	f_pipe    = flag.String("pipe", "", "read/write to or from a named pipe")
 	f_install = flag.String("install", "", "install as Windows service ('manual-start' or 'auto-start')")

--- a/cmd/miniccc/mux.go
+++ b/cmd/miniccc/mux.go
@@ -31,7 +31,7 @@ func mux(done chan struct{}) {
 		}
 	}()
 
-	go ron.Trunk(remote, client.UUID, sendMessage)
+	tunnelStarted := false
 
 	// Read messages from gob, mux message to the correct place
 	var err error
@@ -70,6 +70,14 @@ func mux(done chan struct{}) {
 		switch m.Type {
 		case ron.MESSAGE_CLIENT:
 			// ACK of the handshake
+			if client.UUID == "" && m.Client != nil && m.Client.UUID != "" {
+				client.UUID = m.Client.UUID
+				log.Info("adopted serial-bound UUID: %v", client.UUID)
+			}
+			if !tunnelStarted {
+				go ron.Trunk(remote, client.UUID, sendMessage)
+				tunnelStarted = true
+			}
 			log.Info("handshake complete")
 
 			go periodic(done)

--- a/cmd/miniccc/uuid_linux.go
+++ b/cmd/miniccc/uuid_linux.go
@@ -8,19 +8,51 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strings"
 
 	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
 )
 
-func getUUID() string {
-	d, err := ioutil.ReadFile("/sys/devices/virtual/dmi/id/product_uuid")
-	if err != nil {
-		log.Fatal("unable to get UUID: %v", err)
+var linuxUUIDPaths = []string{
+	"/sys/devices/virtual/dmi/id/product_uuid",
+}
+
+func readLinuxUUID(readFile func(string) ([]byte, error)) (string, error) {
+	var errors []string
+	for _, path := range linuxUUIDPaths {
+		d, err := readFile(path)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("%s: %v", path, err))
+			continue
+		}
+
+		uuid := strings.ToLower(strings.Trim(string(d), "\x00 \t\r\n"))
+		if uuid == "" {
+			errors = append(errors, fmt.Sprintf("%s: empty UUID", path))
+			continue
+		}
+
+		return uuid, nil
 	}
 
-	uuid := strings.ToLower(strings.TrimSpace(string(d)))
+	return "", fmt.Errorf("no usable VM UUID source (%s)", strings.Join(errors, "; "))
+}
+
+func getUUID() string {
+	uuid, err := readLinuxUUID(ioutil.ReadFile)
+	if err != nil {
+		if *f_serial == "" {
+			log.Fatal("unable to get UUID: %v", err)
+		}
+		// Serial MiniCCC connections are already bound to a specific VM by the
+		// host. Leave the UUID empty so that the server can return that trusted
+		// identity during the handshake.
+		log.Warn("unable to get UUID locally; requesting serial-bound identity: %v", err)
+		return ""
+	}
+
 	log.Debug("got UUID: %v", uuid)
 
 	return uuid

--- a/cmd/miniccc/uuid_linux.go
+++ b/cmd/miniccc/uuid_linux.go
@@ -8,19 +8,45 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strings"
 
 	log "github.com/sandia-minimega/minimega/v2/pkg/minilog"
 )
 
+var linuxUUIDPaths = []string{
+	"/sys/devices/virtual/dmi/id/product_uuid",
+	"/sys/firmware/qemu_fw_cfg/by_name/opt/falcons/uuid/raw",
+}
+
+func readLinuxUUID(readFile func(string) ([]byte, error)) (string, error) {
+	var errors []string
+	for _, path := range linuxUUIDPaths {
+		d, err := readFile(path)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("%s: %v", path, err))
+			continue
+		}
+
+		uuid := strings.ToLower(strings.Trim(string(d), "\x00 \t\r\n"))
+		if uuid == "" {
+			errors = append(errors, fmt.Sprintf("%s: empty UUID", path))
+			continue
+		}
+
+		return uuid, nil
+	}
+
+	return "", fmt.Errorf("no usable VM UUID source (%s)", strings.Join(errors, "; "))
+}
+
 func getUUID() string {
-	d, err := ioutil.ReadFile("/sys/devices/virtual/dmi/id/product_uuid")
+	uuid, err := readLinuxUUID(ioutil.ReadFile)
 	if err != nil {
 		log.Fatal("unable to get UUID: %v", err)
 	}
 
-	uuid := strings.ToLower(strings.TrimSpace(string(d)))
 	log.Debug("got UUID: %v", uuid)
 
 	return uuid

--- a/cmd/miniccc/uuid_linux_test.go
+++ b/cmd/miniccc/uuid_linux_test.go
@@ -1,0 +1,43 @@
+// Copyright 2015-2023 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestReadLinuxUUID(t *testing.T) {
+	uuid, err := readLinuxUUID(func(path string) ([]byte, error) {
+		if path == linuxUUIDPaths[0] {
+			return []byte("A5BA6920-5BCF-4022-B8CF-015425F7B05C\n"), nil
+		}
+		return nil, errors.New("unexpected fallback")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uuid != "a5ba6920-5bcf-4022-b8cf-015425f7b05c" {
+		t.Fatalf("unexpected UUID: %q", uuid)
+	}
+}
+
+func TestReadLinuxUUIDReportsSourceError(t *testing.T) {
+	_, err := readLinuxUUID(func(path string) ([]byte, error) {
+		return nil, errors.New("not present")
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	for _, path := range linuxUUIDPaths {
+		if !strings.Contains(err.Error(), path) {
+			t.Fatalf("missing path %q in error: %v", path, err)
+		}
+	}
+}

--- a/cmd/miniccc/uuid_linux_test.go
+++ b/cmd/miniccc/uuid_linux_test.go
@@ -1,0 +1,58 @@
+// Copyright 2015-2023 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestReadLinuxUUIDPrefersDMI(t *testing.T) {
+	uuid, err := readLinuxUUID(func(path string) ([]byte, error) {
+		if path == linuxUUIDPaths[0] {
+			return []byte("A5BA6920-5BCF-4022-B8CF-015425F7B05C\n"), nil
+		}
+		return nil, errors.New("unexpected fallback")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uuid != "a5ba6920-5bcf-4022-b8cf-015425f7b05c" {
+		t.Fatalf("unexpected UUID: %q", uuid)
+	}
+}
+
+func TestReadLinuxUUIDFallsBackToQEMUFWCfg(t *testing.T) {
+	uuid, err := readLinuxUUID(func(path string) ([]byte, error) {
+		if path == linuxUUIDPaths[0] {
+			return nil, errors.New("DMI unavailable")
+		}
+		return []byte("54FCF635-B72E-4D4D-9A7A-21830E61935B\x00"), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uuid != "54fcf635-b72e-4d4d-9a7a-21830e61935b" {
+		t.Fatalf("unexpected UUID: %q", uuid)
+	}
+}
+
+func TestReadLinuxUUIDReportsAllSources(t *testing.T) {
+	_, err := readLinuxUUID(func(path string) ([]byte, error) {
+		return nil, errors.New("not present")
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	for _, path := range linuxUUIDPaths {
+		if !strings.Contains(err.Error(), path) {
+			t.Fatalf("missing path %q in error: %v", path, err)
+		}
+	}
+}

--- a/cmd/minimega/kvm.go
+++ b/cmd/minimega/kvm.go
@@ -120,6 +120,26 @@ type KVMConfig struct {
 	// Note: this configuration only applies to KVM-based VMs.
 	Machine string `validate:"validMachine" suggest:"wrapSuggest(suggestMachine)"`
 
+	// Launch QEMU with only the devices required for a bare-metal firmware.
+	// This suppresses the PC-oriented display, VNC, USB, CD-ROM, keyboard,
+	// RTC, PCI bridge, and virtio backchannel devices that minimega normally
+	// adds. QMP, PID tracking, serial sockets, tap networking, and lifecycle
+	// control remain available.
+	//
+	// Bare-metal guests must provide a kernel/firmware image, disable the
+	// MiniCCC backchannel, and explicitly request any serial ports.
+	//
+	// Default: false
+	Baremetal bool
+
+	// Specify a board-integrated NIC model that QEMU does not report through
+	// its device-help output. Bare-metal machines such as mps2-an385 expose their
+	// network controller as part of the board rather than as a PCI device, so
+	// it must be added explicitly to the accepted network-driver set.
+	//
+	// This setting has no effect unless baremetal is enabled.
+	BaremetalNetworkDriver string
+
 	// Specify the serial ports that will be created for the VM to use. Serial
 	// ports specified will be mapped to the VM's /dev/ttySX device, where X
 	// refers to the connected unix socket on the host at
@@ -273,7 +293,7 @@ func (old KVMConfig) Copy() KVMConfig {
 	return res
 }
 
-func (vm *KVMConfig) ReadFieldConfig(r io.Reader, field, namespace string) error {
+func (vm *KVMConfig) ReadFieldConfig(r io.Reader, field, namespace string, _ *VMConfig) error {
 	switch field {
 	case "disks":
 		scanner := bufio.NewScanner(r)
@@ -346,6 +366,30 @@ func (vm *KVMConfig) ReadFieldConfig(r io.Reader, field, namespace string) error
 }
 
 func NewKVM(name, namespace string, config VMConfig) (*KvmVM, error) {
+	if config.Baremetal {
+		if config.KernelPath == "" {
+			return nil, errors.New("bare-metal VMs require a kernel firmware image")
+		}
+		if config.Backchannel {
+			return nil, errors.New("bare-metal VMs do not support the MiniCCC backchannel")
+		}
+		if config.BidirectionalCopyPaste {
+			return nil, errors.New("bare-metal VMs do not support bidirectional copy and paste")
+		}
+		if config.VirtioPorts != "" {
+			return nil, errors.New("bare-metal VMs do not support virtio serial ports")
+		}
+		if config.CdromPath != "" || len(config.Disks) != 0 || config.MigratePath != "" {
+			return nil, errors.New("bare-metal VMs do not support disks, CD-ROMs, or migrated VM state")
+		}
+		if config.TpmSocketPath != "" {
+			return nil, errors.New("bare-metal VMs do not support TPM devices")
+		}
+		if len(config.Networks) != 0 && config.BaremetalNetworkDriver == "" {
+			return nil, errors.New("networked bare-metal VMs require a bare-metal NIC driver")
+		}
+	}
+
 	vm := new(KvmVM)
 
 	vm.BaseVM = NewBaseVM(name, namespace, config)
@@ -553,6 +597,8 @@ func (vm *KVMConfig) String() string {
 	fmt.Fprintf(w, "Serial Ports:\t%v\n", vm.SerialPorts)
 	fmt.Fprintf(w, "Virtio-Serial Ports:\t%v\n", vm.VirtioPorts)
 	fmt.Fprintf(w, "Machine:\t%v\n", vm.Machine)
+	fmt.Fprintf(w, "Bare metal:\t%v\n", vm.Baremetal)
+	fmt.Fprintf(w, "Bare metal network driver:\t%v\n", vm.BaremetalNetworkDriver)
 	fmt.Fprintf(w, "CPU:\t%v\n", vm.CPU)
 	fmt.Fprintf(w, "Cores:\t%v\n", vm.Cores)
 	fmt.Fprintf(w, "Threads:\t%v\n", vm.Threads)
@@ -746,6 +792,10 @@ func (vm *KvmVM) connectQMP() (err error) {
 }
 
 func (vm *KvmVM) connectVNC() error {
+	if vm.Baremetal {
+		return nil
+	}
+
 	l, err := net.Listen("tcp", "")
 	if err != nil {
 		return err
@@ -954,6 +1004,7 @@ func (vm *KvmVM) launch() error {
 
 	var sOut bytes.Buffer
 	var sErr bytes.Buffer
+	var qemuLog *os.File
 
 	vmConfig := VMConfig{BaseConfig: vm.BaseConfig, KVMConfig: vm.KVMConfig}
 
@@ -981,15 +1032,33 @@ func (vm *KvmVM) launch() error {
 		qemu = v
 	}
 
+	stdout := io.Writer(&sOut)
+	stderr := io.Writer(&sErr)
+	if vm.Baremetal {
+		var err error
+		qemuLog, err = os.OpenFile(vm.path("qemu.log"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if err != nil {
+			return vm.setErrorf("unable to create bare-metal QEMU log: %v", err)
+		}
+		stdout = qemuLog
+		stderr = qemuLog
+	}
+
 	cmd := &exec.Cmd{
 		Path:   qemu,
 		Args:   append([]string{qemu}, args...),
-		Stdout: &sOut,
-		Stderr: &sErr,
+		Stdout: stdout,
+		Stderr: stderr,
 	}
 
 	if err := cmd.Start(); err != nil {
+		if qemuLog != nil {
+			qemuLog.Close()
+		}
 		return vm.setErrorf("unable to start qemu: %v %v", err, sErr.String())
+	}
+	if qemuLog != nil {
+		qemuLog.Close()
 	}
 
 	vm.Pid = cmd.Process.Pid
@@ -1320,10 +1389,14 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 	args = append(args, "-m")
 	args = append(args, strconv.FormatUint(vm.Memory, 10))
 
-	args = append(args, "-nographic")
+	if vm.Baremetal {
+		args = append(args, "-display", "none")
+	} else {
+		args = append(args, "-nographic")
 
-	args = append(args, "-vnc")
-	args = append(args, "unix:"+filepath.Join(vmPath, "vnc"))
+		args = append(args, "-vnc")
+		args = append(args, "unix:"+filepath.Join(vmPath, "vnc"))
+	}
 
 	args = append(args, "-smp")
 	smp := strconv.FormatUint(vm.VCPUs, 10)
@@ -1341,26 +1414,28 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 	args = append(args, "-qmp")
 	args = append(args, "unix:"+filepath.Join(vmPath, "qmp")+",server=on")
 
-	args = append(args, "-vga")
-	if vm.Vga == "" {
-		args = append(args, "std")
-	} else {
-		args = append(args, vm.Vga)
-	}
+	if !vm.Baremetal {
+		args = append(args, "-vga")
+		if vm.Vga == "" {
+			args = append(args, "std")
+		} else {
+			args = append(args, vm.Vga)
+		}
 
-	args = append(args, "-rtc")
-	args = append(args, "clock=vm,base=utc")
+		args = append(args, "-rtc")
+		args = append(args, "clock=vm,base=utc")
 
-	// for USB 1.0, creates bus named usb-bus.0
-	args = append(args, "-usb")
-	// create bus for xHCI or EHCI depending on config
-	if vm.UsbUseXHCI {
-		args = append(args, "-device", "qemu-xhci,id=xhci")
-	} else {
-		args = append(args, "-device", "usb-ehci,id=ehci")
+		// for USB 1.0, creates bus named usb-bus.0
+		args = append(args, "-usb")
+		// create bus for xHCI or EHCI depending on config
+		if vm.UsbUseXHCI {
+			args = append(args, "-device", "qemu-xhci,id=xhci")
+		} else {
+			args = append(args, "-device", "usb-ehci,id=ehci")
+		}
+		// this allows absolute pointers in vnc, and works great on android vms
+		args = append(args, "-device", "usb-tablet,bus=usb-bus.0")
 	}
-	// this allows absolute pointers in vnc, and works great on android vms
-	args = append(args, "-device", "usb-tablet,bus=usb-bus.0")
 
 	if vm.TpmSocketPath != "" {
 		args = append(args, "-chardev")
@@ -1376,23 +1451,32 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 		args = append(args, "-chardev")
 		args = append(args, fmt.Sprintf("socket,id=charserial%v,path=%v%v,server=on,wait=off", i, filepath.Join(vmPath, "serial"), i))
 
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("isa-serial,chardev=charserial%v,id=serial%v", i, i))
+		if vm.Baremetal {
+			args = append(args, "-serial")
+			args = append(args, fmt.Sprintf("chardev:charserial%v", i))
+		} else {
+			args = append(args, "-device")
+			args = append(args, fmt.Sprintf("isa-serial,chardev=charserial%v,id=serial%v", i, i))
+		}
 	}
 
 	args = append(args, "-pidfile")
 	args = append(args, filepath.Join(vmPath, "qemu.pid"))
 
-	args = append(args, "-k")
-	args = append(args, "en-us")
+	if !vm.Baremetal {
+		args = append(args, "-k")
+		args = append(args, "en-us")
+	}
 
 	if vm.CPU != "" {
 		args = append(args, "-cpu")
 		args = append(args, vm.CPU)
 	}
 
-	args = append(args, "-net")
-	args = append(args, "none")
+	if !vm.Baremetal || len(vm.Networks) == 0 {
+		args = append(args, "-net")
+		args = append(args, "none")
+	}
 
 	args = append(args, "-S")
 
@@ -1401,17 +1485,19 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 		args = append(args, fmt.Sprintf("exec:cat %v", vm.MigratePath))
 	}
 
-	// put cdrom *before* disks so that it is always connected to ide0 -- this
-	// allows us to use a hardcoded block device name in cdrom eject/change.
-	if vm.CdromPath != "" {
-		args = append(args, "-drive")
-		args = append(args, "file="+vm.CdromPath+",media=cdrom")
-		args = append(args, "-boot")
-		args = append(args, "once=d")
-	} else {
-		// add an empty cdrom
-		args = append(args, "-drive")
-		args = append(args, "media=cdrom")
+	if !vm.Baremetal {
+		// put cdrom *before* disks so that it is always connected to ide0 -- this
+		// allows us to use a hardcoded block device name in cdrom eject/change.
+		if vm.CdromPath != "" {
+			args = append(args, "-drive")
+			args = append(args, "file="+vm.CdromPath+",media=cdrom")
+			args = append(args, "-boot")
+			args = append(args, "once=d")
+		} else {
+			// add an empty cdrom
+			args = append(args, "-drive")
+			args = append(args, "media=cdrom")
+		}
 	}
 
 	// disks
@@ -1471,89 +1557,98 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 	}
 
 	// net
-	var bus, addr int
-	addBus := func() {
-		addr = 1 // start at 1 because 0 is reserved
-		bus++
-		args = append(args, fmt.Sprintf("-device"))
-		args = append(args, fmt.Sprintf("pci-bridge,id=pci.%v,chassis_nr=%v", bus, bus))
-	}
-
-	addBus()
-	for _, net := range vm.Networks {
-		args = append(args, "-netdev")
-		args = append(args, fmt.Sprintf("tap,id=%v,script=no,ifname=%v", net.Tap, net.Tap))
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("driver=%v,netdev=%v,mac=%v,bus=pci.%v,addr=0x%x", net.Driver, net.Tap, net.MAC, bus, addr))
-		addr++
-		if addr == DEV_PER_BUS {
-			addBus()
+	if vm.Baremetal {
+		for _, net := range vm.Networks {
+			args = append(args, "-netdev")
+			args = append(args, fmt.Sprintf("tap,id=%v,script=no,ifname=%v", net.Tap, net.Tap))
+			args = append(args, "-net")
+			args = append(args, fmt.Sprintf("nic,model=%v,netdev=%v,macaddr=%v", net.Driver, net.Tap, net.MAC))
 		}
-	}
-
-	// start at -1 so that the first time we call addVirtioDevice we create port 0
-	virtioPort := -1
-
-	addVirtioDevice := func() {
-		virtioPort++
-
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("virtio-serial-pci,id=virtio-serial%v,bus=pci.%v,addr=0x%x", virtioPort, bus, addr))
-
-		addr++
-		if addr == DEV_PER_BUS { // check to see if we've run out of addr slots on this bus
-			addBus()
-		}
-	}
-
-	// virtio-serial
-	if vm.Backchannel {
-		addVirtioDevice()
-
-		args = append(args, "-chardev")
-		args = append(args, fmt.Sprintf("socket,id=charvserialCC,path=%v,server=on,wait=off", filepath.Join(vmPath, "cc")))
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=charvserialCC,id=charvserialCC,name=cc", virtioPort))
-	}
-
-	if vm.BidirectionalCopyPaste {
-		addVirtioDevice()
-
-		args = append(args, "-chardev")
-		args = append(args, "qemu-vdagent,id=vdagent,clipboard=on")
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=vdagent,name=com.redhat.spice.0", virtioPort))
-	}
-
-	if vm.VirtioPorts != "" {
-		names := []string{}
-
-		v, err := strconv.ParseUint(vm.VirtioPorts, 10, 64)
-		if err == nil {
-			// if the VirtioPorts is an int, assume they want automatically generated names
-			for i := uint64(0); i < v; i++ {
-				names = append(names, "virtio-serial"+strconv.FormatUint(i, 10))
-			}
-		} else {
-			// otherwise, assume they specified a list of names
-			names = strings.Split(vm.VirtioPorts, ",")
+	} else {
+		var bus, addr int
+		addBus := func() {
+			addr = 1 // start at 1 because 0 is reserved
+			bus++
+			args = append(args, fmt.Sprintf("-device"))
+			args = append(args, fmt.Sprintf("pci-bridge,id=pci.%v,chassis_nr=%v", bus, bus))
 		}
 
-		for i, name := range names {
-			if name == "cc" && vm.Backchannel {
-				// TODO: abort?
-				log.Warn("virtio-port name conflicts with miniccc's")
+		addBus()
+		for _, net := range vm.Networks {
+			args = append(args, "-netdev")
+			args = append(args, fmt.Sprintf("tap,id=%v,script=no,ifname=%v", net.Tap, net.Tap))
+			args = append(args, "-device")
+			args = append(args, fmt.Sprintf("driver=%v,netdev=%v,mac=%v,bus=pci.%v,addr=0x%x", net.Driver, net.Tap, net.MAC, bus, addr))
+			addr++
+			if addr == DEV_PER_BUS {
+				addBus()
 			}
+		}
 
-			// If we've maxed out the device, create a new one
-			if i%DEV_PER_VIRTIO == 0 {
-				addVirtioDevice()
+		// start at -1 so that the first time we call addVirtioDevice we create port 0
+		virtioPort := -1
+
+		addVirtioDevice := func() {
+			virtioPort++
+
+			args = append(args, "-device")
+			args = append(args, fmt.Sprintf("virtio-serial-pci,id=virtio-serial%v,bus=pci.%v,addr=0x%x", virtioPort, bus, addr))
+
+			addr++
+			if addr == DEV_PER_BUS { // check to see if we've run out of addr slots on this bus
+				addBus()
 			}
+		}
+
+		// virtio-serial
+		if vm.Backchannel {
+			addVirtioDevice()
 
 			args = append(args, "-chardev")
-			args = append(args, fmt.Sprintf("socket,id=charvserial%v,path=%v%v,server=on,wait=off", i, filepath.Join(vmPath, "virtio-serial"), i))
+			args = append(args, fmt.Sprintf("socket,id=charvserialCC,path=%v,server=on,wait=off", filepath.Join(vmPath, "cc")))
 			args = append(args, "-device")
-			args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=charvserial%v,id=charvserial%v,name=%v", virtioPort, i, i, name))
+			args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=charvserialCC,id=charvserialCC,name=cc", virtioPort))
+		}
+
+		if vm.BidirectionalCopyPaste {
+			addVirtioDevice()
+
+			args = append(args, "-chardev")
+			args = append(args, "qemu-vdagent,id=vdagent,clipboard=on")
+			args = append(args, "-device")
+			args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=vdagent,name=com.redhat.spice.0", virtioPort))
+		}
+
+		if vm.VirtioPorts != "" {
+			names := []string{}
+
+			v, err := strconv.ParseUint(vm.VirtioPorts, 10, 64)
+			if err == nil {
+				// if the VirtioPorts is an int, assume they want automatically generated names
+				for i := uint64(0); i < v; i++ {
+					names = append(names, "virtio-serial"+strconv.FormatUint(i, 10))
+				}
+			} else {
+				// otherwise, assume they specified a list of names
+				names = strings.Split(vm.VirtioPorts, ",")
+			}
+
+			for i, name := range names {
+				if name == "cc" && vm.Backchannel {
+					// TODO: abort?
+					log.Warn("virtio-port name conflicts with miniccc's")
+				}
+
+				// If we've maxed out the device, create a new one
+				if i%DEV_PER_VIRTIO == 0 {
+					addVirtioDevice()
+				}
+
+				args = append(args, "-chardev")
+				args = append(args, fmt.Sprintf("socket,id=charvserial%v,path=%v%v,server=on,wait=off", i, filepath.Join(vmPath, "virtio-serial"), i))
+				args = append(args, "-device")
+				args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=charvserial%v,id=charvserial%v,name=%v", virtioPort, i, i, name))
+			}
 		}
 	}
 

--- a/cmd/minimega/kvm.go
+++ b/cmd/minimega/kvm.go
@@ -120,6 +120,26 @@ type KVMConfig struct {
 	// Note: this configuration only applies to KVM-based VMs.
 	Machine string `validate:"validMachine" suggest:"wrapSuggest(suggestMachine)"`
 
+	// Launch QEMU with only the devices required for a bare-metal firmware.
+	// This suppresses the PC-oriented display, VNC, USB, CD-ROM, keyboard,
+	// RTC, PCI bridge, and virtio backchannel devices that minimega normally
+	// adds. QMP, PID tracking, serial sockets, tap networking, and lifecycle
+	// control remain available.
+	//
+	// Bare-metal guests must provide a kernel/firmware image, disable the
+	// MiniCCC backchannel, and explicitly request any serial ports.
+	//
+	// Default: false
+	Baremetal bool
+
+	// Specify a board-integrated NIC model that QEMU does not report through
+	// its device-help output. Bare-metal machines such as mps2-an385 expose their
+	// network controller as part of the board rather than as a PCI device, so
+	// it must be added explicitly to the accepted network-driver set.
+	//
+	// This setting has no effect unless baremetal is enabled.
+	BaremetalNetworkDriver string
+
 	// Specify the serial ports that will be created for the VM to use. Serial
 	// ports specified will be mapped to the VM's /dev/ttySX device, where X
 	// refers to the connected unix socket on the host at
@@ -346,6 +366,30 @@ func (vm *KVMConfig) ReadFieldConfig(r io.Reader, field, namespace string) error
 }
 
 func NewKVM(name, namespace string, config VMConfig) (*KvmVM, error) {
+	if config.Baremetal {
+		if config.KernelPath == "" {
+			return nil, errors.New("bare-metal VMs require a kernel firmware image")
+		}
+		if config.Backchannel {
+			return nil, errors.New("bare-metal VMs do not support the MiniCCC backchannel")
+		}
+		if config.BidirectionalCopyPaste {
+			return nil, errors.New("bare-metal VMs do not support bidirectional copy and paste")
+		}
+		if config.VirtioPorts != "" {
+			return nil, errors.New("bare-metal VMs do not support virtio serial ports")
+		}
+		if config.CdromPath != "" || len(config.Disks) != 0 || config.MigratePath != "" {
+			return nil, errors.New("bare-metal VMs do not support disks, CD-ROMs, or migrated VM state")
+		}
+		if config.TpmSocketPath != "" {
+			return nil, errors.New("bare-metal VMs do not support TPM devices")
+		}
+		if len(config.Networks) != 0 && config.BaremetalNetworkDriver == "" {
+			return nil, errors.New("networked bare-metal VMs require a bare-metal NIC driver")
+		}
+	}
+
 	vm := new(KvmVM)
 
 	vm.BaseVM = NewBaseVM(name, namespace, config)
@@ -553,6 +597,8 @@ func (vm *KVMConfig) String() string {
 	fmt.Fprintf(w, "Serial Ports:\t%v\n", vm.SerialPorts)
 	fmt.Fprintf(w, "Virtio-Serial Ports:\t%v\n", vm.VirtioPorts)
 	fmt.Fprintf(w, "Machine:\t%v\n", vm.Machine)
+	fmt.Fprintf(w, "Bare metal:\t%v\n", vm.Baremetal)
+	fmt.Fprintf(w, "Bare metal network driver:\t%v\n", vm.BaremetalNetworkDriver)
 	fmt.Fprintf(w, "CPU:\t%v\n", vm.CPU)
 	fmt.Fprintf(w, "Cores:\t%v\n", vm.Cores)
 	fmt.Fprintf(w, "Threads:\t%v\n", vm.Threads)
@@ -954,6 +1000,7 @@ func (vm *KvmVM) launch() error {
 
 	var sOut bytes.Buffer
 	var sErr bytes.Buffer
+	var qemuLog *os.File
 
 	vmConfig := VMConfig{BaseConfig: vm.BaseConfig, KVMConfig: vm.KVMConfig}
 
@@ -981,15 +1028,33 @@ func (vm *KvmVM) launch() error {
 		qemu = v
 	}
 
+	stdout := io.Writer(&sOut)
+	stderr := io.Writer(&sErr)
+	if vm.Baremetal {
+		var err error
+		qemuLog, err = os.OpenFile(vm.path("qemu.log"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if err != nil {
+			return vm.setErrorf("unable to create bare-metal QEMU log: %v", err)
+		}
+		stdout = qemuLog
+		stderr = qemuLog
+	}
+
 	cmd := &exec.Cmd{
 		Path:   qemu,
 		Args:   append([]string{qemu}, args...),
-		Stdout: &sOut,
-		Stderr: &sErr,
+		Stdout: stdout,
+		Stderr: stderr,
 	}
 
 	if err := cmd.Start(); err != nil {
+		if qemuLog != nil {
+			qemuLog.Close()
+		}
 		return vm.setErrorf("unable to start qemu: %v %v", err, sErr.String())
+	}
+	if qemuLog != nil {
+		qemuLog.Close()
 	}
 
 	vm.Pid = cmd.Process.Pid
@@ -1009,11 +1074,13 @@ func (vm *KvmVM) launch() error {
 
 	go vm.qmpLogger()
 
-	if err := vm.connectVNC(); err != nil {
-		// Failed to connect to vnc so clean up the process
-		cmd.Process.Kill()
+	if !vm.Baremetal {
+		if err := vm.connectVNC(); err != nil {
+			// Failed to connect to vnc so clean up the process
+			cmd.Process.Kill()
 
-		return vm.setErrorf("unable to connect to vnc shim: %v", err)
+			return vm.setErrorf("unable to connect to vnc shim: %v", err)
+		}
 	}
 
 	vm.waitToKill(cmd.Process, waitChan)
@@ -1320,10 +1387,14 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 	args = append(args, "-m")
 	args = append(args, strconv.FormatUint(vm.Memory, 10))
 
-	args = append(args, "-nographic")
+	if vm.Baremetal {
+		args = append(args, "-display", "none")
+	} else {
+		args = append(args, "-nographic")
 
-	args = append(args, "-vnc")
-	args = append(args, "unix:"+filepath.Join(vmPath, "vnc"))
+		args = append(args, "-vnc")
+		args = append(args, "unix:"+filepath.Join(vmPath, "vnc"))
+	}
 
 	args = append(args, "-smp")
 	smp := strconv.FormatUint(vm.VCPUs, 10)
@@ -1341,26 +1412,28 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 	args = append(args, "-qmp")
 	args = append(args, "unix:"+filepath.Join(vmPath, "qmp")+",server=on")
 
-	args = append(args, "-vga")
-	if vm.Vga == "" {
-		args = append(args, "std")
-	} else {
-		args = append(args, vm.Vga)
-	}
+	if !vm.Baremetal {
+		args = append(args, "-vga")
+		if vm.Vga == "" {
+			args = append(args, "std")
+		} else {
+			args = append(args, vm.Vga)
+		}
 
-	args = append(args, "-rtc")
-	args = append(args, "clock=vm,base=utc")
+		args = append(args, "-rtc")
+		args = append(args, "clock=vm,base=utc")
 
-	// for USB 1.0, creates bus named usb-bus.0
-	args = append(args, "-usb")
-	// create bus for xHCI or EHCI depending on config
-	if vm.UsbUseXHCI {
-		args = append(args, "-device", "qemu-xhci,id=xhci")
-	} else {
-		args = append(args, "-device", "usb-ehci,id=ehci")
+		// for USB 1.0, creates bus named usb-bus.0
+		args = append(args, "-usb")
+		// create bus for xHCI or EHCI depending on config
+		if vm.UsbUseXHCI {
+			args = append(args, "-device", "qemu-xhci,id=xhci")
+		} else {
+			args = append(args, "-device", "usb-ehci,id=ehci")
+		}
+		// this allows absolute pointers in vnc, and works great on android vms
+		args = append(args, "-device", "usb-tablet,bus=usb-bus.0")
 	}
-	// this allows absolute pointers in vnc, and works great on android vms
-	args = append(args, "-device", "usb-tablet,bus=usb-bus.0")
 
 	if vm.TpmSocketPath != "" {
 		args = append(args, "-chardev")
@@ -1376,23 +1449,32 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 		args = append(args, "-chardev")
 		args = append(args, fmt.Sprintf("socket,id=charserial%v,path=%v%v,server=on,wait=off", i, filepath.Join(vmPath, "serial"), i))
 
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("isa-serial,chardev=charserial%v,id=serial%v", i, i))
+		if vm.Baremetal {
+			args = append(args, "-serial")
+			args = append(args, fmt.Sprintf("chardev:charserial%v", i))
+		} else {
+			args = append(args, "-device")
+			args = append(args, fmt.Sprintf("isa-serial,chardev=charserial%v,id=serial%v", i, i))
+		}
 	}
 
 	args = append(args, "-pidfile")
 	args = append(args, filepath.Join(vmPath, "qemu.pid"))
 
-	args = append(args, "-k")
-	args = append(args, "en-us")
+	if !vm.Baremetal {
+		args = append(args, "-k")
+		args = append(args, "en-us")
+	}
 
 	if vm.CPU != "" {
 		args = append(args, "-cpu")
 		args = append(args, vm.CPU)
 	}
 
-	args = append(args, "-net")
-	args = append(args, "none")
+	if !vm.Baremetal || len(vm.Networks) == 0 {
+		args = append(args, "-net")
+		args = append(args, "none")
+	}
 
 	args = append(args, "-S")
 
@@ -1403,7 +1485,9 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 
 	// put cdrom *before* disks so that it is always connected to ide0 -- this
 	// allows us to use a hardcoded block device name in cdrom eject/change.
-	if vm.CdromPath != "" {
+	if vm.Baremetal {
+		// Firmware guests do not have an implicit storage controller.
+	} else if vm.CdromPath != "" {
 		args = append(args, "-drive")
 		args = append(args, "file="+vm.CdromPath+",media=cdrom")
 		args = append(args, "-boot")
@@ -1471,89 +1555,98 @@ func (vm VMConfig) qemuArgs(id int, vmPath string) []string {
 	}
 
 	// net
-	var bus, addr int
-	addBus := func() {
-		addr = 1 // start at 1 because 0 is reserved
-		bus++
-		args = append(args, fmt.Sprintf("-device"))
-		args = append(args, fmt.Sprintf("pci-bridge,id=pci.%v,chassis_nr=%v", bus, bus))
-	}
-
-	addBus()
-	for _, net := range vm.Networks {
-		args = append(args, "-netdev")
-		args = append(args, fmt.Sprintf("tap,id=%v,script=no,ifname=%v", net.Tap, net.Tap))
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("driver=%v,netdev=%v,mac=%v,bus=pci.%v,addr=0x%x", net.Driver, net.Tap, net.MAC, bus, addr))
-		addr++
-		if addr == DEV_PER_BUS {
-			addBus()
+	if vm.Baremetal {
+		for _, net := range vm.Networks {
+			args = append(args, "-netdev")
+			args = append(args, fmt.Sprintf("tap,id=%v,script=no,ifname=%v", net.Tap, net.Tap))
+			args = append(args, "-net")
+			args = append(args, fmt.Sprintf("nic,model=%v,netdev=%v,macaddr=%v", net.Driver, net.Tap, net.MAC))
 		}
-	}
-
-	// start at -1 so that the first time we call addVirtioDevice we create port 0
-	virtioPort := -1
-
-	addVirtioDevice := func() {
-		virtioPort++
-
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("virtio-serial-pci,id=virtio-serial%v,bus=pci.%v,addr=0x%x", virtioPort, bus, addr))
-
-		addr++
-		if addr == DEV_PER_BUS { // check to see if we've run out of addr slots on this bus
-			addBus()
-		}
-	}
-
-	// virtio-serial
-	if vm.Backchannel {
-		addVirtioDevice()
-
-		args = append(args, "-chardev")
-		args = append(args, fmt.Sprintf("socket,id=charvserialCC,path=%v,server=on,wait=off", filepath.Join(vmPath, "cc")))
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=charvserialCC,id=charvserialCC,name=cc", virtioPort))
-	}
-
-	if vm.BidirectionalCopyPaste {
-		addVirtioDevice()
-
-		args = append(args, "-chardev")
-		args = append(args, "qemu-vdagent,id=vdagent,clipboard=on")
-		args = append(args, "-device")
-		args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=vdagent,name=com.redhat.spice.0", virtioPort))
-	}
-
-	if vm.VirtioPorts != "" {
-		names := []string{}
-
-		v, err := strconv.ParseUint(vm.VirtioPorts, 10, 64)
-		if err == nil {
-			// if the VirtioPorts is an int, assume they want automatically generated names
-			for i := uint64(0); i < v; i++ {
-				names = append(names, "virtio-serial"+strconv.FormatUint(i, 10))
-			}
-		} else {
-			// otherwise, assume they specified a list of names
-			names = strings.Split(vm.VirtioPorts, ",")
+	} else {
+		var bus, addr int
+		addBus := func() {
+			addr = 1 // start at 1 because 0 is reserved
+			bus++
+			args = append(args, fmt.Sprintf("-device"))
+			args = append(args, fmt.Sprintf("pci-bridge,id=pci.%v,chassis_nr=%v", bus, bus))
 		}
 
-		for i, name := range names {
-			if name == "cc" && vm.Backchannel {
-				// TODO: abort?
-				log.Warn("virtio-port name conflicts with miniccc's")
+		addBus()
+		for _, net := range vm.Networks {
+			args = append(args, "-netdev")
+			args = append(args, fmt.Sprintf("tap,id=%v,script=no,ifname=%v", net.Tap, net.Tap))
+			args = append(args, "-device")
+			args = append(args, fmt.Sprintf("driver=%v,netdev=%v,mac=%v,bus=pci.%v,addr=0x%x", net.Driver, net.Tap, net.MAC, bus, addr))
+			addr++
+			if addr == DEV_PER_BUS {
+				addBus()
 			}
+		}
 
-			// If we've maxed out the device, create a new one
-			if i%DEV_PER_VIRTIO == 0 {
-				addVirtioDevice()
+		// start at -1 so that the first time we call addVirtioDevice we create port 0
+		virtioPort := -1
+
+		addVirtioDevice := func() {
+			virtioPort++
+
+			args = append(args, "-device")
+			args = append(args, fmt.Sprintf("virtio-serial-pci,id=virtio-serial%v,bus=pci.%v,addr=0x%x", virtioPort, bus, addr))
+
+			addr++
+			if addr == DEV_PER_BUS { // check to see if we've run out of addr slots on this bus
+				addBus()
 			}
+		}
+
+		// virtio-serial
+		if vm.Backchannel {
+			addVirtioDevice()
 
 			args = append(args, "-chardev")
-			args = append(args, fmt.Sprintf("socket,id=charvserial%v,path=%v%v,server=on,wait=off", i, filepath.Join(vmPath, "virtio-serial"), i))
+			args = append(args, fmt.Sprintf("socket,id=charvserialCC,path=%v,server=on,wait=off", filepath.Join(vmPath, "cc")))
 			args = append(args, "-device")
-			args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=charvserial%v,id=charvserial%v,name=%v", virtioPort, i, i, name))
+			args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=charvserialCC,id=charvserialCC,name=cc", virtioPort))
+		}
+
+		if vm.BidirectionalCopyPaste {
+			addVirtioDevice()
+
+			args = append(args, "-chardev")
+			args = append(args, "qemu-vdagent,id=vdagent,clipboard=on")
+			args = append(args, "-device")
+			args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=vdagent,name=com.redhat.spice.0", virtioPort))
+		}
+
+		if vm.VirtioPorts != "" {
+			names := []string{}
+
+			v, err := strconv.ParseUint(vm.VirtioPorts, 10, 64)
+			if err == nil {
+				// if the VirtioPorts is an int, assume they want automatically generated names
+				for i := uint64(0); i < v; i++ {
+					names = append(names, "virtio-serial"+strconv.FormatUint(i, 10))
+				}
+			} else {
+				// otherwise, assume they specified a list of names
+				names = strings.Split(vm.VirtioPorts, ",")
+			}
+
+			for i, name := range names {
+				if name == "cc" && vm.Backchannel {
+					// TODO: abort?
+					log.Warn("virtio-port name conflicts with miniccc's")
+				}
+
+				// If we've maxed out the device, create a new one
+				if i%DEV_PER_VIRTIO == 0 {
+					addVirtioDevice()
+				}
+
+				args = append(args, "-chardev")
+				args = append(args, fmt.Sprintf("socket,id=charvserial%v,path=%v%v,server=on,wait=off", i, filepath.Join(vmPath, "virtio-serial"), i))
+				args = append(args, "-device")
+				args = append(args, fmt.Sprintf("virtserialport,bus=virtio-serial%v.0,chardev=charvserial%v,id=charvserial%v,name=%v", virtioPort, i, i, name))
+			}
 		}
 	}
 

--- a/cmd/minimega/kvm_baremetal_test.go
+++ b/cmd/minimega/kvm_baremetal_test.go
@@ -1,0 +1,141 @@
+// Copyright (2012) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func hasArgSequence(args []string, want ...string) bool {
+	for i := 0; i+len(want) <= len(args); i++ {
+		match := true
+		for j := range want {
+			if args[i+j] != want[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBaremetalQemuArgs(t *testing.T) {
+	c := NewVMConfig()
+	c.Baremetal = true
+	c.Backchannel = false
+	c.Memory = 16
+	c.VCPUs = 1
+	c.Machine = "mps2-an385"
+	c.CPU = "cortex-m3"
+	c.KernelPath = "/firmware/RTOSDemo.out"
+	c.SerialPorts = 1
+	c.UUID = "11111111-2222-3333-4444-555555555555"
+
+	args := c.qemuArgs(7, "/tmp/minimega/7")
+	for _, seq := range [][]string{
+		{"-display", "none"},
+		{"-M", "mps2-an385"},
+		{"-cpu", "cortex-m3"},
+		{"-kernel", "/firmware/RTOSDemo.out"},
+		{"-serial", "chardev:charserial0"},
+		{"-qmp", "unix:/tmp/minimega/7/qmp,server=on"},
+		{"-net", "none"},
+	} {
+		if !hasArgSequence(args, seq...) {
+			t.Errorf("missing argument sequence %q in %q", seq, args)
+		}
+	}
+
+	joined := strings.Join(args, " ")
+	for _, forbidden := range []string{"-vnc", "-vga", "-usb", "usb-tablet", "pci-bridge", "media=cdrom", "isa-serial"} {
+		if strings.Contains(joined, forbidden) {
+			t.Errorf("bare-metal arguments contain %q: %s", forbidden, joined)
+		}
+	}
+}
+
+func TestBaremetalNetworkUsesBoardNIC(t *testing.T) {
+	c := NewVMConfig()
+	c.Baremetal = true
+	c.Backchannel = false
+	c.BaremetalNetworkDriver = "lan9118"
+	c.KernelPath = "/firmware/RTOSDemo.out"
+	c.Networks = NetConfigs{{
+		Tap:    "mega_tap0",
+		MAC:    "52:54:00:12:34:ad",
+		Driver: "lan9118",
+	}}
+
+	args := c.qemuArgs(8, "/tmp/minimega/8")
+	if !hasArgSequence(args, "-netdev", "tap,id=mega_tap0,script=no,ifname=mega_tap0") {
+		t.Fatalf("missing bare-metal tap arguments: %q", args)
+	}
+	if !hasArgSequence(args, "-net", "nic,model=lan9118,netdev=mega_tap0,macaddr=52:54:00:12:34:ad") {
+		t.Fatalf("missing bare-metal NIC arguments: %q", args)
+	}
+	if hasArgSequence(args, "-net", "none") {
+		t.Fatalf("networked bare-metal VM unexpectedly disables networking: %q", args)
+	}
+	if strings.Contains(strings.Join(args, " "), "pci-bridge") {
+		t.Fatalf("bare-metal network unexpectedly uses PCI: %q", args)
+	}
+}
+
+func TestBaremetalValidation(t *testing.T) {
+	c := NewVMConfig()
+	c.Baremetal = true
+	c.Backchannel = false
+	if _, err := NewKVM("freertos", "test", c); err == nil || !strings.Contains(err.Error(), "firmware") {
+		t.Fatalf("expected missing firmware error, got %v", err)
+	}
+
+	c.KernelPath = "/firmware/RTOSDemo.out"
+	c.Backchannel = true
+	if _, err := NewKVM("freertos", "test", c); err == nil || !strings.Contains(err.Error(), "backchannel") {
+		t.Fatalf("expected backchannel error, got %v", err)
+	}
+
+	c.Backchannel = false
+	c.Networks = NetConfigs{{Driver: "lan9118"}}
+	if _, err := NewKVM("freertos", "test", c); err == nil || !strings.Contains(err.Error(), "NIC driver") {
+		t.Fatalf("expected missing bare-metal NIC driver error, got %v", err)
+	}
+}
+
+func TestBaremetalSkipsVNC(t *testing.T) {
+	vm := &KvmVM{KVMConfig: KVMConfig{Baremetal: true}}
+	if err := vm.connectVNC(); err != nil {
+		t.Fatal(err)
+	}
+	if vm.vncShim != nil || vm.VNCPort != 0 {
+		t.Fatalf("bare-metal VM created a VNC shim: listener=%v port=%d", vm.vncShim, vm.VNCPort)
+	}
+}
+
+func TestBaremetalConfigReadPreservesBoardNIC(t *testing.T) {
+	const saved = `vm config qemu minimega-test-qemu-not-found
+vm config machine mps2-an385
+vm config kernel /firmware/RTOSDemo.out
+vm config baremetal true
+vm config baremetal-network-driver lan9118
+vm config backchannel false
+vm config networks 378,52:54:00:12:34:ad,lan9118
+`
+
+	c := NewVMConfig()
+	if err := c.ReadConfig(strings.NewReader(saved), "test-baremetal-config-read"); err != nil {
+		t.Fatal(err)
+	}
+	if len(c.Networks) != 1 {
+		t.Fatalf("expected one restored network, got %d", len(c.Networks))
+	}
+	if got := c.Networks[0].Driver; got != "lan9118" {
+		t.Fatalf("unexpected restored network driver: %q", got)
+	}
+}

--- a/cmd/minimega/kvm_baremetal_test.go
+++ b/cmd/minimega/kvm_baremetal_test.go
@@ -1,0 +1,109 @@
+// Copyright (2012) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func hasArgSequence(args []string, want ...string) bool {
+	for i := 0; i+len(want) <= len(args); i++ {
+		match := true
+		for j := range want {
+			if args[i+j] != want[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBaremetalQemuArgs(t *testing.T) {
+	c := NewVMConfig()
+	c.Baremetal = true
+	c.Backchannel = false
+	c.Memory = 16
+	c.VCPUs = 1
+	c.Machine = "mps2-an385"
+	c.CPU = "cortex-m3"
+	c.KernelPath = "/firmware/RTOSDemo.out"
+	c.SerialPorts = 1
+	c.UUID = "11111111-2222-3333-4444-555555555555"
+
+	args := c.qemuArgs(7, "/tmp/minimega/7")
+	for _, seq := range [][]string{
+		{"-display", "none"},
+		{"-M", "mps2-an385"},
+		{"-cpu", "cortex-m3"},
+		{"-kernel", "/firmware/RTOSDemo.out"},
+		{"-serial", "chardev:charserial0"},
+		{"-qmp", "unix:/tmp/minimega/7/qmp,server=on"},
+		{"-net", "none"},
+	} {
+		if !hasArgSequence(args, seq...) {
+			t.Errorf("missing argument sequence %q in %q", seq, args)
+		}
+	}
+
+	joined := strings.Join(args, " ")
+	for _, forbidden := range []string{"-vnc", "-vga", "-usb", "usb-tablet", "pci-bridge", "media=cdrom", "isa-serial"} {
+		if strings.Contains(joined, forbidden) {
+			t.Errorf("bare-metal arguments contain %q: %s", forbidden, joined)
+		}
+	}
+}
+
+func TestBaremetalNetworkUsesBoardNIC(t *testing.T) {
+	c := NewVMConfig()
+	c.Baremetal = true
+	c.Backchannel = false
+	c.BaremetalNetworkDriver = "lan9118"
+	c.KernelPath = "/firmware/RTOSDemo.out"
+	c.Networks = NetConfigs{{
+		Tap:    "mega_tap0",
+		MAC:    "52:54:00:12:34:ad",
+		Driver: "lan9118",
+	}}
+
+	args := c.qemuArgs(8, "/tmp/minimega/8")
+	if !hasArgSequence(args, "-netdev", "tap,id=mega_tap0,script=no,ifname=mega_tap0") {
+		t.Fatalf("missing bare-metal tap arguments: %q", args)
+	}
+	if !hasArgSequence(args, "-net", "nic,model=lan9118,netdev=mega_tap0,macaddr=52:54:00:12:34:ad") {
+		t.Fatalf("missing bare-metal NIC arguments: %q", args)
+	}
+	if hasArgSequence(args, "-net", "none") {
+		t.Fatalf("networked bare-metal VM unexpectedly disables networking: %q", args)
+	}
+	if strings.Contains(strings.Join(args, " "), "pci-bridge") {
+		t.Fatalf("bare-metal network unexpectedly uses PCI: %q", args)
+	}
+}
+
+func TestBaremetalValidation(t *testing.T) {
+	c := NewVMConfig()
+	c.Baremetal = true
+	c.Backchannel = false
+	if _, err := NewKVM("freertos", "test", c); err == nil || !strings.Contains(err.Error(), "firmware") {
+		t.Fatalf("expected missing firmware error, got %v", err)
+	}
+
+	c.KernelPath = "/firmware/RTOSDemo.out"
+	c.Backchannel = true
+	if _, err := NewKVM("freertos", "test", c); err == nil || !strings.Contains(err.Error(), "backchannel") {
+		t.Fatalf("expected backchannel error, got %v", err)
+	}
+
+	c.Backchannel = false
+	c.Networks = NetConfigs{{Driver: "lan9118"}}
+	if _, err := NewKVM("freertos", "test", c); err == nil || !strings.Contains(err.Error(), "NIC driver") {
+		t.Fatalf("expected missing bare-metal NIC driver error, got %v", err)
+	}
+}

--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -17,7 +17,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sandia-minimega/minimega/v2/internal/qemu"
 	"github.com/sandia-minimega/minimega/v2/internal/ron"
 	"github.com/sandia-minimega/minimega/v2/internal/vlans"
 	"github.com/sandia-minimega/minimega/v2/internal/vnc"
@@ -614,7 +613,7 @@ func (n *Namespace) processVMDisks(vals []string) error {
 // active vmConfig.
 func (n *Namespace) parseVMNets(vals []string) ([]NetConfig, error) {
 	// get valid NIC drivers for current qemu/machine
-	nics, err := qemu.NICs(n.vmConfig.QemuPath, n.vmConfig.Machine)
+	nics, err := qemuNICsForConfig(n.vmConfig)
 
 	// warn on not finding kvm because we may just be using containers,
 	// otherwise throw a regular error

--- a/cmd/minimega/recovery.go
+++ b/cmd/minimega/recovery.go
@@ -161,7 +161,9 @@ func recover() error {
 
 				go kvm.qmpLogger()
 
-				log.Info("connecting to VNC for vm %s (ID: %s)", name, vm.VMID)
+				if !kvm.Baremetal {
+					log.Info("connecting to VNC for vm %s (ID: %s)", name, vm.VMID)
+				}
 
 				if err := kvm.connectVNC(); err != nil {
 					return fmt.Errorf("unable to connect VNC for vm %s: %w", vm.VMID, err)

--- a/cmd/minimega/vm_cli.go
+++ b/cmd/minimega/vm_cli.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -331,6 +333,28 @@ and a JSON string, and returns the JSON encoded response. For example:
 			"vm qmp <vm name> <qmp command>",
 		},
 		Call:    wrapVMTargetCLI(cliVMQmp),
+		Suggest: wrapVMSuggest(VM_ANY_STATE, false),
+	},
+	{ // vm serial
+		HelpShort: "read a bounded snapshot from a VM serial port",
+		HelpLong: `
+Connect to a VM's QEMU serial socket and return output for a bounded interval.
+This is intended for firmware and recovery consoles that do not expose VNC.
+The default port is 0, the default read interval is 750 milliseconds, and the
+default output limit is 65536 bytes. The maximum interval is 5000 milliseconds
+and the maximum output is 1048576 bytes.
+
+Examples:
+
+	vm serial freertos
+	vm serial freertos 0 1500 131072`,
+		Patterns: []string{
+			"vm serial <vm name>",
+			"vm serial <vm name> <port>",
+			"vm serial <vm name> <port> <milliseconds>",
+			"vm serial <vm name> <port> <milliseconds> <bytes>",
+		},
+		Call:    wrapVMTargetCLI(cliVMSerial),
 		Suggest: wrapVMSuggest(VM_ANY_STATE, false),
 	},
 	{ // vm screenshot
@@ -772,6 +796,84 @@ func cliVMQmp(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 
 	resp.Response = out
 	return nil
+}
+
+func cliVMSerial(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	vm, err := ns.FindKvmVM(c.StringArgs["vm"])
+	if err != nil {
+		return err
+	}
+
+	port, milliseconds, limit := 0, 750, 65536
+	for key, target := range map[string]*int{
+		"port":         &port,
+		"milliseconds": &milliseconds,
+		"bytes":        &limit,
+	} {
+		if value := c.StringArgs[key]; value != "" {
+			parsed, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid serial %s: %q", key, value)
+			}
+			*target = parsed
+		}
+	}
+	if port < 0 || uint64(port) >= vm.SerialPorts {
+		return fmt.Errorf("serial port %d is not configured for VM %s", port, vm.GetName())
+	}
+	if milliseconds < 1 || milliseconds > 5000 {
+		return errors.New("serial read interval must be between 1 and 5000 milliseconds")
+	}
+	if limit < 1 || limit > 1048576 {
+		return errors.New("serial output limit must be between 1 and 1048576 bytes")
+	}
+
+	path := filepath.Join(vm.GetInstancePath(), fmt.Sprintf("serial%d", port))
+	out, err := readUnixSocketSnapshot(
+		path,
+		time.Duration(milliseconds)*time.Millisecond,
+		limit,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to read serial port %d for VM %s: %v", port, vm.GetName(), err)
+	}
+	resp.Response = string(out)
+	return nil
+}
+
+func readUnixSocketSnapshot(path string, duration time.Duration, limit int) ([]byte, error) {
+	conn, err := net.DialTimeout("unix", path, time.Second)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(duration)); err != nil {
+		return nil, err
+	}
+	result := make([]byte, 0, limit)
+	buffer := make([]byte, 4096)
+	for len(result) < limit {
+		remaining := limit - len(result)
+		if remaining < len(buffer) {
+			buffer = buffer[:remaining]
+		}
+		count, readErr := conn.Read(buffer)
+		if count > 0 {
+			result = append(result, buffer[:count]...)
+		}
+		if readErr == nil {
+			continue
+		}
+		if errors.Is(readErr, io.EOF) {
+			return result, nil
+		}
+		if netErr, ok := readErr.(net.Error); ok && netErr.Timeout() {
+			return result, nil
+		}
+		return result, readErr
+	}
+	return result, nil
 }
 
 func cliVMScreenshot(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/cmd/minimega/vm_serial_test.go
+++ b/cmd/minimega/vm_serial_test.go
@@ -1,0 +1,70 @@
+// Copyright (2012) Sandia Corporation.
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+
+package main
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReadUnixSocketSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "serial0")
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		_, err = conn.Write([]byte("FreeRTOS scheduler running\n"))
+		done <- err
+	}()
+
+	out, err := readUnixSocketSnapshot(path, time.Second, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "FreeRTOS scheduler running\n" {
+		t.Fatalf("unexpected serial output: %q", out)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadUnixSocketSnapshotHonorsLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "serial0")
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		conn.Write([]byte("0123456789"))
+	}()
+
+	out, err := readUnixSocketSnapshot(path, time.Second, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "0123" {
+		t.Fatalf("unexpected limited output: %q", out)
+	}
+}

--- a/cmd/minimega/vmconfig.go
+++ b/cmd/minimega/vmconfig.go
@@ -146,13 +146,23 @@ func (vm *VMConfig) WriteConfig(w io.Writer) error {
 }
 
 func (vm *VMConfig) ReadConfig(r io.ReadSeeker, ns string) error {
-	vm.BaseConfig.ReadConfig(r, ns)
-	r.Seek(0, io.SeekStart)
-	vm.KVMConfig.ReadConfig(r, ns)
-	r.Seek(0, io.SeekStart)
-	vm.ContainerConfig.ReadConfig(r, ns)
-	r.Seek(0, io.SeekStart)
-	vm.AndroidConfig.ReadConfig(r, ns)
+	readers := []func(io.Reader, string, *VMConfig) error{
+		vm.KVMConfig.ReadConfig,
+		vm.BaseConfig.ReadConfig,
+		vm.ContainerConfig.ReadConfig,
+		vm.AndroidConfig.ReadConfig,
+	}
+
+	for i, read := range readers {
+		if err := read(r, ns, vm); err != nil {
+			return err
+		}
+		if i != len(readers)-1 {
+			if _, err := r.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }
@@ -241,13 +251,33 @@ func (vm *BaseConfig) QosString(b, t, i string) string {
 	return strings.Trim(val, " ")
 }
 
-func (vm *BaseConfig) ReadFieldConfig(r io.Reader, field, namespace string) error {
+// qemuNICsForConfig returns the NIC drivers accepted by the active VM
+// configuration. QEMU's device listing omits controllers integrated into
+// bare-metal boards, so an explicitly configured board NIC is admitted in
+// addition to the discoverable devices.
+func qemuNICsForConfig(config VMConfig) (map[string]bool, error) {
+	nics, err := qemu.NICs(config.QemuPath, config.Machine)
+	if nics == nil {
+		nics = make(map[string]bool)
+	}
+	if config.Baremetal && config.BaremetalNetworkDriver != "" {
+		nics[config.BaremetalNetworkDriver] = true
+	}
+	return nics, err
+}
+
+func (vm *BaseConfig) ReadFieldConfig(r io.Reader, field, namespace string, config *VMConfig) error {
 	switch field {
 	case "networks":
-		ns := GetOrCreateNamespace(namespace)
+		var activeConfig VMConfig
+		if config == nil {
+			activeConfig = GetOrCreateNamespace(namespace).vmConfig
+		} else {
+			activeConfig = *config
+		}
 
-		// get valid NIC drivers for current qemu/machine
-		nics, err := qemu.NICs(ns.vmConfig.QemuPath, ns.vmConfig.Machine)
+		// get valid NIC drivers for the qemu/machine being loaded
+		nics, err := qemuNICsForConfig(activeConfig)
 		if err != nil {
 			if strings.Contains(err.Error(), "executable file not found in $PATH") {
 				// warn on not finding kvm because we may just be using containers,
@@ -272,14 +302,12 @@ func (vm *BaseConfig) ReadFieldConfig(r io.Reader, field, namespace string) erro
 			for _, spec := range specs {
 				nic, err := ParseNetConfig(spec, nics)
 				if err != nil {
-					log.Warnln(err) // ??
-					continue
+					return fmt.Errorf("invalid network %q: %w", spec, err)
 				}
 
 				vlan, err := lookupVLAN(namespace, nic.Alias)
 				if err != nil {
-					log.Warnln(err) // ??
-					continue
+					return fmt.Errorf("invalid VLAN %q: %w", nic.Alias, err)
 				}
 
 				nic.VLAN = vlan

--- a/cmd/minimega/vmconfig.go
+++ b/cmd/minimega/vmconfig.go
@@ -241,13 +241,28 @@ func (vm *BaseConfig) QosString(b, t, i string) string {
 	return strings.Trim(val, " ")
 }
 
+// qemuNICsForConfig returns the NIC drivers accepted by the active VM
+// configuration. QEMU's device listing omits controllers integrated into
+// bare-metal boards, so an explicitly configured board NIC is admitted in
+// addition to the discoverable devices.
+func qemuNICsForConfig(config VMConfig) (map[string]bool, error) {
+	nics, err := qemu.NICs(config.QemuPath, config.Machine)
+	if nics == nil {
+		nics = make(map[string]bool)
+	}
+	if config.Baremetal && config.BaremetalNetworkDriver != "" {
+		nics[config.BaremetalNetworkDriver] = true
+	}
+	return nics, err
+}
+
 func (vm *BaseConfig) ReadFieldConfig(r io.Reader, field, namespace string) error {
 	switch field {
 	case "networks":
 		ns := GetOrCreateNamespace(namespace)
 
 		// get valid NIC drivers for current qemu/machine
-		nics, err := qemu.NICs(ns.vmConfig.QemuPath, ns.vmConfig.Machine)
+		nics, err := qemuNICsForConfig(ns.vmConfig)
 		if err != nil {
 			if strings.Contains(err.Error(), "executable file not found in $PATH") {
 				// warn on not finding kvm because we may just be using containers,

--- a/cmd/minimega/vmconfiger_cli.go
+++ b/cmd/minimega/vmconfiger_cli.go
@@ -682,6 +682,57 @@ Note: this configuration only applies to KVM-based VMs.
 		}),
 	},
 	{
+		HelpShort: "configures baremetal",
+		HelpLong: `Launch QEMU with only the devices required for a bare-metal firmware.
+This suppresses the PC-oriented display, VNC, USB, CD-ROM, keyboard,
+RTC, PCI bridge, and virtio backchannel devices that minimega normally
+adds. QMP, PID tracking, serial sockets, tap networking, and lifecycle
+control remain available.
+
+Bare-metal guests must provide a kernel/firmware image, disable the
+MiniCCC backchannel, and explicitly request any serial ports.
+
+Default: false
+`,
+		Patterns: []string{
+			"vm config baremetal [true,false]",
+		},
+		Call: wrapSimpleCLI(func(ns *Namespace, c *minicli.Command, r *minicli.Response) error {
+			if len(c.BoolArgs) == 0 {
+				r.Response = strconv.FormatBool(ns.vmConfig.Baremetal)
+				return nil
+			}
+
+			ns.vmConfig.Baremetal = c.BoolArgs["true"]
+
+			return nil
+		}),
+	},
+	{
+		HelpShort: "configures baremetal-network-driver",
+		HelpLong: `Specify a board-integrated NIC model that QEMU does not report through
+its device-help output. Bare-metal machines such as mps2-an385 expose their
+network controller as part of the board rather than as a PCI device, so
+it must be added explicitly to the accepted network-driver set.
+
+This setting has no effect unless baremetal is enabled.
+`,
+		Patterns: []string{
+			"vm config baremetal-network-driver [value]",
+		},
+
+		Call: wrapSimpleCLI(func(ns *Namespace, c *minicli.Command, r *minicli.Response) error {
+			if len(c.StringArgs) == 0 {
+				r.Response = ns.vmConfig.BaremetalNetworkDriver
+				return nil
+			}
+
+			ns.vmConfig.BaremetalNetworkDriver = c.StringArgs["value"]
+
+			return nil
+		}),
+	},
+	{
 		HelpShort: "configures serial-ports",
 		HelpLong: `Specify the serial ports that will be created for the VM to use. Serial
 ports specified will be mapped to the VM's /dev/ttySX device, where X
@@ -1149,6 +1200,8 @@ Default: empty map
 			"clear vm config <android-avd,>",
 			"clear vm config <append,>",
 			"clear vm config <backchannel,>",
+			"clear vm config <baremetal,>",
+			"clear vm config <baremetal-network-driver,>",
 			"clear vm config <bidirectional-copy-paste,>",
 			"clear vm config <bonds,>",
 			"clear vm config <cpu,>",
@@ -1302,7 +1355,7 @@ func (v *AndroidConfig) WriteConfig(w io.Writer) error {
 	return nil
 }
 
-func (v *AndroidConfig) ReadConfig(r io.Reader, ns string) error {
+func (v *AndroidConfig) ReadConfig(r io.Reader, ns string, vmConfig *VMConfig) error {
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
@@ -1456,7 +1509,7 @@ func (v *BaseConfig) WriteConfig(w io.Writer) error {
 	return nil
 }
 
-func (v *BaseConfig) ReadConfig(r io.Reader, ns string) error {
+func (v *BaseConfig) ReadConfig(r io.Reader, ns string, vmConfig *VMConfig) error {
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
@@ -1487,9 +1540,13 @@ func (v *BaseConfig) ReadConfig(r io.Reader, ns string) error {
 		case "backchannel":
 			v.Backchannel, _ = strconv.ParseBool(config[1])
 		case "networks":
-			v.ReadFieldConfig(strings.NewReader(line), "networks", ns)
+			if err := v.ReadFieldConfig(strings.NewReader(line), "networks", ns, vmConfig); err != nil {
+				return err
+			}
 		case "bonds":
-			v.ReadFieldConfig(strings.NewReader(line), "bonds", ns)
+			if err := v.ReadFieldConfig(strings.NewReader(line), "bonds", ns, vmConfig); err != nil {
+				return err
+			}
 		case "tags":
 			v.Tags[config[1]] = config[2]
 		}
@@ -1569,7 +1626,7 @@ func (v *ContainerConfig) WriteConfig(w io.Writer) error {
 	return nil
 }
 
-func (v *ContainerConfig) ReadConfig(r io.Reader, ns string) error {
+func (v *ContainerConfig) ReadConfig(r io.Reader, ns string, vmConfig *VMConfig) error {
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
@@ -1636,6 +1693,12 @@ func (v *KVMConfig) Info(field string) (string, error) {
 	if field == "machine" {
 		return v.Machine, nil
 	}
+	if field == "baremetal" {
+		return strconv.FormatBool(v.Baremetal), nil
+	}
+	if field == "baremetal-network-driver" {
+		return v.BaremetalNetworkDriver, nil
+	}
 	if field == "serial-ports" {
 		return strconv.FormatUint(v.SerialPorts, 10), nil
 	}
@@ -1701,6 +1764,12 @@ func (v *KVMConfig) Clear(mask string) {
 	if mask == Wildcard || mask == "machine" {
 		v.Machine = ""
 	}
+	if mask == Wildcard || mask == "baremetal" {
+		v.Baremetal = false
+	}
+	if mask == Wildcard || mask == "baremetal-network-driver" {
+		v.BaremetalNetworkDriver = ""
+	}
 	if mask == Wildcard || mask == "serial-ports" {
 		v.SerialPorts = 0
 	}
@@ -1764,6 +1833,12 @@ func (v *KVMConfig) WriteConfig(w io.Writer) error {
 	if v.Machine != "" {
 		fmt.Fprintf(w, "vm config machine %v\n", v.Machine)
 	}
+	if v.Baremetal != false {
+		fmt.Fprintf(w, "vm config baremetal %t\n", v.Baremetal)
+	}
+	if v.BaremetalNetworkDriver != "" {
+		fmt.Fprintf(w, "vm config baremetal-network-driver %v\n", v.BaremetalNetworkDriver)
+	}
 	if v.SerialPorts != 0 {
 		fmt.Fprintf(w, "vm config serial-ports %v\n", v.SerialPorts)
 	}
@@ -1798,7 +1873,7 @@ func (v *KVMConfig) WriteConfig(w io.Writer) error {
 	return nil
 }
 
-func (v *KVMConfig) ReadConfig(r io.Reader, ns string) error {
+func (v *KVMConfig) ReadConfig(r io.Reader, ns string, vmConfig *VMConfig) error {
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
@@ -1832,6 +1907,10 @@ func (v *KVMConfig) ReadConfig(r io.Reader, ns string) error {
 			v.Threads, _ = strconv.ParseUint(config[1], 10, 64)
 		case "machine":
 			v.Machine = config[1]
+		case "baremetal":
+			v.Baremetal, _ = strconv.ParseBool(config[1])
+		case "baremetal-network-driver":
+			v.BaremetalNetworkDriver = config[1]
 		case "serial-ports":
 			v.SerialPorts, _ = strconv.ParseUint(config[1], 10, 64)
 		case "virtio-ports":
@@ -1841,7 +1920,9 @@ func (v *KVMConfig) ReadConfig(r io.Reader, ns string) error {
 		case "append":
 			v.Append = fieldsQuoteEscape("\"", strings.Join(config[1:], " "))
 		case "disks":
-			v.ReadFieldConfig(strings.NewReader(line), "disks", ns)
+			if err := v.ReadFieldConfig(strings.NewReader(line), "disks", ns, vmConfig); err != nil {
+				return err
+			}
 		case "usb-use-xhci":
 			v.UsbUseXHCI, _ = strconv.ParseBool(config[1])
 		case "tpm-socket":
@@ -1851,7 +1932,9 @@ func (v *KVMConfig) ReadConfig(r io.Reader, ns string) error {
 		case "qemu-append":
 			v.QemuAppend = fieldsQuoteEscape("\"", strings.Join(config[1:], " "))
 		case "qemu-override":
-			v.ReadFieldConfig(strings.NewReader(line), "qemu-override", ns)
+			if err := v.ReadFieldConfig(strings.NewReader(line), "qemu-override", ns, vmConfig); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/minimega/vmconfiger_cli.go
+++ b/cmd/minimega/vmconfiger_cli.go
@@ -682,6 +682,57 @@ Note: this configuration only applies to KVM-based VMs.
 		}),
 	},
 	{
+		HelpShort: "configures baremetal",
+		HelpLong: `Launch QEMU with only the devices required for a bare-metal firmware.
+This suppresses the PC-oriented display, VNC, USB, CD-ROM, keyboard,
+RTC, PCI bridge, and virtio backchannel devices that minimega normally
+adds. QMP, PID tracking, serial sockets, tap networking, and lifecycle
+control remain available.
+
+Bare-metal guests must provide a kernel/firmware image, disable the
+MiniCCC backchannel, and explicitly request any serial ports.
+
+Default: false
+`,
+		Patterns: []string{
+			"vm config baremetal [true,false]",
+		},
+		Call: wrapSimpleCLI(func(ns *Namespace, c *minicli.Command, r *minicli.Response) error {
+			if len(c.BoolArgs) == 0 {
+				r.Response = strconv.FormatBool(ns.vmConfig.Baremetal)
+				return nil
+			}
+
+			ns.vmConfig.Baremetal = c.BoolArgs["true"]
+
+			return nil
+		}),
+	},
+	{
+		HelpShort: "configures baremetal-network-driver",
+		HelpLong: `Specify a board-integrated NIC model that QEMU does not report through
+its device-help output. Bare-metal machines such as mps2-an385 expose their
+network controller as part of the board rather than as a PCI device, so
+it must be added explicitly to the accepted network-driver set.
+
+This setting has no effect unless baremetal is enabled.
+`,
+		Patterns: []string{
+			"vm config baremetal-network-driver [value]",
+		},
+
+		Call: wrapSimpleCLI(func(ns *Namespace, c *minicli.Command, r *minicli.Response) error {
+			if len(c.StringArgs) == 0 {
+				r.Response = ns.vmConfig.BaremetalNetworkDriver
+				return nil
+			}
+
+			ns.vmConfig.BaremetalNetworkDriver = c.StringArgs["value"]
+
+			return nil
+		}),
+	},
+	{
 		HelpShort: "configures serial-ports",
 		HelpLong: `Specify the serial ports that will be created for the VM to use. Serial
 ports specified will be mapped to the VM's /dev/ttySX device, where X
@@ -1149,6 +1200,8 @@ Default: empty map
 			"clear vm config <android-avd,>",
 			"clear vm config <append,>",
 			"clear vm config <backchannel,>",
+			"clear vm config <baremetal,>",
+			"clear vm config <baremetal-network-driver,>",
 			"clear vm config <bidirectional-copy-paste,>",
 			"clear vm config <bonds,>",
 			"clear vm config <cpu,>",
@@ -1636,6 +1689,12 @@ func (v *KVMConfig) Info(field string) (string, error) {
 	if field == "machine" {
 		return v.Machine, nil
 	}
+	if field == "baremetal" {
+		return strconv.FormatBool(v.Baremetal), nil
+	}
+	if field == "baremetal-network-driver" {
+		return v.BaremetalNetworkDriver, nil
+	}
 	if field == "serial-ports" {
 		return strconv.FormatUint(v.SerialPorts, 10), nil
 	}
@@ -1701,6 +1760,12 @@ func (v *KVMConfig) Clear(mask string) {
 	if mask == Wildcard || mask == "machine" {
 		v.Machine = ""
 	}
+	if mask == Wildcard || mask == "baremetal" {
+		v.Baremetal = false
+	}
+	if mask == Wildcard || mask == "baremetal-network-driver" {
+		v.BaremetalNetworkDriver = ""
+	}
 	if mask == Wildcard || mask == "serial-ports" {
 		v.SerialPorts = 0
 	}
@@ -1763,6 +1828,12 @@ func (v *KVMConfig) WriteConfig(w io.Writer) error {
 	}
 	if v.Machine != "" {
 		fmt.Fprintf(w, "vm config machine %v\n", v.Machine)
+	}
+	if v.Baremetal != false {
+		fmt.Fprintf(w, "vm config baremetal %t\n", v.Baremetal)
+	}
+	if v.BaremetalNetworkDriver != "" {
+		fmt.Fprintf(w, "vm config baremetal-network-driver %v\n", v.BaremetalNetworkDriver)
 	}
 	if v.SerialPorts != 0 {
 		fmt.Fprintf(w, "vm config serial-ports %v\n", v.SerialPorts)
@@ -1832,6 +1903,10 @@ func (v *KVMConfig) ReadConfig(r io.Reader, ns string) error {
 			v.Threads, _ = strconv.ParseUint(config[1], 10, 64)
 		case "machine":
 			v.Machine = config[1]
+		case "baremetal":
+			v.Baremetal, _ = strconv.ParseBool(config[1])
+		case "baremetal-network-driver":
+			v.BaremetalNetworkDriver = config[1]
 		case "serial-ports":
 			v.SerialPorts, _ = strconv.ParseUint(config[1], 10, 64)
 		case "virtio-ports":

--- a/cmd/vmconfiger/templates.go
+++ b/cmd/vmconfiger/templates.go
@@ -312,7 +312,7 @@ func (v *{{ $type }} ) WriteConfig(w io.Writer) error {
 	return nil
 }
 
-func (v *{{ $type }} ) ReadConfig(r io.Reader, ns string) error {
+func (v *{{ $type }} ) ReadConfig(r io.Reader, ns string, vmConfig *VMConfig) error {
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
@@ -341,7 +341,9 @@ func (v *{{ $type }} ) ReadConfig(r io.Reader, ns string) error {
 			{{- else if eq .Type "slice" }}
 			v.{{ .Field }} = fieldsQuoteEscape("\"", strings.Join(config[1:], " "))
 			{{- else }}
-			v.ReadFieldConfig(strings.NewReader(line), "{{ .ConfigName }}", ns)
+			if err := v.ReadFieldConfig(strings.NewReader(line), "{{ .ConfigName }}", ns, vmConfig); err != nil {
+				return err
+			}
 			{{- end }}
 		{{- end }}
 		}

--- a/doc/content/articles/tutorials/cc.article
+++ b/doc/content/articles/tutorials/cc.article
@@ -65,6 +65,13 @@ virtio-serial file.
 
 	miniccc -serial /dev/virtio-ports/cc
 
+Miniccc normally reads its VM UUID from the guest platform. When a serial
+client has no local UUID source, minimega binds the connection to the UUID of
+the VM that owns that serial port. A TCP client without a platform UUID must
+provide one explicitly:
+
+	miniccc -parent 10.0.0.1 -uuid 3b440429-067f-5b75-a0c3-f436519f8ccb
+
 *NOTE:* In linux, the default virtio-serial cc port is `/dev/virtio-ports/cc`.
 In Windows, the path is `\\.\Global\cc`.
 

--- a/doc/content/articles/vmtypes.article
+++ b/doc/content/articles/vmtypes.article
@@ -75,8 +75,54 @@ Configuration parameters specific to `KVM` instances:
 - `cpu` - Set the virtual CPU architecture.
 - `kernel` - Attach a kernel image to a VM.
 - `initrd` - Attach an initrd image to a VM.
+- `baremetal` - Suppress PC-oriented devices and launch a firmware image with QMP, serial, and tap-network lifecycle support.
+- `baremetal-network-driver` - Admit a board-integrated QEMU NIC model for bare-metal network configuration.
 - `serial` - Specify serial ports.
 - `virtio-serial` - Specify virtio-serial ports.
+
+*** Bare-metal firmware
+
+The `baremetal` configuration supports firmware and RTOS guests whose QEMU
+machine does not provide PC hardware. It removes minimega's implicit VNC,
+VGA, USB, CD-ROM, keyboard, RTC, PCI bridge, and virtio backchannel devices.
+QMP lifecycle control, PID tracking, kernel loading, serial sockets, and tap
+networking remain available.
+
+Bare-metal VMs require `vm config kernel`, must disable `backchannel`, and do
+not support disks, CD-ROMs, migrated state, TPM devices, virtio serial ports,
+or bidirectional copy and paste. Serial ports use the target board's native
+UARTs and are exposed as unix sockets in the VM instance directory. Network
+interfaces use QEMU's board-oriented `-net nic,model=...` form rather than a
+PCI bridge, so the configured driver must be implemented by both the selected
+QEMU machine and the firmware. Set `vm config baremetal-network-driver` when using
+a board-integrated controller because QEMU does not report those controllers
+through its PCI device-discovery interface.
+
+For example, an Arm Cortex-M3 firmware built for QEMU's MPS2 AN385 board can
+be configured with:
+
+	vm config qemu /usr/bin/qemu-system-arm
+	vm config machine mps2-an385
+	vm config cpu cortex-m3
+	vm config memory 16
+	vm config vcpus 1
+	vm config kernel /absolute/path/RTOSDemo.out
+	vm config baremetal true
+	vm config baremetal-network-driver lan9118
+	vm config backchannel false
+	vm config serial-ports 1
+	vm config net 378,52:54:00:12:34:ad,lan9118
+	vm launch kvm freertos-mps2
+	vm start freertos-mps2
+
+The firmware's first UART is then available at `serial0` in the VM instance
+directory. Bare-metal firmware normally has no framebuffer, so VNC is not
+created and the `vnc_port` field is zero. QEMU stdout and stderr diagnostics are
+captured in `qemu.log` in the same instance directory. Firmware console and Arm
+semihosting output remain available through the configured serial socket.
+Firmware that uses Arm semihosting can enable it with:
+
+	vm config qemu-append -semihosting -semihosting-config enable=on,target=native
 
 *** Technical details
 

--- a/internal/qemu/qemu.go
+++ b/internal/qemu/qemu.go
@@ -25,6 +25,19 @@ var (
 
 type parser func(io.Reader) (map[string]bool, error)
 
+func copyCapabilities(src map[string]bool) map[string]bool {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]bool, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
+}
+
 // CPUs returns a list of supported QEMU CPUs for the specified qemu and
 // machine type.
 func CPUs(qemu, machine string) (map[string]bool, error) {
@@ -89,7 +102,7 @@ func caps(name string, cmd []string, fn parser) (map[string]bool, error) {
 
 	// test if the key exists
 	if v, ok := cache[name]; ok {
-		return v, nil
+		return copyCapabilities(v), nil
 	}
 
 	out, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
@@ -103,7 +116,7 @@ func caps(name string, cmd []string, fn parser) (map[string]bool, error) {
 	}
 
 	cache[name] = res
-	return res, nil
+	return copyCapabilities(res), nil
 }
 
 func parseCPUs(r io.Reader) (map[string]bool, error) {

--- a/internal/qemu/qemu_test.go
+++ b/internal/qemu/qemu_test.go
@@ -44,3 +44,36 @@ func TestParseNICs(t *testing.T) {
 
 	t.Logf("parsed %v nics", len(res))
 }
+
+func TestCapsReturnsIndependentMaps(t *testing.T) {
+	const name = "test-independent-capability-maps"
+
+	mu.Lock()
+	original, existed := cache[name]
+	cache[name] = map[string]bool{"e1000": true}
+	mu.Unlock()
+
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if existed {
+			cache[name] = original
+		} else {
+			delete(cache, name)
+		}
+	})
+
+	first, err := caps(name, []string{"unused"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first["lan9118"] = true
+
+	second, err := caps(name, []string{"unused"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second["lan9118"] {
+		t.Fatal("mutating returned capabilities changed the cached map")
+	}
+}

--- a/internal/ron/server.go
+++ b/internal/ron/server.go
@@ -257,7 +257,7 @@ func (s *Server) DialSerial(path, uuid string) error {
 				return
 			}
 
-			cli, err := s.handshake(conn)
+			cli, err := s.handshake(conn, uuid)
 			if err != nil {
 				if errors.Is(err, errClientTooOld) {
 					log.Error("%v", err.Error())
@@ -655,7 +655,7 @@ func (s *Server) serve(addr string, ln net.Listener) {
 		remote := conn.RemoteAddr()
 
 		log.Info("client connected: %v -> %v", remote, addr)
-		c, err := s.handshake(conn)
+		c, err := s.handshake(conn, "")
 		if err != nil {
 			if err != io.EOF {
 				// supress these, VM was probably never started
@@ -674,7 +674,7 @@ func (s *Server) serve(addr string, ln net.Listener) {
 
 // handshake performs a handshake with the client, returning the new client if
 // there were no errors.
-func (s *Server) handshake(conn net.Conn) (*client, error) {
+func (s *Server) handshake(conn net.Conn, expectedUUID string) (*client, error) {
 	// read until we see the magic bytes
 	var buf [3]byte
 	for string(buf[:]) != "RON" {
@@ -705,6 +705,14 @@ func (s *Server) handshake(conn net.Conn) (*client, error) {
 	// get the first client struct as a handshake
 	var m Message
 	if err := c.dec.Decode(&m); err != nil {
+		return nil, err
+	}
+
+	// A serial connection is created for one specific VM, so its expected UUID
+	// is host-controlled. Guests without DMI can leave their UUID empty and
+	// adopt this trusted identity from the handshake response. Unbound clients
+	// must provide an identity of their own.
+	if err := bindClientUUID(&m, expectedUUID); err != nil {
 		return nil, err
 	}
 
@@ -788,6 +796,23 @@ func (s *Server) handshake(conn net.Conn) (*client, error) {
 	s.clients[c.UUID] = c
 
 	return c, nil
+}
+
+func bindClientUUID(m *Message, expectedUUID string) error {
+	if m.Client == nil {
+		return fmt.Errorf("client handshake missing client metadata")
+	}
+	if m.Client.UUID != "" {
+		return nil
+	}
+	if expectedUUID == "" {
+		return fmt.Errorf("client handshake missing UUID without serial binding")
+	}
+
+	m.Client.UUID = expectedUUID
+	m.UUID = expectedUUID
+	log.Info("bound serial client to VM UUID %s", expectedUUID)
+	return nil
 }
 
 // client and transport handler for connections.

--- a/internal/ron/server_test.go
+++ b/internal/ron/server_test.go
@@ -1,0 +1,42 @@
+// Copyright 2015-2023 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package ron
+
+import "testing"
+
+func TestBindClientUUIDUsesSerialIdentity(t *testing.T) {
+	want := "3b440429-067f-5b75-a0c3-f436519f8ccb"
+	m := &Message{Client: &Client{}}
+	if err := bindClientUUID(m, want); err != nil {
+		t.Fatal(err)
+	}
+	if m.Client.UUID != want || m.UUID != want {
+		t.Fatalf("serial identity was not adopted: %#v", m)
+	}
+}
+
+func TestBindClientUUIDPreservesGuestIdentity(t *testing.T) {
+	want := "a5ba6920-5bcf-4022-b8cf-015425f7b05c"
+	m := &Message{Client: &Client{UUID: want}}
+	if err := bindClientUUID(m, "different-host-identity"); err != nil {
+		t.Fatal(err)
+	}
+	if m.Client.UUID != want {
+		t.Fatalf("guest identity changed: %q", m.Client.UUID)
+	}
+}
+
+func TestBindClientUUIDRejectsUnboundIdentity(t *testing.T) {
+	for name, m := range map[string]*Message{
+		"missing client": {},
+		"missing UUID":   {Client: &Client{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := bindClientUUID(m, ""); err == nil {
+				t.Fatal("expected an unbound client identity error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description ##

Adds explicit support for bare-metal firmware and RTOS guests:

- Adds `vm config baremetal` and board-integrated NIC configuration.
- Removes incompatible PC devices while preserving QMP, serial, tap networking, and lifecycle control.
- Adds bounded `vm serial` snapshots.
- Adds a MiniCCC UUID fallback for guests without DMI.
- Adds focused tests and FreeRTOS documentation.

## Motivation and context ##

MiniMega's normal KVM path assumes PC hardware such as PCI, VGA, VNC, USB, and a virtio backchannel. Microcontroller and RTOS targets do not provide these devices.

This change adds a validated, opt-in firmware mode while retaining MiniMega orchestration, isolation, serial access, networking, and targeted teardown.

## Testing ##

Tested with ARM64, RISC-V64, and Arm Cortex-M3 FreeRTOS guests.

```bash
./scripts/check.bash
CGO_ENABLED=0 go test -mod=vendor ./cmd/miniccc
go test -mod=vendor ./cmd/minimega -count=1
go build -mod=vendor ./cmd/minimega
```

Verified bare-metal argument generation, invalid configuration rejection, board-integrated networking, bounded serial reads, UUID selection, FreeRTOS UART/network activity, and targeted relaunch/teardown.

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [ ] All GitHub Actions are passing.

## Additional Notes ##

Bare-metal mode is opt-in and does not change existing KVM or container behavior. Firmware guests normally use UART serial output instead of VNC or MiniCCC.
