### PR TITLE
feat(miniplumber): add file terminal support

### DIFF
--- a/cmd/minimega/plumber.go
+++ b/cmd/minimega/plumber.go
@@ -30,15 +30,23 @@ var plumbCLIHandlers = []minicli.Handler{
 	{ // plumb
 		HelpShort: "plumb I/O between minimega, VMs, and external programs",
 		HelpLong: `
-Create pipelines composed of named pipes and external programs. Pipelines pass
-data on standard I/O, with messages split on newlines. Pipelines are
-constructed similar to that of UNIX pipelines. For example, to pipeline named
-pipe "foo" through "sed" and into another pipe "bar":
+Create pipelines composed of named pipes, external programs, and file
+terminals. Pipelines pass data on standard I/O, with messages split on
+newlines. Pipelines are constructed similar to that of UNIX pipelines. For
+example, to pipeline named pipe "foo" through "sed" and into another pipe
+"bar":
 
 	plumb foo "sed -u s/foo/moo/" bar
 
 When specifying pipelines, strings that are not found in $PATH are considered
-named pipes.
+named pipes, unless prefixed with "file://" in which case they are treated as
+file terminals.
+
+A file terminal (e.g. file:///foo/bar) may appear as the last element in a
+pipeline to write all received data to that file. If the file already exists,
+data is appended; otherwise the file is created.
+
+	plumb foo file:///foo/bar
 
 Pipelines can be composed into larger, nonlinear pipelines. For example, to
 create a simple tree rooted at A with leaves B and C, simply specify multiple
@@ -123,6 +131,10 @@ func cliPlumbLocal(ns *Namespace, c *minicli.Command, resp *minicli.Response) er
 	args := append([]string{c.StringArgs["src"]}, c.ListArgs["dst"]...)
 
 	for i, e := range args {
+		// file:// terminals are passed through as-is
+		if strings.HasPrefix(e, "file://") {
+			continue
+		}
 		// This production is a little odd but we have to make choices
 		// somewhere - if a field isn't already in the namespace//pipe
 		// format AND doesn't exist in the path, then it must be a pipe

--- a/internal/miniplumber/miniplumber.go
+++ b/internal/miniplumber/miniplumber.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -304,6 +305,17 @@ func (p *Plumber) sendReaders(m *Message) {
 }
 
 func (p *Plumber) Plumb(production ...string) error {
+	for i, element := range production {
+		if strings.HasPrefix(element, "file://") {
+			if i == 0 {
+				return fmt.Errorf("file terminal cannot be the first pipeline element: %v", element)
+			}
+			if i != len(production)-1 {
+				return fmt.Errorf("file terminal must be the final pipeline element: %v", element)
+			}
+		}
+	}
+
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -775,6 +787,13 @@ func (p *Plumber) startPipeline(pl *pipeline) {
 			continue
 		}
 
+		// looks like a file terminal
+		if strings.HasPrefix(e, "file://") {
+			path := strings.TrimPrefix(e, "file://")
+			b = pl.fileTerminal(path, b)
+			continue
+		}
+
 		// looks like a named pipe
 		var in *Reader
 
@@ -930,6 +949,42 @@ func (pl *pipeline) cancel() {
 		log.Debug("closing pipeline: %v", pl.name)
 		close(pl.done)
 	})
+}
+
+// fileTerminal writes all incoming data to the file at path. If the file
+// exists it is appended to; otherwise it is created. The returned channel is
+// always nil because a file terminal consumes data and produces no output.
+func (pl *pipeline) fileTerminal(path string, in <-chan string) <-chan string {
+	log.Debug("fileTerminal: %v", path)
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		pl.cancel()
+		log.Errorln(err)
+		return nil
+	}
+
+	go func() {
+		defer pl.cancel()
+		defer f.Close()
+
+		for {
+			select {
+			case v, ok := <-in:
+				if !ok {
+					return
+				}
+				if _, err := f.WriteString(v); err != nil {
+					log.Errorln(err)
+					return
+				}
+			case <-pl.done:
+				return
+			}
+		}
+	}()
+
+	return nil
 }
 
 func (p *Pipe) Name() string {

--- a/internal/miniplumber/miniplumber_test.go
+++ b/internal/miniplumber/miniplumber_test.go
@@ -1,0 +1,81 @@
+package miniplumber
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPlumbFileTerminal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "output")
+	plumber := New(nil)
+
+	if err := plumber.Plumb("printf hello", "file://"+path); err != nil {
+		t.Fatalf("Plumb returned error: %v", err)
+	}
+
+	waitForPipeline(t, plumber)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if string(data) != "hello\n" {
+		t.Fatalf("file contents = %q, want %q", data, "hello\n")
+	}
+
+	if err := plumber.Plumb("printf world", "file://"+path); err != nil {
+		t.Fatalf("Plumb returned error: %v", err)
+	}
+
+	waitForPipeline(t, plumber)
+
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if string(data) != "hello\nworld\n" {
+		t.Fatalf("file contents = %q, want %q", data, "hello\nworld\n")
+	}
+}
+
+func TestPlumbRejectsInvalidFileTerminalPosition(t *testing.T) {
+	tests := []struct {
+		name       string
+		production []string
+	}{
+		{
+			name:       "source",
+			production: []string{"file:///tmp/output"},
+		},
+		{
+			name:       "non-final",
+			production: []string{"printf hello", "file:///tmp/output", "cat"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := New(nil).Plumb(tt.production...); err == nil {
+				t.Fatal("Plumb returned nil error")
+			}
+		})
+	}
+}
+
+func waitForPipeline(t *testing.T, plumber *Plumber) {
+	t.Helper()
+
+	deadline := time.After(TIMEOUT)
+	for {
+		if len(plumber.Pipelines()) == 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for pipeline")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add file:// pipeline terminals with append/create behavior.
- Validate terminal placement and add focused tests.

Closes #1394

## Validation
- go test ./internal/miniplumber
- scripts/check.bash: blocked by existing macOS date incompatibility and undefined cmd/miniccc getUUID.
