### PR TITLE
feat(disk): add disk extract command to pull files from a disk image

### DIFF
--- a/cmd/minimega/disk.go
+++ b/cmd/minimega/disk.go
@@ -248,44 +248,51 @@ func diskResize(image, size string) error {
 	return nil
 }
 
-// diskInject injects files into or deletes files from a disk image.
-// dst/partition specify the image and the partition number. for injecting
-// files, pairs is the dst/src filepaths. for deleting files, paths is the
-// comma-separated list of filepaths to delete. options can be used to supply
-// mount arguments.
-func diskInject(dst, partition string, pairs map[string]string, options []string, delete bool, paths []string) error {
+// mountedImage tracks the state of an image that has been connected via nbd
+// and mounted onto the host filesystem. Close() undoes the mount/connect, in
+// reverse order, and removes the temporary mount point.
+type mountedImage struct {
+	image   string
+	nbdPath string
+	device  string // device (or partition) that was mounted
+	mntDir  string
+}
+
+// mountImage loads nbd, connects image, waits for/selects the desired
+// partition, and mounts it at a newly created temporary directory using the
+// provided mount args. mountArgsFn is called with the device path to mount
+// and should return one or more candidate sets of `mount` arguments; each
+// candidate is tried in turn (allowing callers to fall back to alternative
+// mount options, e.g. to work around mild filesystem corruption). Callers
+// must call Close() on the returned mountedImage once done.
+func mountImage(image, partition string, mountArgsFn func(path string) [][]string) (*mountedImage, error) {
 	// Load nbd
 	if err := nbd.Modprobe(); err != nil {
-		return err
+		return nil, err
 	}
 
 	// create a tmp mount point
 	mntDir, err := os.MkdirTemp(*f_base, "dstImg")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	log.Debug("temporary mount point: %v", mntDir)
-	defer func() {
-		if err := os.Remove(mntDir); err != nil {
-			log.Error("rm mount dir failed: %v", err)
-		}
-	}()
 
-	nbdPath, err := nbd.ConnectImage(dst)
+	mi := &mountedImage{image: image, mntDir: mntDir}
+
+	nbdPath, err := nbd.ConnectImage(image)
 	if err != nil {
-		return err
+		os.Remove(mntDir)
+		return nil, err
 	}
-	defer func() {
-		if err := nbd.DisconnectDevice(nbdPath); err != nil {
-			log.Error("nbd disconnect failed: %v", err)
-		}
-	}()
+	mi.nbdPath = nbdPath
 
 	path := nbdPath
 
 	f, err := os.Open(nbdPath)
 	if err != nil {
-		return err
+		mi.Close()
+		return nil, err
 	}
 	defer f.Close()
 
@@ -295,7 +302,8 @@ func diskInject(dst, partition string, pairs map[string]string, options []string
 		timeoutTime := time.Now().Add(10 * time.Second)
 		for i := 1; ; i++ {
 			if time.Now().After(timeoutTime) {
-				return fmt.Errorf("[image %s] no partitions found on image", dst)
+				mi.Close()
+				return nil, fmt.Errorf("[image %s] no partitions found on image", image)
 			}
 
 			// tell kernel to reread partitions
@@ -314,7 +322,8 @@ func diskInject(dst, partition string, pairs map[string]string, options []string
 		if partition == "" {
 			_, err = os.Stat(nbdPath + "p2")
 			if err == nil {
-				return fmt.Errorf("[image %s] please specify a partition; multiple found", dst)
+				mi.Close()
+				return nil, fmt.Errorf("[image %s] please specify a partition; multiple found", image)
 			}
 
 			partition = "1"
@@ -326,70 +335,142 @@ func diskInject(dst, partition string, pairs map[string]string, options []string
 		for i := 1; i <= 5; i++ {
 			_, err = os.Stat(path)
 			if err != nil {
-				err = fmt.Errorf("[image %s] desired partition %s not found", dst, partition)
+				err = fmt.Errorf("[image %s] desired partition %s not found", image, partition)
 
 				time.Sleep(time.Duration(i*100) * time.Millisecond)
 				continue
 			}
 
-			log.Info("desired partition %s found in image %s", partition, dst)
+			log.Info("desired partition %s found in image %s", partition, image)
 			break
 		}
 
 		if err != nil {
-			return err
+			mi.Close()
+			return nil, err
 		}
 	}
+
+	mi.device = path
 
 	// we use mount(8), because the mount syscall (mount(2)) requires we
 	// populate the fstype field, which we don't know
-	args := []string{"mount"}
-	if len(options) != 0 {
-		args = append(args, options...)
-		args = append(args, path, mntDir)
-	} else {
-		args = []string{"mount", "-w", path, mntDir}
-	}
-	log.Debug("mount args: %v", args)
-
 	var out string
+	var mountErr error
 	mounted := false
-	for i := 1; i <= 5; i++ {
-		out, err = processWrapper(args...)
-		if err == nil {
-			mounted = true
+
+	for _, args := range mountArgsFn(path) {
+		args = append(args, mntDir)
+		log.Debug("mount args: %v", args)
+
+		for i := 1; i <= 5; i++ {
+			out, mountErr = processWrapper(args...)
+			if mountErr == nil {
+				mounted = true
+				break
+			}
+			log.Debug("mount attempt %d failed: %v", i, mountErr)
+			time.Sleep(time.Duration(i*100) * time.Millisecond)
+		}
+
+		if mounted {
 			break
 		}
-		log.Debug("mount attempt %d failed: %v", i, err)
-		time.Sleep(time.Duration(i*100) * time.Millisecond)
+
+		log.Debug("mount attempt with args %v failed: %v, %v", args, out, mountErr)
 	}
 
 	if !mounted {
-		log.Debug("standard mount failed, trying ntfs-3g: %v, %v", out, err)
-		// check that ntfs-3g is installed
-		out, err := processWrapper("ntfs-3g", "--version")
-		if err != nil {
-			log.Error("ntfs-3g not found, ntfs images unwriteable")
-			return fmt.Errorf("[image %s] ntfs-3g not found %v: %v", dst, out, err)
-		}
+		mi.Close()
+		return nil, fmt.Errorf("[image %s] unable to mount %s: %v: %v", image, path, out, mountErr)
+	}
 
-		// mount with ntfs-3g
-		out, err = processWrapper("mount", "-o", "ntfs-3g", path, mntDir)
-		if err != nil {
-			log.Error("failed to mount partition")
-			return fmt.Errorf("[image %s] %v: %v", dst, out, err)
+	return mi, nil
+}
+
+// Close unmounts the filesystem (if mounted), disconnects the nbd device (if
+// connected), and removes the temporary mount point (if created). Errors are
+// logged rather than returned since Close is expected to be deferred.
+func (mi *mountedImage) Close() {
+	if mi.device != "" {
+		if err := syscall.Unmount(mi.mntDir, 0); err != nil {
+			log.Error("unmount failed: %v", err)
+		} else if out, err := processWrapper("blockdev", "--flushbufs", mi.device); err != nil {
+			log.Error("[image %s] unable to flush: %v %v", mi.image, out, err)
 		}
 	}
-	defer func() {
-		if err := syscall.Unmount(mntDir, 0); err != nil {
-			log.Error("unmount failed: %v", err)
+
+	if mi.nbdPath != "" {
+		if err := nbd.DisconnectDevice(mi.nbdPath); err != nil {
+			log.Error("nbd disconnect failed: %v", err)
 		}
-	}()
+	}
+
+	if err := os.Remove(mi.mntDir); err != nil {
+		log.Error("rm mount dir failed: %v", err)
+	}
+}
+
+// writableMountArgs returns candidate mount option sets for read-write
+// mounting, trying the user-supplied options first, then falling back to
+// ntfs-3g for NTFS images.
+func writableMountArgs(options []string) func(path string) [][]string {
+	return func(path string) [][]string {
+		if len(options) != 0 {
+			args := append([]string{"mount"}, options...)
+			args = append(args, path)
+			return [][]string{args}
+		}
+
+		return [][]string{
+			{"mount", "-w", path},
+			{"mount", "-o", "ntfs-3g", path},
+		}
+	}
+}
+
+// readOnlyMountArgs returns candidate mount option sets for read-only
+// mounting. In addition to the user-supplied options (if any), it tries a
+// handful of fallbacks intended to cope with mild filesystem corruption,
+// such as skipping journal replay.
+func readOnlyMountArgs(options []string) func(path string) [][]string {
+	return func(path string) [][]string {
+		if len(options) != 0 {
+			args := append([]string{"mount"}, options...)
+			args = append(args, path)
+			return [][]string{args}
+		}
+
+		return [][]string{
+			// normal read-only mount
+			{"mount", "-r", path},
+			// ext2/3/4: mount without replaying the journal, in case the
+			// journal itself is corrupt or replaying it would otherwise fail
+			{"mount", "-r", "-o", "noload", path},
+			// xfs: skip log recovery
+			{"mount", "-r", "-o", "norecovery", path},
+			// ntfs: force mount even if marked dirty/unclean
+			{"mount", "-r", "-o", "ntfs-3g,force", path},
+		}
+	}
+}
+
+// diskInject injects files into or deletes files from a disk image.
+// dst/partition specify the image and the partition number. for injecting
+// files, pairs is the dst/src filepaths. for deleting files, paths is the
+// comma-separated list of filepaths to delete. options can be used to supply
+// mount arguments.
+func diskInject(dst, partition string, pairs map[string]string, options []string, delete bool, paths []string) error {
+	mi, err := mountImage(dst, partition, writableMountArgs(options))
+	if err != nil {
+		return err
+	}
+	defer mi.Close()
 
 	if delete {
 		// delete the file paths from mntDir.
 		for _, path := range paths {
-			mntPath := filepath.Join(mntDir, path)
+			mntPath := filepath.Join(mi.mntDir, path)
 			if _, err := os.Stat(mntPath); os.IsNotExist(err) {
 				log.Warn("[image %s] path does not exist to delete: %v", dst, path)
 			} else {
@@ -402,20 +483,49 @@ func diskInject(dst, partition string, pairs map[string]string, options []string
 	} else {
 		// copy files/folders into mntDir
 		for target, source := range pairs {
-			dir := filepath.Dir(filepath.Join(mntDir, target))
+			dir := filepath.Dir(filepath.Join(mi.mntDir, target))
 			os.MkdirAll(dir, 0o775)
 
-			out, err := processWrapper("cp", "-fr", source, filepath.Join(mntDir, target))
+			out, err := processWrapper("cp", "-fr", source, filepath.Join(mi.mntDir, target))
 			if err != nil {
 				return fmt.Errorf("[image %s] %v: %v", dst, out, err)
 			}
 		}
 	}
 
-	// explicitly flush buffers
-	out, err = processWrapper("blockdev", "--flushbufs", path)
+	return nil
+}
+
+// diskExtract extracts files/directories from a disk image onto the host
+// filesystem. src/partition specify the image and the partition number.
+// pairs maps a destination path on the host to the source path within the
+// image. options can be used to supply mount arguments. The image is always
+// mounted read-only; a handful of mount fallbacks are attempted to cope with
+// mild filesystem corruption.
+func diskExtract(src, partition string, pairs map[string]string, options []string) error {
+	mi, err := mountImage(src, partition, readOnlyMountArgs(options))
 	if err != nil {
-		return fmt.Errorf("[image %s] unable to flush: %v %v", dst, out, err)
+		return err
+	}
+	defer mi.Close()
+
+	// copy files/folders out of mntDir
+	for dst, source := range pairs {
+		mntPath := filepath.Join(mi.mntDir, source)
+
+		if _, err := os.Stat(mntPath); err != nil {
+			return fmt.Errorf("[image %s] error accessing '%s' in image: %v", src, source, err)
+		}
+
+		dir := filepath.Dir(dst)
+		if err := os.MkdirAll(dir, 0o775); err != nil {
+			return fmt.Errorf("[image %s] error creating destination directory '%s': %v", src, dir, err)
+		}
+
+		out, err := processWrapper("cp", "-fr", mntPath, dst)
+		if err != nil {
+			return fmt.Errorf("[image %s] %v: %v", src, out, err)
+		}
 	}
 
 	return nil

--- a/cmd/minimega/disk_cli.go
+++ b/cmd/minimega/disk_cli.go
@@ -77,6 +77,44 @@ a comma. For example:
 		Call: wrapSimpleCLI(cliDiskInject),
 	},
 	{
+		HelpShort: "extracts files/directories from a disk",
+		HelpLong: `
+Extracts files or directories from a disk image and writes them to the host
+filesystem.
+
+To extract files from an image:
+
+	disk extract window7_miniccc.qc2 files "Program Files/miniccc":miniccc
+
+Each argument after the image should be a source and destination pair,
+separated by a ':', where the source is a path within the image and the
+destination is a path on the host. If the file paths contain spaces, use
+double quotes. Optionally, you may specify a partition (partition 1 will be
+used by default):
+
+	disk extract window7_miniccc.qc2:2 files "Program Files/miniccc":miniccc
+
+You may also specify that there is no partition on the disk, if your
+filesystem was directly written to the disk (this is highly unusual):
+
+	disk extract partitionless_disk.qc2:none files /miniccc:/miniccc
+
+You can optionally specify mount arguments to use with extract. Multiple
+options should be quoted. For example:
+
+	disk extract foo.qcow2 options "-t fat -o offset=100" files foo:bar
+
+The image is always mounted read-only. If the standard mount fails, extract
+will automatically retry with a handful of options intended to work around
+mild filesystem corruption (e.g. skipping journal replay).
+		`,
+		Patterns: []string{
+			"disk <extract,> <image> files <files like /path/to/src:/path/to/dst>...",
+			"disk <extract,> <image> <options,> <options> files <files like /path/to/src:/path/to/dst>",
+		},
+		Call: wrapSimpleCLI(cliDiskExtract),
+	},
+	{
 		HelpShort: "provides info about a disk",
 		HelpLong: `
 Provides information about a disk such as format, virtual/actual size, and backing file.
@@ -167,17 +205,25 @@ func getImage(c *minicli.Command) string {
 	return image
 }
 
-func cliDiskInject(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	image := getImage(c)
-	var partition string
-
+// splitImagePartition splits an "<image>[:<partition>]" string into its
+// image and partition parts. partition is "" if not specified.
+func splitImagePartition(image string) (string, string, error) {
 	if strings.Contains(image, ":") {
 		parts := strings.Split(image, ":")
 		if len(parts) != 2 {
-			return errors.New("found way too many ':'s, expected <path/to/image>:<partition>")
+			return "", "", errors.New("found way too many ':'s, expected <path/to/image>:<partition>")
 		}
 
-		image, partition = parts[0], parts[1]
+		return parts[0], parts[1], nil
+	}
+
+	return image, "", nil
+}
+
+func cliDiskInject(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	image, partition, err := splitImagePartition(getImage(c))
+	if err != nil {
+		return err
 	}
 
 	delete := strings.Contains(c.Original, " delete files ")
@@ -198,6 +244,30 @@ func cliDiskInject(ns *Namespace, c *minicli.Command, resp *minicli.Response) er
 	}
 
 	return diskInject(image, partition, pairs, options, delete, paths)
+}
+
+func cliDiskExtract(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	image, partition, err := splitImagePartition(getImage(c))
+	if err != nil {
+		return err
+	}
+
+	options := fieldsQuoteEscape("\"", c.StringArgs["options"])
+	log.Debug("got options: %v", options)
+
+	var files interface{}
+	if _, ok := c.StringArgs["options"]; !ok {
+		files = c.ListArgs["files"]
+	} else {
+		files = c.StringArgs["files"]
+	}
+
+	pairs, _, err := parseFiles(files, false)
+	if err != nil {
+		return err
+	}
+
+	return diskExtract(image, partition, pairs, options)
 }
 
 func cliDiskCreate(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {

--- a/cmd/minimega/disk_cli_test.go
+++ b/cmd/minimega/disk_cli_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import "testing"
+
+func TestSplitImagePartition(t *testing.T) {
+	cases := []struct {
+		name          string
+		in            string
+		wantImage     string
+		wantPartition string
+		wantErr       bool
+	}{
+		{
+			name:      "no partition",
+			in:        "/tmp/minimega/files/foo.qcow2",
+			wantImage: "/tmp/minimega/files/foo.qcow2",
+		},
+		{
+			name:          "with partition",
+			in:            "/tmp/minimega/files/foo.qcow2:2",
+			wantImage:     "/tmp/minimega/files/foo.qcow2",
+			wantPartition: "2",
+		},
+		{
+			name:          "none partition",
+			in:            "/tmp/minimega/files/foo.qcow2:none",
+			wantImage:     "/tmp/minimega/files/foo.qcow2",
+			wantPartition: "none",
+		},
+		{
+			name:    "too many colons",
+			in:      "/tmp/minimega/files/foo.qcow2:2:3",
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			image, partition, err := splitImagePartition(c.in)
+
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if image != c.wantImage {
+				t.Errorf("image = %q, want %q", image, c.wantImage)
+			}
+			if partition != c.wantPartition {
+				t.Errorf("partition = %q, want %q", partition, c.wantPartition)
+			}
+		})
+	}
+}

--- a/cmd/minimega/disk_test.go
+++ b/cmd/minimega/disk_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseInjectPairs(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "single pair",
+			in:   []string{"src:dst"},
+			want: map[string]string{"dst": "src"},
+		},
+		{
+			name: "multiple pairs",
+			in:   []string{"src1:dst1", "src2:dst2"},
+			want: map[string]string{"dst1": "src1", "dst2": "src2"},
+		},
+		{
+			name:    "malformed - no colon",
+			in:      []string{"srcdst"},
+			wantErr: true,
+		},
+		{
+			name:    "malformed - too many colons",
+			in:      []string{"src:dst:extra"},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate destination",
+			in:      []string{"src1:dst", "src2:dst"},
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseInjectPairs(c.in)
+
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("pairs = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseFiles(t *testing.T) {
+	cases := []struct {
+		name      string
+		files     interface{}
+		delete    bool
+		wantPairs map[string]string
+		wantPaths []string
+		wantErr   bool
+	}{
+		{
+			name:      "inject list arg",
+			files:     []string{"src1:dst1", "src2:dst2"},
+			wantPairs: map[string]string{"dst1": "src1", "dst2": "src2"},
+		},
+		{
+			name:      "inject string arg (options case)",
+			files:     "src:dst",
+			wantPairs: map[string]string{"dst": "src"},
+		},
+		{
+			name:      "delete single path from list arg",
+			delete:    true,
+			files:     []string{"foo.txt"},
+			wantPaths: []string{"foo.txt"},
+		},
+		{
+			name:      "delete comma-separated paths from list arg",
+			delete:    true,
+			files:     []string{"foo.txt,bar/baz.txt"},
+			wantPaths: []string{"foo.txt", "bar/baz.txt"},
+		},
+		{
+			name:      "delete single path from string arg",
+			delete:    true,
+			files:     "foo.txt",
+			wantPaths: []string{"foo.txt"},
+		},
+		{
+			name:      "delete comma-separated paths from string arg",
+			delete:    true,
+			files:     "foo.txt,bar/baz.txt",
+			wantPaths: []string{"foo.txt", "bar/baz.txt"},
+		},
+		{
+			name:    "malformed inject pair",
+			files:   []string{"nodest"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown type",
+			files:   42,
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pairs, paths, err := parseFiles(c.files, c.delete)
+
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if c.wantPairs != nil && !reflect.DeepEqual(pairs, c.wantPairs) {
+				t.Errorf("pairs = %v, want %v", pairs, c.wantPairs)
+			}
+			if c.wantPaths != nil && !reflect.DeepEqual(paths, c.wantPaths) {
+				t.Errorf("paths = %v, want %v", paths, c.wantPaths)
+			}
+		})
+	}
+}
+
+func TestWritableMountArgsNoOptions(t *testing.T) {
+	candidates := writableMountArgs(nil)("/dev/nbd0p1")
+
+	want := [][]string{
+		{"mount", "-w", "/dev/nbd0p1"},
+		{"mount", "-o", "ntfs-3g", "/dev/nbd0p1"},
+	}
+
+	if !reflect.DeepEqual(candidates, want) {
+		t.Errorf("candidates = %v, want %v", candidates, want)
+	}
+}
+
+func TestWritableMountArgsWithOptions(t *testing.T) {
+	options := []string{"-t", "fat", "-o", "offset=100"}
+	candidates := writableMountArgs(options)("/dev/nbd0p1")
+
+	want := [][]string{
+		{"mount", "-t", "fat", "-o", "offset=100", "/dev/nbd0p1"},
+	}
+
+	if !reflect.DeepEqual(candidates, want) {
+		t.Errorf("candidates = %v, want %v", candidates, want)
+	}
+}
+
+func TestReadOnlyMountArgsNoOptions(t *testing.T) {
+	candidates := readOnlyMountArgs(nil)("/dev/nbd0p1")
+
+	want := [][]string{
+		{"mount", "-r", "/dev/nbd0p1"},
+		{"mount", "-r", "-o", "noload", "/dev/nbd0p1"},
+		{"mount", "-r", "-o", "norecovery", "/dev/nbd0p1"},
+		{"mount", "-r", "-o", "ntfs-3g,force", "/dev/nbd0p1"},
+	}
+
+	if !reflect.DeepEqual(candidates, want) {
+		t.Errorf("candidates = %v, want %v", candidates, want)
+	}
+}
+
+func TestReadOnlyMountArgsWithOptions(t *testing.T) {
+	options := []string{"-t", "fat", "-o", "offset=100"}
+	candidates := readOnlyMountArgs(options)("/dev/nbd0p1")
+
+	want := [][]string{
+		{"mount", "-t", "fat", "-o", "offset=100", "/dev/nbd0p1"},
+	}
+
+	if !reflect.DeepEqual(candidates, want) {
+		t.Errorf("candidates = %v, want %v", candidates, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `disk extract` API that pulls files/directories out of a qcow2/raw
disk image and writes them to the host filesystem, mirroring the existing
`disk inject` command.

Closes #1343

## Details

- New CLI command: `disk extract <image>[:<partition>] files <src>:<dst>...`
  (with an optional `options <mount args>` clause, matching `disk inject`'s
  syntax).
- `disk extract` always mounts the image **read-only**. If the plain
  read-only mount fails, it retries with a few options:
  - `noload` (ext2/3/4 — skip journal replay)
  - `norecovery` (xfs — skip log recovery)
  - `ntfs-3g,force` (ntfs — force mount despite dirty/unclean flag)

## Testing

This repo's disk code is Linux/cgo-only (nbd, `linux/fs.h`), so validation
was done in a `golang:1.24` Linux container:

- `go build ./...`
- `go vet ./cmd/minimega/...`
- `go test ./cmd/minimega/...`

Added unit tests for the parsing/argument-building logic introduced or
touched by this change.

Actually mounting/copying from a real nbd-backed disk image requires root,
the `nbd` kernel module, and `qemu-nbd`/`mount`, which aren't available in
CI/sandbox environments (and weren't previously covered by tests either), so
`mountImage`/`diskInject`/`diskExtract` themselves are not unit tested.
