### PR TITLE
docs(agents): add agent repository guidance and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+ARG GO_IMAGE=golang:1.24.13
+FROM ${GO_IMAGE}
+
+ENV PATH="/opt/minimega-python/bin:/usr/local/go/bin:/go/bin:${PATH}"
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpcap-dev \
+    python3-build \
+    python3-venv \
+    sudo \
+  && python3 -m venv --system-site-packages /opt/minimega-python \
+  && printf '%s\n' \
+    'export PATH="/opt/minimega-python/bin:/usr/local/go/bin:/go/bin:$PATH"' \
+    > /etc/profile.d/minimega-path.sh \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+RUN groupadd --gid "${USER_GID}" "${USERNAME}" \
+  && useradd --uid "${USER_UID}" --gid "${USER_GID}" \
+    --create-home --shell /bin/bash "${USERNAME}" \
+  && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" \
+    > "/etc/sudoers.d/${USERNAME}" \
+  && chmod 0440 "/etc/sudoers.d/${USERNAME}"
+
+USER ${USERNAME}

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,69 @@
+# minimega development container
+
+Use this container for Linux source builds and unit tests when developing on
+macOS or Windows. It provides Go 1.24, vendored module resolution, libpcap
+headers, and the Python tooling used by the build scripts. It is a development
+environment, not the privileged minimega deployment image under `docker/`.
+
+## Start with VS Code
+
+1. Install Docker Desktop, configured to use Linux containers, and the VS Code
+   [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Open the repository root in VS Code.
+3. Run **Dev Containers: Reopen in Container** from the Command Palette.
+4. After changing either file in `.devcontainer/`, run
+   **Dev Containers: Rebuild Container**.
+
+The repository is bind-mounted into the container, so source edits and generated
+files remain on the host.
+
+## Run checks
+
+Open a terminal in the container and initialize the repository environment:
+
+```bash
+source scripts/env.bash
+go version
+```
+
+Run the smallest checks that cover the change:
+
+```bash
+./scripts/check.bash
+./scripts/test.bash
+GOFLAGS=-mod=vendor go test ./pkg/...
+git diff --check
+```
+
+Use `./scripts/build.bash` or `./scripts/all.bash` when the change requires the
+full source build or generated documentation. These scripts create ignored
+outputs in the bind-mounted repository; inspect the working tree afterward and
+use `./scripts/clean.bash` only when it will not remove wanted work.
+
+The optional
+[Dev Container CLI](https://github.com/devcontainers/cli) can run the same
+environment without the VS Code UI:
+
+```bash
+devcontainer up --workspace-folder .
+devcontainer exec --workspace-folder . bash -c 'source scripts/env.bash && ./scripts/test.bash'
+```
+
+## Limitations
+
+Docker Desktop supplies Linux user space, but not a Linux host equivalent for
+KVM, host kernel modules, cgroups, network namespaces, or Open vSwitch. Do not
+use this container as final validation for privileged runtime or minitest
+behavior. Use a suitable Linux host, a Linux VM with nested virtualization when
+required, or GitHub Actions, and report unverified runtime checks.
+
+Linked Git worktrees may place their common Git directory outside the mounted
+workspace. Prefer opening a regular clone. For a worktree created with relative
+Git paths, the Dev Container CLI can mount its common directory:
+
+```bash
+devcontainer up --workspace-folder . --mount-git-worktree-common-dir
+```
+
+If Git still cannot resolve the worktree, use a regular clone or explicitly
+mount the common Git directory. Do not rewrite the worktree's `.git` file.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "minimega Linux development",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "containerEnv": {
+    "GOFLAGS": "-mod=vendor"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "golang.Go"
+      ]
+    }
+  },
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true
+}

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for your interest in contributing to minimega! We welcome contribution
 ## Table of Contents
 
 - [Getting Started](#getting-started)
+  - [Development Container](#development-container)
 - [How to Contribute](#how-to-contribute)
   - [Reporting Issues](#reporting-issues)
   - [Suggesting Enhancements](#suggesting-enhancements)
@@ -41,6 +42,15 @@ Thank you for your interest in contributing to minimega! We welcome contribution
         git push origin master
         ```
 
+### Development Container
+
+On macOS or Windows, use the repository development container for Linux builds
+and unit tests. Install Docker Desktop in Linux-container mode and the VS Code
+[Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers),
+open the repository, and run **Dev Containers: Reopen in Container**. See the
+[development container guide](../.devcontainer/README.md) for checks, CLI usage,
+worktree guidance, and runtime limitations.
+
 ## How to Contribute
 
 ### Reporting Issues
@@ -57,9 +67,9 @@ We welcome suggestions for improvements! Please open an issue to discuss your id
 
 ### Submitting Code
 
-1. **Create a Branch**: Create a new branch (on your fork of the repository) for your feature or bug fix using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) notation. The branch name should follow this format:
+1. **Create a Branch**: Create a new branch (on your fork of the repository) for your feature or bug fix using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) notation. The branch name should follow this format and must not contain `/`:
     ```bash
-    type/description
+    type-short-description
     ```
     Where `type` can be one of the following:
     - `feat`: A new feature
@@ -72,7 +82,7 @@ We welcome suggestions for improvements! Please open an issue to discuss your id
 
     Example:
     ```bash
-    git checkout -b feat/add-user-authentication
+    git checkout -b feat-add-user-authentication
     ```
 
 2. **Make Your Changes**: Implement your changes.
@@ -112,7 +122,7 @@ We welcome suggestions for improvements! Please open an issue to discuss your id
     
     Example:
     ```bash
-    git push origin feat/add-user-authentication
+    git push origin feat-add-user-authentication
     ```
     
 5. **Open a Pull Request**: Go to the original repository and open a [pull request](https://github.com/sandia-minimega/minimega/pulls). Provide a clear description of your changes and reference any related issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,7 @@
 - [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
 - [ ] I have included no proprietary/sensitive information in my code or the PR.
 - [ ] I have performed a self-review of my code.
+- [ ] My branch is rebased onto `master` and has one commit unless multiple commits are intentionally reviewable.
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have made corresponding changes to the documentation.
 - [ ] I have tested my code (describe above).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,184 @@
+# AGENTS.md
+
+## Project and scoped guidance
+
+minimega is a Go platform for managing KVM virtual machines, Android emulators,
+Linux containers, networks, and distributed experiments. The root module is
+`github.com/sandia-minimega/minimega/v2`, requires Go 1.24 or newer, and uses
+vendored dependencies through `GOFLAGS=-mod=vendor`.
+
+Read the guide that matches the task instead of rediscovering repository
+behavior:
+
+- Read [`skills/minimega/SKILL.md`](skills/minimega/SKILL.md) before answering
+  minimega usage questions or changing startup flags, CLI commands, namespaces,
+  VM lifecycle, networking, file transfer, miniccc, miniweb, Docker or systemd
+  configuration, or phēnix/FIREWHEEL integration. See
+  [Development and validation](#development-and-validation) for minitest.
+- Read [`.devcontainer/README.md`](.devcontainer/README.md) before building or
+  testing on macOS or Windows.
+- Read the relevant article in
+  [`doc/content/articles/developer/`](doc/content/articles/developer/) before
+  changing locking, namespaces, naming, status updates, or vendored dependencies.
+- Read [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) before opening or
+  updating a pull request.
+
+Treat the implementation as authoritative. Update task-specific guidance when a
+behavior change makes it stale.
+
+## Repository map
+
+- `cmd/`
+  - [`cmd/minimega/`](cmd/minimega/) contains the main daemon, CLI handlers,
+    namespaces, scheduling, and VM lifecycle.
+  - Companion binaries are `apigen`, `miniccc`, `minifuzzer`,
+    `minirouter`, `minitest`, `miniweb`, `nfcat`, `passwordify`, `powerbot`,
+    `protonuke`, `pyapigen`, `rfbplay`, `rond`, `vmbetter`, `vmconfiger`, and
+    `vncdrone`.
+  - [`cmd/plumbing/`](cmd/plumbing/) contains support commands excluded from
+    canonical build and test loops.
+- [`internal/`](internal/) contains private packages: `bridge`, `gonetflow`,
+  `iomeshage`, `meshage`, `miniplumber`, `minitunnel`, `nbd`, `present`, `qemu`,
+  `qmp`, `recovery`, `ron`, `version`, `vlans`, `vmconfig`, and `vnc`.
+- [`pkg/`](pkg/) contains reusable packages: `minicli`, `miniclient`, `minilog`,
+  `minipager`, and `ranges`.
+- [`tests/`](tests/) contains minitest command files and matching `.want`
+  expectations, including distributed tests.
+- [`scripts/`](scripts/) contains canonical check, build, test, documentation,
+  install, and cleanup scripts.
+- [`doc/content/`](doc/content/) contains Markdown articles, presentations,
+  training material, and static content.
+- [`.devcontainer/`](.devcontainer/) provides Linux source-build and unit-test
+  tooling for macOS and Windows hosts.
+- [`docker/`](docker/), [`misc/daemon/`](misc/daemon/), and
+  [`packaging/`](packaging/) contain container, service, Debian, and RPM
+  configuration.
+- [`packages/`](packages/) contains maintained local module forks;
+  [`vendor/`](vendor/) contains dependency copies; [`web/`](web/) includes
+  bundled third-party projects.
+- [`lib/`](lib/) contains Python package metadata; `lib/minimega.py` is
+  generated.
+
+Useful references are the
+[hosted documentation](https://sandia-minimega.github.io/minimega/), the
+[generated API documentation](https://sandia-minimega.github.io/minimega/reference/minimega/),
+[`doc/content/articles/installing.md`](doc/content/articles/installing.md),
+and [`doc/content/articles/usage.md`](doc/content/articles/usage.md).
+
+## Development and validation
+
+Use a native Linux host for privileged runtime tests. On macOS or Windows, use
+the repository development container for Linux builds and unit tests; do not run
+the Linux-oriented scripts directly on the host.
+
+Initialize each shell:
+
+```bash
+source scripts/env.bash
+go version
+```
+
+During iteration, run the narrowest relevant test:
+
+```bash
+GOFLAGS=-mod=vendor go test ./pkg/minicli
+GOFLAGS=-mod=vendor go test ./cmd/minimega -run '^TestName$'
+GOFLAGS=-mod=vendor go test -race ./cmd/minimega -run '^TestName$'
+```
+
+Use `-race` for concurrency, namespace, meshage, and VM lifecycle changes.
+Before submitting a Go change, run:
+
+```bash
+./scripts/check.bash
+./scripts/test.bash
+git diff --check
+```
+
+Run `./scripts/all.bash` when the change affects full builds or generated
+documentation. The scripts assume GNU/Linux and regenerate ignored binaries,
+version metadata, generated API Markdown, Python bindings, and distributions; inspect the
+worktree afterward and clean only unwanted outputs.
+
+### minitest functional tests
+
+Run minitest only on a suitable isolated Linux host. Each test is an
+extensionless command file under [`tests/`](tests/) with a matching `.want`
+file; the runner writes ignored `.got` output.
+
+```bash
+sudo ./bin/minitest -dir tests -run '^vm_uuid$'
+diff -u tests/vm_uuid.want tests/vm_uuid.got
+```
+
+An expectation mismatch prints `got != want` but does not produce a failing exit
+status. Automation must inspect the output or explicitly compare `.got` and
+`.want`. Use `.filter`, `.columns`, and `.annotate false` to remove unstable
+fields, and never accept `.got` without reviewing it.
+
+## Change conventions
+
+- Run `gofmt` on changed Go files and follow nearby package and test patterns.
+- Preserve lowercase project names in prose.
+- Update CLI help, API documentation, articles, examples, and integration
+  guidance when user-visible behavior changes.
+- Keep command registration, handlers, generated API Markdown, Python bindings,
+  and external callers aligned when command syntax or output changes.
+- Do not directly edit `cmd/minimega/vmconfiger_cli.go`,
+  `internal/version/version.go`, generated API Markdown, or `lib/minimega.py`.
+  Regenerate API Markdown and Python bindings with `./scripts/doc.bash` after
+  building the documentation tools.
+  Regenerate VM configuration handlers with:
+
+  ```bash
+  source scripts/env.bash
+  go install ./cmd/vmconfiger
+  go generate ./cmd/minimega
+  ```
+
+- Files under [`doc/content/`](doc/content/) use Markdown for documentation
+  content.
+- Files under [`doc/content/releases/`](doc/content/releases/) and
+  [`doc/content/presentations/`](doc/content/presentations/) are legacy
+  documentation; do not modify or update them.
+- Do not run `go mod tidy`, regenerate `vendor/`, or change dependencies unless
+  dependency maintenance is the task. Keep changed local forks under `packages/`
+  aligned with their `vendor/` copies and preserve license notices.
+- Surface invalid configuration and operational errors through existing response
+  and logging patterns; do not add silent fallbacks.
+- Never add credentials, keys, proprietary data, VM images, packet captures, or
+  other sensitive artifacts.
+
+## Concurrency and command invariants
+
+When changing [`cmd/minimega/`](cmd/minimega/):
+
+- Route asynchronous command execution through `runCommands`; do not call
+  `minicli.ProcessCommand` directly.
+- Acquire locks in this order: `cmdChannel`, `vmLock`, `VM.lock`, then other
+  locks. minimega locks precede locks in other packages.
+- Use exported `VMs` and namespace helpers instead of directly accessing global
+  maps or namespace state.
+- Lowercase helpers may require an existing lock; preserve `// LOCK: ...`
+  annotations at non-obvious call sites.
+- Do not call `ron` operations while holding a VM lock except where existing
+  code explicitly documents safety.
+- Use the existing status-update mechanism and `meshageStatusPeriod` for
+  long-running distributed work.
+
+## CI, releases, and pull requests
+
+When build inputs, generated outputs, dependencies, or packaging change, update
+every affected workflow under [`.github/workflows/`](.github/workflows/). Do not
+publish artifacts, change `VERSION`, create tags, or use release credentials
+unless explicitly requested.
+
+- Follow [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) and
+  [`.github/pull_request_template.md`](.github/pull_request_template.md).
+- Use `type(scope): subject` for commit messages and pull request titles.
+- Use slash-free branch names such as `feat-add-user-authentication`.
+- Rebase onto upstream `master`; most pull requests should contain one commit.
+  Amend updates and use `--force-with-lease`, never `--force`.
+- Add a `Co-authored-by` trailer for each contributing AI agent.
+- Keep pull requests focused, update tests and documentation, self-review for
+  sensitive data, and report exact validation.

--- a/doc/content/training/miniclass/module-29.md
+++ b/doc/content/training/miniclass/module-29.md
@@ -15,7 +15,8 @@ minimega's plumber is designed to interact with unix command line tools and prov
 
 You can use miniplumber to send a message over miniccc in a manner very similar to netcat.
 
-You can find a presentation on miniplumber here: [github.com/sandia-minimega/minimega/blob/master/doc/content/presentations/miniplumber.slide](https://github.com/sandia-minimega/minimega/blob/master/doc/content/presentations/miniplumber.slide)
+You can find the [miniplumber presentation](../../presentations/miniplumber.md)
+in the repository.
 
 ## Environment Build
 

--- a/doc/content/training/miniclass/module-31.md
+++ b/doc/content/training/miniclass/module-31.md
@@ -13,10 +13,10 @@ This guide covers the basics of setting up a cluster to run minimega and the pro
 
 Here are some additional docs on doing so:
 
-- [minimega.org/articles/cluster.article](http://minimega.org/articles/cluster.article)
-- [minimega.org/articles/namespaces.article](http://minimega.org/articles/namespaces.article)
-- [minimega.org/articles/file.article](http://minimega.org/articles/file.article)
-- [minimega.org/articles/usage.article](http://minimega.org/articles/usage.article)
+- [Cluster guide](../../articles/cluster.md)
+- [Namespaces guide](../../articles/namespaces.md)
+- [File transfer guide](../../articles/file.md)
+- [User guide](../../articles/usage.md)
 
 ### Suggestions:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -173,6 +173,7 @@ The defaults set for minimega are:
 MM_BASE=/tmp/minimega
 MM_FILEPATH=/tmp/minimega/files
 MM_BROADCAST=255.255.255.255
+MM_VLANRANGE=101-4096
 MM_PORT=9000
 MM_DEGREE=1
 MM_CONTEXT=minimega
@@ -181,6 +182,7 @@ MM_LOGFILE=/var/log/minimega.log
 MM_FORCE=true
 MM_RECOVER=false
 MM_CGROUP=/sys/fs/cgroup
+MM_ABSSNAPSHOT=false
 ```
 
 The defaults set for miniweb are:
@@ -201,8 +203,8 @@ Docker when starting the container or by binding a file to
 
 > [!NOTE]
 > If a value is specified both as an environment variable to Docker and in
-> the file bound to `/etc/default/minimega`, the value in
-> `/etc/default/minimega` will be used.
+> the file bound to `/etc/default/minimega`, the existing non-empty environment
+> variable will be used.
 
 > [!WARNING]
 > If the port is changed for minimega or miniweb and standard container

--- a/skills/minimega/SKILL.md
+++ b/skills/minimega/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: minimega
+description: 'Guide for configuring, operating, and integrating minimega to manage KVM virtual machines, Android emulators, Linux containers, networks, namespaces, clusters, files, and miniccc command-and-control. Use for startup flags, environment variables, command files, Docker or systemd configuration, CLI commands, command socket or Python API usage, miniweb, phēnix or FIREWHEEL integration, VM lifecycle, VLANs, captures, or distributed emulation troubleshooting.'
+license: GPL-3.0-only (see LICENSE)
+---
+
+# minimega operations and integration
+
+minimega manages KVM virtual machines, Android emulators, and Linux containers
+on one host or across a mesh-connected cluster. Read
+[AGENTS.md](../../AGENTS.md) before changing this repository or writing tests;
+this skill focuses on using minimega and preserving its operational contracts.
+
+## When to use this skill
+
+- Run, attach to, automate, or troubleshoot a minimega instance.
+- Configure, launch, start, inspect, stop, or remove supported VM types.
+- Work with namespaces, scheduling, VLANs, taps, bridges, captures, or clusters.
+- Use miniccc command-and-control, file transfer, or miniweb.
+- Integrate through the command socket, Go client, generated Python module, or
+  higher-level orchestrators such as phēnix and FIREWHEEL.
+- Change code that defines minimega commands or externally visible behavior.
+
+## Execution modes
+
+Full operation requires Linux, root or equivalent device/network permissions,
+KVM, libpcap, and the external tools needed by the selected feature.
+
+```bash
+minimega                         # interactive instance
+minimega -nostdin &              # daemonized instance
+minimega -attach                 # attach to existing instance
+minimega -e vm info              # execute one command
+minimega -base /path -e vm info  # target a non-default base
+```
+
+`-attach` and `-e` connect to `<base>/minimega`, under `/tmp/minimega` by
+default. For scripts and agents, prefer one-shot `-e` commands over an
+interactive prompt.
+
+The repository container provides an `mm` wrapper:
+
+```bash
+docker exec minimega mm vm info
+```
+
+Omit `-it` for non-interactive automation. The normal container deployment is
+privileged and mounts host devices; follow `../../docker/README.md`.
+
+## Configuration and CLI help
+
+Read [AGENTS.md](../../AGENTS.md) before modifying configuration, startup flags,
+deployment defaults, the Docker wrapper, service units, or configuration
+methods. Keep every launcher aligned with the flags registered in
+[`cmd/minimega/main.go`](../../cmd/minimega/main.go) and
+[`pkg/minilog/minilog.go`](../../pkg/minilog/minilog.go).
+
+### Native process
+
+The native binary does not load YAML, JSON, or TOML configuration files, and
+does not treat `.env` as a dotenv file. Local client modes have one exception:
+they read `MM_BASE` from `/etc/minimega/minimega.conf` when needed to find the
+daemon socket.
+Startup values come from compiled defaults, supported `MM_*` process environment
+variables, and command-line flags:
+
+| Purpose | Flags |
+|---|---|
+| Runtime state | `-base`, `-filepath`, `-cgroup` |
+| Mesh and VLANs | `-context`, `-degree`, `-msa`, `-broadcast`, `-port`, `-vlanrange`, `-headnode` |
+| Lifecycle | `-nostdin`, `-force`, `-recover`, `-panic`, `-hashfiles`, `-abssnapshot` |
+| Logging | `-level`, `-logfile`, `-v`, `-verbose` |
+| Alternate and client modes | `-e`, `-attach`, `-namespace`, `-pipe`, `-version`, `-cli`, `-completion`, `-suggest` |
+
+Use Go flag syntax: `-name=value` works for every flag, `-name value` works for
+non-boolean flags, and booleans use `-flag` or `-flag=false`. Parsing stops at
+the first non-flag argument or `--`; when a flag is repeated, the last parsed
+value wins. Put `-base` and `-namespace` before the command following `-e`.
+`-namespace` affects only `-e` and `-attach`. When `-recover=true`, minimega
+attempts recovery after mesh initialization even if `-force=true`; `-force`
+only takes precedence when removing an existing command socket. When `-base`
+changes while `-filepath` retains its default value, minimega rebases the file
+path to `<base>/files`.
+
+There is no automatic startup command file. Despite the `[file]...` text in the
+startup usage line, normal server startup ignores positional arguments. Apply
+runtime configuration explicitly after startup:
+
+```bash
+minimega -e read /path/to/experiment.mm
+minimega -e read /path/to/experiment.mm check
+```
+
+`read <file>` executes commands in order, stops at invalid syntax, does not stop
+when a valid command returns an error, and rejects nested `read` commands. The
+`check` form validates syntax without executing commands.
+
+The process recognizes these environment-backed flag defaults:
+`MM_BASE`, `MM_DEGREE`, `MM_MSA`, `MM_BROADCAST`, `MM_VLANRANGE`, `MM_PORT`,
+`MM_FORCE`, `MM_RECOVER`, `MM_DAEMON`, `MM_CONTEXT`, `MM_FILEPATH`,
+`MM_LOGLEVEL`, `MM_LOGFILE`, `MM_CGROUP`, `MM_PANIC`, and `MM_ABSSNAPSHOT`.
+Explicit command-line flags take precedence. For `-e`, `-attach`, and `-pipe`,
+when neither `MM_BASE` nor `-base` is set, minimega also reads `MM_BASE` from
+`/etc/minimega/minimega.conf`; other configuration-file values are not read in
+these client modes.
+
+The process explicitly honors `GOMAXPROCS`; inherited environment variables are
+also expanded from `$NAME` or `${NAME}` in runtime command string and list
+arguments. The `.env` mentioned in command help is a runtime minicli command,
+not a file; minimega does not discover or read dotenv files. Use `.env` to
+inspect or change the daemon's environment. An empty value unsets a variable,
+and changes last only for that process lifetime. `PATH` and tool-specific
+variables still affect discovery and execution of external helpers.
+
+### Effective precedence
+
+- **Native:** explicit CLI flags, then supported process environment variables,
+  then the compiled default. Repeated CLI flags use the last value.
+- **Runtime scripts:** commands execute sequentially, so later commands can
+  replace earlier runtime state.
+- **Docker:** for generated flags, a non-empty container environment value wins
+  over `/etc/default/minimega`, which wins over the wrapper default. A duplicate
+  flag in `MM_APPEND` wins because it is appended last; explicit flags then win
+  over native defaults.
+- **systemd:** systemd resolves `EnvironmentFile=` and substitutes those values
+  into explicit `ExecStart` flags; those flags win over native defaults.
+
+### Docker container
+
+The image runs [`docker/start-minimega.sh`](../../docker/start-minimega.sh) as
+its default command. The script starts Open vSwitch, waits for it, starts
+miniweb, then runs minimega with `-nostdin` and generated flags.
+
+- `MM_BASE`, `MM_FILEPATH`, `MM_BROADCAST`, `MM_VLANRANGE`, `MM_PORT`,
+  `MM_DEGREE`, `MM_CONTEXT`, `MM_LOGLEVEL`, `MM_LOGFILE`, `MM_FORCE`,
+  `MM_RECOVER`, `MM_CGROUP`, and `MM_ABSSNAPSHOT` map to same-purpose minimega
+  flags.
+- `MINIWEB_ROOT`, `MINIWEB_HOST`, and `MINIWEB_PORT` configure miniweb.
+- `OVS_APPEND` adds raw `ovs-ctl start` arguments. `OVS_HOST_IFACE` uses
+  `<bridge>:<port>[,<port>...]`.
+- `MM_APPEND` adds otherwise unsupported minimega flags, such as
+  `-msa=20 -hashfiles`.
+
+Set values with Docker `-e`, Compose `environment` or `env_file`, or a file
+mounted at `/etc/default/minimega`. Existing **non-empty** container environment
+values take precedence; an unset or empty value permits the file value, then the
+script default. The file parser accepts simple `KEY=value` lines, strips only
+surrounding double quotes, and does not source shell expressions.
+This container-only file is distinct from the host service's
+`/etc/minimega/minimega.conf`.
+
+The wrapper expands scalar configuration values without shell quoting, so paths
+and other single values cannot safely contain whitespace, glob characters, or
+shell syntax. `MM_APPEND` and `OVS_APPEND` are intentionally split on whitespace:
+spaces separate shell-safe argument tokens but cannot be preserved inside one
+argument. In `MM_APPEND`, a positional token stops parsing later tokens. Because
+it appears last, avoid accidentally duplicating generated flags unless an
+override is intentional.
+
+Docker defaults intentionally differ from native defaults, including
+`MM_DEGREE=1`, `MM_LOGLEVEL=info`, `MM_LOGFILE=/var/log/minimega.log`, and
+`MM_FORCE=true`. Additional container gotchas:
+
+- Changing `MM_PORT` or `MINIWEB_PORT` also requires matching published ports.
+- Changing `MM_BASE` breaks the `mm` wrapper and default Compose health check,
+  which connect through `/tmp/minimega`; use `minimega -base=<path> -e ...` and
+  update the health check.
+- Supplying a command after the image name replaces the Dockerfile `CMD` and
+  skips the Open vSwitch, miniweb, and minimega startup wrapper.
+
+### systemd service
+
+The packaged [`minimega.service`](../../misc/daemon/minimega.service) reads
+`/etc/minimega/minimega.conf` through `EnvironmentFile=` and maps its `MM_*`
+values to explicit startup flags; `MM_APPEND` is not supported. Keep the file to
+literal `KEY=value` assignments and check `readlink -f` before editing because a
+package may link it into `/opt/minimega`.
+
+Restart the service after changing the environment file. After changing the unit
+or a drop-in, run `systemctl daemon-reload` before restarting; replacing
+`ExecStart` requires first clearing it with an empty `ExecStart=`. Because the
+unit uses `Restart=on-success`, use `systemctl stop minimega` rather than runtime
+`quit` when the service must remain stopped.
+
+### Getting help
+
+```bash
+minimega -h                  # startup flags and compiled defaults
+minimega -e help             # runtime command summary
+minimega -e help vm config   # exact runtime command forms
+minimega -cli                # machine-readable runtime CLI as JSON, then exit
+minimega -completion bash    # generate bash, zsh, or fish completion
+```
+
+At an interactive or attached prompt, use `help` and `help <command>`. Pass the
+correct `-base=<path>` before `-e` when the daemon uses a non-default base.
+`-suggest` is an internal completion-script interface, not normal operator help.
+
+## Core concepts
+
+### Base directory, file path, and context
+
+- `-base` controls runtime state and the local command socket.
+- `-filepath` controls files served by iomeshage; relative VM image paths resolve
+  beneath it. Use absolute paths when the file is elsewhere.
+- `-context` separates mesh discovery groups. `-degree 0` disables automatic
+  peer discovery; a positive degree maintains that many mesh connections.
+- `-broadcast` and UDP port `9000` control default mesh discovery.
+
+Do not confuse a mesh **context** with a minimega **namespace**. Contexts isolate
+clusters at process startup; namespaces isolate and schedule experiment state
+inside a running cluster.
+
+### Namespaces
+
+The active namespace scopes VMs, taps, captures, VLAN aliases, and other state.
+The default namespace is `minimega`.
+
+```text
+namespace                         # list namespaces
+namespace experiment-a            # create/select namespace
+namespace experiment-a vm info    # run one command in a namespace
+ns hosts                          # list active namespace hosts
+clear namespace                   # return to default namespace
+clear namespace experiment-a      # destroy namespace and its resources
+```
+
+A new clustered namespace normally contains mesh nodes except the local head
+node. With no mesh peers, it contains the local node. `ns add-hosts` only accepts
+hosts already present in the mesh.
+
+### VM configuration and lifecycle
+
+minimega supports `kvm`, `container`, and `android` VM types. `vm config` is
+mutable namespace-local state copied into every subsequently launched VM; it
+does not retroactively change existing VMs.
+
+```text
+vm config                         # inspect current defaults
+vm config disk image.qcow2
+vm config net LAN
+vm launch kvm node1               # create VM in BUILDING state
+vm start node1                    # start created VM
+.columns name,state vm info
+vm stop node1
+vm kill node1
+clear vm config                   # reset current VM configuration
+```
+
+KVM can boot from a disk, CD-ROM, or kernel/initrd pair. Bare-metal firmware and
+RTOS guests use KVM with `vm config baremetal true`; they require a kernel image
+and disabled backchannel, while QMP lifecycle control, serial sockets, and tap
+networking remain available. Set `vm config baremetal-network-driver <model>`
+for a board-integrated NIC that QEMU does not expose through device discovery.
+Containers require a filesystem containing their init executable. Android VMs
+require an AVD name, KVM, and discoverable `emulator` and `adb` tools;
+`android-sdk` and `android-avd-dir` are optional overrides. Disk snapshot mode
+defaults to `true`, so writes normally do not modify the source image.
+
+When `ns queueing true` is active, `vm launch <type> <name>` queues VMs.
+Run `vm launch` with no additional arguments to flush the queue and invoke the
+scheduler.
+
+## Command usage and integration
+
+- Run `help` for command groups and `help <command>` for exact syntax. Treat
+  generated help and the implementation as authoritative.
+- Commands entered at the prompt, through `-e`, over the command socket, or over
+  meshage use the same command set.
+- Output modifiers such as `.columns`, `.filter`, and `.annotate false` precede
+  the command and produce stable, narrow output for automation.
+- Use `pkg/miniclient` for Go integrations instead of implementing the socket
+  framing again.
+- `lib/minimega.py` is generated by `pyapigen`; regenerate it through
+  `scripts/build.bash`, never edit it directly.
+- Use `phenix mm <minimega command...>` when debugging through a phēnix
+  deployment.
+- Reproduce FIREWHEEL-generated commands directly in minimega when debugging
+  model component or experiment-control failures.
+
+Common command areas include:
+
+```text
+check                              # report external dependency availability
+host name                          # inspect local host
+mesh status                        # inspect cluster connectivity
+vm info                            # inspect VMs
+vlans                              # inspect allocated VLANs
+file list                          # inspect iomeshage files
+cc clients                         # inspect miniccc clients
+capture                            # inspect active captures
+```
+
+Consult command help before mutating state; subcommand requirements evolve.
+
+## Gotchas
+
+- **Do not use `-force` casually.** It repopulates a base directory that appears
+  occupied; first confirm no live instance owns it.
+- **A daemon needs `-nostdin`.** Closing stdin otherwise causes minimega to exit.
+- **Use `disconnect`, not `quit`, from `-attach`.** `quit` stops the daemon.
+- **Match `-base` for `-e` and `-attach`.** The wrong base targets a different
+  socket or reports no running instance.
+- **`vm launch` does not mean running.** Without namespace queueing it creates a
+  VM, then `vm start` starts it; with queueing it only enqueues until flushed.
+- **`vm config` persists.** Clear or explicitly replace prior values before
+  launching a different VM class.
+- **Relative images use `-filepath`.** A path valid in the shell may not resolve
+  as expected inside minimega or its container.
+- **Android capacity is finite.** Emulator console/ADB port allocation currently
+  limits each host to 64 active Android VMs, or fewer when ports are occupied.
+- **Namespace deletion is destructive.** It kills VMs and removes namespace
+  captures, VLAN aliases, and taps.
+- **Most functional operations alter the host.** Use an isolated Linux system
+  for privileged tests involving KVM, Open vSwitch, taps, mounts, or cgroups.
+- **Do not parse default tables by column position.** Select columns explicitly
+  because command output is also consumed by phēnix, FIREWHEEL, and scripts.
+
+## Troubleshooting
+
+| Symptom | Likely cause or fix |
+|---|---|
+| Existing instance not found | Pass the same `-base` used to start it and verify `<base>/minimega` exists. |
+| Startup warns about missing tools | Run `check`; install only dependencies required by the intended VM/network operation. |
+| VM remains `BUILDING` or enters `ERROR` | Inspect `vm info`, minimega logs, QEMU/KVM availability, image paths, and Open vSwitch state. |
+| Cluster peers are absent | Confirm matching `-context`, broadcast domain, port, and nonzero `-degree`; use mesh commands for manual links when broadcast is unavailable. |
+| VM image is not found | Check `-filepath`, container mounts, iomeshage availability, and whether the command used a relative path. |
+| phēnix operation fails in minimega | Run the equivalent raw command with `phenix mm`, then inspect namespace, VM, file, and miniccc state. |
+| FIREWHEEL operation fails in minimega | Capture the generated minimega command, reproduce it directly, then inspect host, namespace, VM, network, and miniccc state. |
+
+## References
+
+- `../../doc/content/articles/usage.md`: startup, scripts, command socket,
+  mesh operation, and logging.
+- `../../doc/content/articles/namespaces.md`: namespace scheduling.
+- `../../doc/content/articles/vmtypes.md`: KVM and container behavior.
+- `../../docker/README.md`: container operation and configuration.
+- [minimega API documentation](https://sandia-minimega.github.io/)
+- [phēnix](https://github.com/sandialabs/sceptre-phenix): higher-level
+  experiment orchestration.
+- [FIREWHEEL](https://github.com/sandialabs/firewheel): model-component-based
+  distributed experiment orchestration.


### PR DESCRIPTION
## Description ##

Add repository and minimega agent guidance, plus a Linux devcontainer for source builds and unit tests from macOS or Windows. Document configuration behavior, update branch naming and devcontainer contribution guidance, and align the pull request checklist.

## Motivation and context ##

Give contributors and coding agents consistent architecture, testing, integration, configuration, and cross-platform development guidance.

Related agent-guidance work:
- [sceptre-phenix#386](https://github.com/sandialabs/sceptre-phenix/pull/386) adds an `AGENTS.md`.
- [sceptre-phenix#374](https://github.com/sandialabs/sceptre-phenix/pull/374) adds the phēnix skill.
- [sceptre-phenix-apps#128](https://github.com/sandialabs/sceptre-phenix-apps/pull/128) adds an `AGENTS.md`.

## Testing ##

- `git diff --check upstream/master..HEAD`
- `python3 -m json.tool .devcontainer/devcontainer.json`
- Built `.devcontainer/Dockerfile` with Docker Desktop.
- Ran `./scripts/all.bash` successfully inside the development container.
- Validated documentation links, skill metadata, and all 28 startup flags.
- Verified `CONTRIBUTING.md` retains its structure with targeted branch naming and devcontainer guidance.
- GitHub Actions `Run Tests` passes.

Privileged KVM, kernel-module, host-network, and minitest behavior still requires a suitable Linux host.

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] My branch is rebased onto `master` and has one commit unless multiple commits are intentionally reviewable.
- [x] I have commented my code, particularly in hard-to-understand areas (documentation and configuration change).
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##

Draft while Goes figures out what he's missing and needs to add to this lol