### PR TITLE
docs(training): update minidoc training modules

### DIFF
--- a/doc/content/training/module01.slide
+++ b/doc/content/training/module01.slide
@@ -144,9 +144,12 @@ Then, a second interface is added to the router VM, and again, the router will a
 
 * Step 3 - Configure the Router
 
-Then, we define a routing protocol of OSPF. These two lines allow the traffic of each network to cross over via the router.
+Then, we set the router as the default gateway for each network, using the `router` option of the `router`dhcp` command:
 
-Details on how OSPF works is beyond the scope of this tutorial, however we recommend the user be familiar with such networking details, if this impacts how you will be configuring your experiment.
+ router router dhcp 10.0.0.0 router 10.0.0.1
+ router router dhcp 20.0.0.0 router 20.0.0.1
+
+We don't need a routing protocol like OSPF here. Because the router VM is a member of both networks, and DHCP has already told each VM to use the router as its default gateway, the router already knows how to get traffic everywhere it needs to go.
 
 Finally, after any router commands are defined, the user must commit the commands using the commit command:
 

--- a/doc/content/training/module01_content/vm_sandwich.mm
+++ b/doc/content/training/module01_content/vm_sandwich.mm
@@ -29,8 +29,8 @@ router router dhcp 10.0.0.0 dns 10.0.0.2
 router router interface 1 20.0.0.1/24
 router router dhcp 20.0.0.0 range 20.0.0.2 20.0.0.2
 router router dhcp 20.0.0.0 dns 20.0.0.2
-router router route ospf 0 0
-router router route ospf 0 1
+router router dhcp 10.0.0.0 router 10.0.0.1
+router router dhcp 20.0.0.0 router 20.0.0.1
 router router commit
 
 shell echo "start the router first, and give it a chance to configure"

--- a/doc/content/training/module01_content/vm_sandwich_p2.mm
+++ b/doc/content/training/module01_content/vm_sandwich_p2.mm
@@ -13,8 +13,8 @@ router router dhcp 10.0.0.0 dns 10.0.0.2
 router router interface 1 20.0.0.1/24
 router router dhcp 20.0.0.0 range 20.0.0.2 20.0.0.2
 router router dhcp 20.0.0.0 dns 20.0.0.2
-router router route ospf 0 0
-router router route ospf 0 1
+router router dhcp 10.0.0.0 router 10.0.0.1
+router router dhcp 20.0.0.0 router 20.0.0.1
 router router commit
 
 

--- a/doc/content/training/module02_5.slide
+++ b/doc/content/training/module02_5.slide
@@ -49,6 +49,16 @@ A container only requires a filesystem with the various programs and files neede
 
 Consequently, containers require far fewer resources to run, and you can therefore run many more containers on a host compared to KVMs.
 
+* How minimega containers differ from Docker/LXC
+
+minimega implements its own lightweight container runtime rather than shelling out to Docker or LXC.
+
+minimega builds containers directly using Linux namespaces (mount, PID, network, UTS, IPC) and cgroups, without requiring a container engine daemon (such as dockerd) to be installed or running on the host.
+
+Because minimega manages the namespaces itself, containers are treated as first-class citizens alongside KVM VMs: they share the same `vm`config`/`vm`launch` workflow, the same networking (VLANs, taps), the same command and control (miniccc), and the same instrumentation tools (`vm`top`, packet capture, etc.).
+
+minimega containers also boot from a plain root filesystem (an `init` program and a directory tree) rather than a layered image format like a Docker image, which keeps the tooling (vmbetter) simple and avoids the overhead of an image registry or union filesystem.
+
 * Types of VM image files
 
 There are a number of image files you can use to launch a virtual machine or container. 

--- a/doc/content/training/module03.slide
+++ b/doc/content/training/module03.slide
@@ -244,4 +244,4 @@ The base directory is important when connecting to an already running minimega i
 
 * Next Up...
 
-[[module04.slide][Module 04: miniweb]]
+[[module04.slide][Module 04: Experiment Visualization]]

--- a/doc/content/training/module04.slide
+++ b/doc/content/training/module04.slide
@@ -45,7 +45,7 @@ This will print the available options for miniweb
 
 * 
 
-- If you want minimega to be available via console
+- If you like the minimega console to be available in the web application
 -- use the -console flag
 -- ensure minimega is located in a bin directory, specify with -base
 

--- a/doc/content/training/module06.slide
+++ b/doc/content/training/module06.slide
@@ -89,12 +89,14 @@ See [[/articles/api.article][the minimega API]] for more details on dnsmasq, or 
 
     minimega$ help dnsmasq
 
+Note: DNSMASQ runs on the host, which means the host itself becomes part of your experiment's network. For most experiments, it's better to use minirouter (or another dedicated VM) to serve DHCP instead, so the host stays isolated from the experiment network. See the next section for details.
+
 
 * minirouter
 
 minirouter is a simple tool, run in a VM, that orchestrates various router functions such as DHCP, DNS, IPv4/IPv6 assignments, and, of course, routing. The minirouter tool is interfaced by minimega's router API and the minimega distribution provides a prebuilt minirouter container image.
 
-minirouter currently supports several protocols and capabilities including DHCP, DNS, router advertisements, OSPF, and static routes. It can route in excess of 40 gigabits per second when running as a container. 
+minirouter currently supports several protocols and capabilities including DHCP, DNS, router advertisements, static routes, OSPF, and BGP. It can route in excess of 40 gigabits per second when running as a container. 
 
 minirouter can run on bare metal, as a container, or a KVM image.
 
@@ -160,7 +162,7 @@ minirouter provides a simple mechanism to add A or AAAA records for any host/IP 
 
 * Routing
 
-minirouter uses the bird routing daemon to provide routing using a variety of protocols. Currently, minirouter only supports static and OSPF routes. Support for BGP and others are planned.
+minirouter uses the bird routing daemon to provide routing using a variety of protocols. minirouter supports static routes, OSPF, and BGP.
 
 Bird is a lightweight routing daemon that scales well. In our tests we were able to scale minirouter with bird to at least 40 gigabit
 
@@ -177,6 +179,16 @@ minirouter provides basic support for OSPF and OSPFv3 (IPv6 enabled OSPF) by spe
 Interfaces are identified by the index in which they were added by the vm config net API. For example, to add the first and third network of the router VM to area 0 in an OSPF route:
 
 .mega module06_content/router08.mm
+
+OSPF route costs can also be tuned to influence path selection. See [[/articles/ospf_cost.article][the OSPF cost article]] for details.
+
+* Routing - the full router API
+
+We've only covered a subset of the `router` API in this module. The router API includes commands for interfaces, DHCP, DNS, upstream DNS, default gateway, router advertisements, routes, router ID, and firewall rules (about 9 subcommands in total).
+
+See [[/articles/api.article][the minimega API]] for the full list, or in minimega:
+
+    minimega$ help router
 
 * Connecting to the internet
 

--- a/doc/content/training/module07.slide
+++ b/doc/content/training/module07.slide
@@ -190,6 +190,18 @@ Tags are key/value pairs, and are added simply by using the -tag switch on a run
 
     ./miniccc -tag foo bar
 
+* Pitfall: version mismatches
+
+miniccc and minimega must come from the same minimega release. The c2 protocol between them can change between versions, so mixing versions can cause clients to fail to connect, silently drop commands, or misreport responses.
+
+When a client's version doesn't match, minimega logs a warning at handshake time:
+
+    mismatched miniccc version on <hostname>: <client version>
+
+Check minimega's log (-level info or higher) if clients seem to connect but never respond as expected.
+
+If you see this warning, rebuild your VM image's miniccc binary any time you upgrade minimega.
+
 * Next up…
 
 [[module08.slide][Module 08: Background traffic]]


### PR DESCRIPTION
Fixes #1407

Updates the minidoc training slides per the review feedback in the issue:

- **Module 1**: use DHCP default gateway (`router dhcp <net> router <gw>`) instead of OSPF for the router sandwich
- **Module 2.5**: explain how minimega containers differ from Docker/LXC
- **Module 3**: fix module 4 link title mismatch (miniweb vs. Experiment Visualization)
- **Module 4**: reword console availability bullet
- **Module 6**: recommend minirouter over host DNSMASQ for DHCP, correct outdated "BGP planned" status (BGP is implemented), link the OSPF cost article, summarize the full router API
- **Module 7**: add a pitfall slide on miniccc/minimega version mismatches

All slide changes were verified by building and rendering `cmd/minidoc` locally.

Module 2.5 was intentionally *not* renumbered into its own module (as also suggested in the issue) to keep this change minimal and low-risk.