### PR TITLE
feat(container): support cgroup v2 (alternative)

### DIFF
--- a/cmd/minimega/container.go
+++ b/cmd/minimega/container.go
@@ -308,6 +308,7 @@ var (
 	containerInitLock    sync.Mutex
 	containerInitOnce    bool
 	containerInitSuccess bool
+	containerInitErr     error
 )
 
 func containerInit() error {
@@ -315,20 +316,30 @@ func containerInit() error {
 	defer containerInitLock.Unlock()
 
 	if containerInitOnce {
-		return nil
+		return containerInitErr
 	}
 	containerInitOnce = true
 
-	// create minimega freezer and memory cgroups
 	log.Debug("cgroup init: %v", *f_cgroup)
 
-	cgroupFreezer := filepath.Join(*f_cgroup, "freezer", "minimega")
-	cgroupMemory := filepath.Join(*f_cgroup, "memory", "minimega")
-	cgroupDevices := filepath.Join(*f_cgroup, "devices", "minimega")
-	cgroupCPU := filepath.Join(*f_cgroup, "cpu", "minimega")
-	cgroups := []string{cgroupFreezer, cgroupMemory, cgroupDevices, cgroupCPU}
+	// clean potentially old cgroup noise before configuring the hierarchy
+	containerCleanCgroupDirs()
 
-	for _, cgroup := range cgroups {
+	if containerCgroupV2(*f_cgroup) {
+		containerInitErr = containerInitV2(*f_cgroup)
+	} else {
+		containerInitErr = containerInitV1(*f_cgroup)
+	}
+	if containerInitErr != nil {
+		return containerInitErr
+	}
+
+	containerInitSuccess = true
+	return nil
+}
+
+func containerInitV1(root string) error {
+	for _, cgroup := range containerCgroupParents(root) {
 		if err := os.MkdirAll(cgroup, 0755); err != nil {
 			return fmt.Errorf("cgroup mkdir: %v", err)
 		}
@@ -339,25 +350,40 @@ func containerInit() error {
 		}
 	}
 
+	cgroupMemory := containerCgroupParent(root, "memory")
 	if err := ioutil.WriteFile(filepath.Join(cgroupMemory, "memory.use_hierarchy"), []byte("1"), 0664); err != nil {
 		return fmt.Errorf("setting use_hierarchy: %v", err)
 	}
 
-	// clean potentially old cgroup noise
-	containerCleanCgroupDirs()
+	return nil
+}
 
-	containerInitSuccess = true
+func containerInitV2(root string) error {
+	if err := enableCgroupV2Controllers(root); err != nil {
+		return err
+	}
+
+	cgroup := containerCgroupParent(root, "")
+	if err := os.MkdirAll(cgroup, 0755); err != nil {
+		return fmt.Errorf("cgroup mkdir: %v", err)
+	}
+	if err := enableCgroupV2Controllers(cgroup); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func enableCgroupV2Controllers(cgroup string) error {
+	subtreeControl := filepath.Join(cgroup, "cgroup.subtree_control")
+	if err := ioutil.WriteFile(subtreeControl, []byte("+cpu +memory"), 0644); err != nil {
+		return fmt.Errorf("enabling cgroup v2 controllers in %q: %v", cgroup, err)
+	}
 	return nil
 }
 
 func containerTeardown() {
-	cgroupFreezer := filepath.Join(*f_cgroup, "freezer", "minimega")
-	cgroupMemory := filepath.Join(*f_cgroup, "memory", "minimega")
-	cgroupDevices := filepath.Join(*f_cgroup, "devices", "minimega")
-	cgroupCPU := filepath.Join(*f_cgroup, "cpu", "minimega")
-	cgroups := []string{cgroupFreezer, cgroupMemory, cgroupDevices, cgroupCPU}
-
-	for _, cgroup := range cgroups {
+	for _, cgroup := range containerCgroupParents(*f_cgroup) {
 		if err := os.Remove(cgroup); err != nil {
 			if containerInitSuccess {
 				log.Errorln(err)
@@ -1015,10 +1041,7 @@ func (vm *ContainerVM) launch() error {
 		defer vm.cond.Signal()
 
 		cgroupFreezer := vm.cgroup("freezer")
-		cgroupMemory := vm.cgroup("memory")
-		cgroupDevices := vm.cgroup("devices")
-		cgroupCPU := vm.cgroup("cpu")
-		cgroups := []string{cgroupFreezer, cgroupMemory, cgroupDevices, cgroupCPU}
+		cgroups := containerCgroupPaths(*f_cgroup, strconv.Itoa(vm.ID))
 
 		select {
 		case err := <-errChan:
@@ -1048,7 +1071,7 @@ func (vm *ContainerVM) launch() error {
 			// wait for the taskset to actually exit (from uninterruptible
 			// sleep state).
 			for {
-				t, err := ioutil.ReadFile(filepath.Join(cgroupFreezer, "tasks"))
+				t, err := ioutil.ReadFile(containerCgroupProcessFile(*f_cgroup, cgroupFreezer))
 				if err != nil {
 					vm.setErrorf("unable to read tasks: %v", err)
 					break
@@ -1363,8 +1386,8 @@ func (vm *ContainerVM) console(pseudotty *os.File) {
 }
 
 func (vm *ContainerVM) freeze() error {
-	freezer := filepath.Join(vm.cgroup("freezer"), "freezer.state")
-	if err := ioutil.WriteFile(freezer, []byte("FROZEN"), 0644); err != nil {
+	freezer, value := containerCgroupFreezeSetting(*f_cgroup, vm.cgroup("freezer"), true)
+	if err := ioutil.WriteFile(freezer, []byte(value), 0644); err != nil {
 		return fmt.Errorf("freezer: %v", err)
 	}
 
@@ -1372,8 +1395,8 @@ func (vm *ContainerVM) freeze() error {
 }
 
 func (vm *ContainerVM) thaw() error {
-	freezer := filepath.Join(vm.cgroup("freezer"), "freezer.state")
-	if err := ioutil.WriteFile(freezer, []byte("THAWED"), 0644); err != nil {
+	freezer, value := containerCgroupFreezeSetting(*f_cgroup, vm.cgroup("freezer"), false)
+	if err := ioutil.WriteFile(freezer, []byte(value), 0644); err != nil {
 		return fmt.Errorf("freezer: %v", err)
 	}
 
@@ -1381,7 +1404,7 @@ func (vm *ContainerVM) thaw() error {
 }
 
 func (vm *ContainerVM) cgroup(s string) string {
-	return filepath.Join(*f_cgroup, s, "minimega", strconv.Itoa(vm.ID))
+	return filepath.Join(containerCgroupParent(*f_cgroup, s), strconv.Itoa(vm.ID))
 }
 
 func (vm *ContainerVM) ProcStats() (map[int]*ProcStats, error) {
@@ -1507,15 +1530,22 @@ func containerChroot(fsPath string) error {
 }
 
 func containerPopulateCgroups(vmID, vcpus, memory int) error {
-	cgroupFreezer := filepath.Join(*f_cgroup, "freezer", "minimega", strconv.Itoa(vmID))
-	cgroupMemory := filepath.Join(*f_cgroup, "memory", "minimega", strconv.Itoa(vmID))
-	cgroupDevices := filepath.Join(*f_cgroup, "devices", "minimega", strconv.Itoa(vmID))
-	cgroupCPU := filepath.Join(*f_cgroup, "cpu", "minimega", strconv.Itoa(vmID))
-	cgroups := []string{cgroupFreezer, cgroupMemory, cgroupDevices, cgroupCPU}
+	if containerCgroupV2(*f_cgroup) {
+		return containerPopulateCgroupsV2(*f_cgroup, vmID, vcpus, memory)
+	}
+	return containerPopulateCgroupsV1(*f_cgroup, vmID, vcpus, memory)
+}
+
+func containerPopulateCgroupsV1(root string, vmID, vcpus, memory int) error {
+	id := strconv.Itoa(vmID)
+	cgroupMemory := filepath.Join(containerCgroupParent(root, "memory"), id)
+	cgroupDevices := filepath.Join(containerCgroupParent(root, "devices"), id)
+	cgroupCPU := filepath.Join(containerCgroupParent(root, "cpu"), id)
+	cgroups := containerCgroupPaths(root, id)
 
 	for _, cgroup := range cgroups {
 		if err := os.MkdirAll(cgroup, 0755); err != nil {
-			return err
+			return fmt.Errorf("creating cgroup %q: %v", cgroup, err)
 		}
 	}
 
@@ -1523,11 +1553,11 @@ func containerPopulateCgroups(vmID, vcpus, memory int) error {
 	deny := filepath.Join(cgroupDevices, "devices.deny")
 	allow := filepath.Join(cgroupDevices, "devices.allow")
 	if err := ioutil.WriteFile(deny, []byte("a"), 0200); err != nil {
-		return err
+		return fmt.Errorf("setting device deny list: %v", err)
 	}
 	for _, a := range containerDevices {
 		if err := ioutil.WriteFile(allow, []byte(a), 0200); err != nil {
-			return err
+			return fmt.Errorf("allowing device %q: %v", a, err)
 		}
 	}
 
@@ -1543,25 +1573,58 @@ func containerPopulateCgroups(vmID, vcpus, memory int) error {
 	quota := int64(vcpus) * time.Second.Nanoseconds() / 1000
 	cfsPeriod := filepath.Join(cgroupCPU, "cpu.cfs_period_us")
 	if err := ioutil.WriteFile(cfsPeriod, []byte(strconv.FormatInt(period, 10)), 0644); err != nil {
-		return err
+		return fmt.Errorf("setting CPU period: %v", err)
 	}
 	cfsQuota := filepath.Join(cgroupCPU, "cpu.cfs_quota_us")
 	if err := ioutil.WriteFile(cfsQuota, []byte(strconv.FormatInt(quota, 10)), 0644); err != nil {
-		return err
+		return fmt.Errorf("setting CPU quota: %v", err)
 	}
 
 	// memory
 	memLimit := filepath.Join(cgroupMemory, "memory.limit_in_bytes")
 	if err := ioutil.WriteFile(memLimit, []byte(fmt.Sprintf("%vM", memory)), 0644); err != nil {
-		return err
+		return fmt.Errorf("setting memory limit: %v", err)
 	}
 
 	// associate the pid with these permissions
 	for _, cgroup := range cgroups {
 		tasks := filepath.Join(cgroup, "cgroup.procs")
 		if err := ioutil.WriteFile(tasks, []byte(fmt.Sprintf("%v", os.Getpid())), 0644); err != nil {
-			return err
+			return fmt.Errorf("adding process to cgroup %q: %v", cgroup, err)
 		}
+	}
+
+	return nil
+}
+
+func containerPopulateCgroupsV2(root string, vmID, vcpus, memory int) error {
+	return containerPopulateCgroupsV2WithDeviceFilter(root, vmID, vcpus, memory, containerAttachDeviceFilter)
+}
+
+func containerPopulateCgroupsV2WithDeviceFilter(root string, vmID, vcpus, memory int, attachDeviceFilter func(string, []string) error) error {
+	cgroup := filepath.Join(containerCgroupParent(root, ""), strconv.Itoa(vmID))
+	if err := os.MkdirAll(cgroup, 0755); err != nil {
+		return fmt.Errorf("creating cgroup %q: %v", cgroup, err)
+	}
+
+	period := time.Second.Nanoseconds() / 1000
+	quota := int64(vcpus) * period
+	cpuMax := fmt.Sprintf("%d %d", quota, period)
+	if err := ioutil.WriteFile(filepath.Join(cgroup, "cpu.max"), []byte(cpuMax), 0644); err != nil {
+		return fmt.Errorf("setting CPU limit: %v", err)
+	}
+
+	memoryBytes := uint64(memory) * 1024 * 1024
+	if err := ioutil.WriteFile(filepath.Join(cgroup, "memory.max"), []byte(strconv.FormatUint(memoryBytes, 10)), 0644); err != nil {
+		return fmt.Errorf("setting memory limit: %v", err)
+	}
+
+	if err := attachDeviceFilter(cgroup, containerDevices); err != nil {
+		return fmt.Errorf("setting device allow list: %v", err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(cgroup, "cgroup.procs"), []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
+		return fmt.Errorf("adding process to cgroup %q: %v", cgroup, err)
 	}
 
 	return nil
@@ -1724,19 +1787,11 @@ func containerMountVolumes(fsPath string, volumes []string) error {
 // aggressively cleanup container cruff, called by the nuke api
 func containerNuke() {
 	// walk minimega cgroups for tasks, killing each one
-	cgroupFreezer := filepath.Join(*f_cgroup, "freezer", "minimega")
-	cgroupMemory := filepath.Join(*f_cgroup, "memory", "minimega")
-	cgroupDevices := filepath.Join(*f_cgroup, "devices", "minimega")
-	cgroupCPU := filepath.Join(*f_cgroup, "cpu", "minimega")
-
-	cgroups := []string{cgroupFreezer, cgroupMemory, cgroupDevices, cgroupCPU}
-
-	for _, cgroup := range cgroups {
-		if _, err := os.Stat(cgroup); err == nil {
-			err := filepath.Walk(cgroup, containerNukeWalker)
-			if err != nil {
-				log.Errorln(err)
-			}
+	cgroup := containerCgroupParent(*f_cgroup, "freezer")
+	if _, err := os.Stat(cgroup); err == nil {
+		err := filepath.Walk(cgroup, containerNukeWalker)
+		if err != nil {
+			log.Errorln(err)
 		}
 	}
 
@@ -1786,8 +1841,8 @@ func containerNukeWalker(path string, info os.FileInfo, err error) error {
 
 	log.Debug("walking file: %v", path)
 
-	switch info.Name() {
-	case "tasks":
+	processFile := filepath.Base(containerCgroupProcessFile(*f_cgroup, path))
+	if info.Name() == processFile {
 		d, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil
@@ -1801,8 +1856,9 @@ func containerNukeWalker(path string, info os.FileInfo, err error) error {
 			pathFields := strings.Split(path, string(os.PathSeparator))
 			vmID := pathFields[len(pathFields)-2]
 
-			freezer := filepath.Join(*f_cgroup, "freezer", "minimega", vmID, "freezer.state")
-			if err := ioutil.WriteFile(freezer, []byte("THAWED"), 0644); err != nil {
+			cgroup := filepath.Join(containerCgroupParent(*f_cgroup, "freezer"), vmID)
+			freezer, value := containerCgroupFreezeSetting(*f_cgroup, cgroup, false)
+			if err := ioutil.WriteFile(freezer, []byte(value), 0644); err != nil {
 				log.Debugln(err)
 			}
 
@@ -1822,13 +1878,7 @@ func containerNukeWalker(path string, info os.FileInfo, err error) error {
 
 // remove state across cgroup mounts
 func containerCleanCgroupDirs() {
-	paths := []string{
-		filepath.Join(*f_cgroup, "freezer", "minimega"),
-		filepath.Join(*f_cgroup, "memory", "minimega"),
-		filepath.Join(*f_cgroup, "devices", "minimega"),
-		filepath.Join(*f_cgroup, "cpu", "minimega"),
-	}
-	for _, d := range paths {
+	for _, d := range containerCgroupParents(*f_cgroup) {
 		_, err := os.Stat(d)
 		if err != nil {
 			continue
@@ -1864,4 +1914,60 @@ func containerCleanCgroupDirs() {
 			log.Errorln(err)
 		}
 	}
+}
+
+func containerCgroupV2(root string) bool {
+	_, err := os.Stat(filepath.Join(root, "cgroup.controllers"))
+	return err == nil
+}
+
+func containerCgroupParent(root, controller string) string {
+	if containerCgroupV2(root) {
+		return filepath.Join(root, "minimega")
+	}
+	return filepath.Join(root, controller, "minimega")
+}
+
+func containerCgroupParents(root string) []string {
+	if containerCgroupV2(root) {
+		return []string{containerCgroupParent(root, "")}
+	}
+	return []string{
+		containerCgroupParent(root, "freezer"),
+		containerCgroupParent(root, "memory"),
+		containerCgroupParent(root, "devices"),
+		containerCgroupParent(root, "cpu"),
+	}
+}
+
+func containerCgroupPaths(root, id string) []string {
+	parents := containerCgroupParents(root)
+	paths := make([]string, 0, len(parents))
+	for _, parent := range parents {
+		paths = append(paths, filepath.Join(parent, id))
+	}
+	return paths
+}
+
+func containerCgroupProcessFile(root, cgroup string) string {
+	if containerCgroupV2(root) {
+		return filepath.Join(cgroup, "cgroup.procs")
+	}
+	return filepath.Join(cgroup, "tasks")
+}
+
+func containerCgroupFreezeSetting(root, cgroup string, freeze bool) (string, string) {
+	if containerCgroupV2(root) {
+		value := "0"
+		if freeze {
+			value = "1"
+		}
+		return filepath.Join(cgroup, "cgroup.freeze"), value
+	}
+
+	value := "THAWED"
+	if freeze {
+		value = "FROZEN"
+	}
+	return filepath.Join(cgroup, "freezer.state"), value
 }

--- a/cmd/minimega/container_cgroup_devices_linux.go
+++ b/cmd/minimega/container_cgroup_devices_linux.go
@@ -1,0 +1,260 @@
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	bpfDeviceBlock = 1
+	bpfDeviceChar  = 2
+
+	bpfAccessMknod = 1
+	bpfAccessRead  = 2
+	bpfAccessWrite = 4
+)
+
+const (
+	bpfLoadWordCode      = 0x61
+	bpfMoveRegisterCode  = 0xbf
+	bpfRightShiftCode    = 0x77
+	bpfAndCode           = 0x57
+	bpfJumpNotEqualCode  = 0x55
+	bpfJumpSetCode       = 0x45
+	bpfMoveImmediateCode = 0xb7
+	bpfExitCode          = 0x95
+)
+
+type containerDeviceRule struct {
+	deviceType int32
+	major      int32
+	minor      int32
+	access     int32
+}
+
+type bpfInstruction struct {
+	code      uint8
+	dstSource uint8
+	offset    int16
+	immediate int32
+}
+
+type bpfProgLoadAttr struct {
+	progType           uint32
+	instructionCount   uint32
+	instructions       uint64
+	license            uint64
+	logLevel           uint32
+	logSize            uint32
+	logBuffer          uint64
+	kernelVersion      uint32
+	progFlags          uint32
+	progName           [16]byte
+	progIfIndex        uint32
+	expectedAttachType uint32
+}
+
+type bpfProgAttachAttr struct {
+	targetFD     uint32
+	attachBpfFD  uint32
+	attachType   uint32
+	attachFlags  uint32
+	replaceBpfFD uint32
+}
+
+func containerAttachDeviceFilter(cgroup string, devices []string) error {
+	rules := make([]containerDeviceRule, 0, len(devices))
+	for _, device := range devices {
+		rule, err := parseContainerDeviceRule(device)
+		if err != nil {
+			return err
+		}
+		rules = append(rules, rule)
+	}
+
+	instructions := containerDeviceFilterProgram(rules)
+	license := []byte("GPL\x00")
+	logBuffer := make([]byte, 64*1024)
+	loadAttr := bpfProgLoadAttr{
+		progType:           unix.BPF_PROG_TYPE_CGROUP_DEVICE,
+		instructionCount:   uint32(len(instructions)),
+		instructions:       uint64(uintptr(unsafe.Pointer(&instructions[0]))),
+		license:            uint64(uintptr(unsafe.Pointer(&license[0]))),
+		logLevel:           1,
+		logSize:            uint32(len(logBuffer)),
+		logBuffer:          uint64(uintptr(unsafe.Pointer(&logBuffer[0]))),
+		expectedAttachType: unix.BPF_CGROUP_DEVICE,
+	}
+
+	programFD, _, errno := unix.Syscall(unix.SYS_BPF, unix.BPF_PROG_LOAD, uintptr(unsafe.Pointer(&loadAttr)), unsafe.Sizeof(loadAttr))
+	runtime.KeepAlive(instructions)
+	runtime.KeepAlive(license)
+	runtime.KeepAlive(logBuffer)
+	if errno != 0 {
+		return fmt.Errorf("loading cgroup device BPF program: %v: %s", errno, strings.TrimRight(string(logBuffer), "\x00"))
+	}
+	defer unix.Close(int(programFD))
+
+	cgroupFile, err := os.Open(cgroup)
+	if err != nil {
+		return fmt.Errorf("opening cgroup %q: %v", cgroup, err)
+	}
+	defer cgroupFile.Close()
+
+	attachAttr := bpfProgAttachAttr{
+		targetFD:    uint32(cgroupFile.Fd()),
+		attachBpfFD: uint32(programFD),
+		attachType:  unix.BPF_CGROUP_DEVICE,
+	}
+	_, _, errno = unix.Syscall(unix.SYS_BPF, unix.BPF_PROG_ATTACH, uintptr(unsafe.Pointer(&attachAttr)), unsafe.Sizeof(attachAttr))
+	runtime.KeepAlive(cgroupFile)
+	if errno != 0 {
+		return fmt.Errorf("attaching cgroup device BPF program: %v", errno)
+	}
+
+	return nil
+}
+
+func parseContainerDeviceRule(value string) (containerDeviceRule, error) {
+	fields := strings.Fields(value)
+	if len(fields) != 3 {
+		return containerDeviceRule{}, fmt.Errorf("invalid device rule %q", value)
+	}
+
+	var rule containerDeviceRule
+	switch fields[0] {
+	case "b":
+		rule.deviceType = bpfDeviceBlock
+	case "c":
+		rule.deviceType = bpfDeviceChar
+	default:
+		return containerDeviceRule{}, fmt.Errorf("invalid device type in rule %q", value)
+	}
+
+	device := strings.Split(fields[1], ":")
+	if len(device) != 2 {
+		return containerDeviceRule{}, fmt.Errorf("invalid device number in rule %q", value)
+	}
+
+	var err error
+	rule.major, err = parseContainerDeviceNumber(device[0])
+	if err != nil {
+		return containerDeviceRule{}, fmt.Errorf("invalid major number in rule %q: %v", value, err)
+	}
+	rule.minor, err = parseContainerDeviceNumber(device[1])
+	if err != nil {
+		return containerDeviceRule{}, fmt.Errorf("invalid minor number in rule %q: %v", value, err)
+	}
+
+	for _, access := range fields[2] {
+		switch access {
+		case 'm':
+			rule.access |= bpfAccessMknod
+		case 'r':
+			rule.access |= bpfAccessRead
+		case 'w':
+			rule.access |= bpfAccessWrite
+		default:
+			return containerDeviceRule{}, fmt.Errorf("invalid access in device rule %q", value)
+		}
+	}
+	if rule.access == 0 {
+		return containerDeviceRule{}, fmt.Errorf("missing access in device rule %q", value)
+	}
+
+	return rule, nil
+}
+
+func parseContainerDeviceNumber(value string) (int32, error) {
+	if value == "*" {
+		return -1, nil
+	}
+
+	number, err := strconv.ParseInt(value, 10, 32)
+	if err != nil || number < 0 {
+		return 0, fmt.Errorf("expected non-negative integer or *")
+	}
+	return int32(number), nil
+}
+
+func containerDeviceFilterProgram(rules []containerDeviceRule) []bpfInstruction {
+	// A cgroup device context encodes access in the upper 16 bits and device
+	// type in the lower 16 bits. Keep those values and major/minor in registers
+	// while testing each allow-list rule.
+	instructions := []bpfInstruction{
+		bpfLoadWord(2, 1, 0),
+		bpfMoveRegister(3, 2),
+		bpfAnd(3, 0xffff),
+		bpfRightShift(2, 16),
+		bpfLoadWord(4, 1, 4),
+		bpfLoadWord(5, 1, 8),
+	}
+
+	for _, rule := range rules {
+		start := len(instructions)
+		instructions = append(instructions, bpfJumpNotEqual(3, rule.deviceType))
+		if rule.major >= 0 {
+			instructions = append(instructions, bpfJumpNotEqual(4, rule.major))
+		}
+		if rule.minor >= 0 {
+			instructions = append(instructions, bpfJumpNotEqual(5, rule.minor))
+		}
+		if denied := int32(bpfAccessMknod|bpfAccessRead|bpfAccessWrite) &^ rule.access; denied != 0 {
+			instructions = append(instructions, bpfJumpSet(2, denied))
+		}
+		instructions = append(instructions, bpfMoveImmediate(0, 1), bpfExit())
+
+		next := len(instructions)
+		for i := start; i < next-2; i++ {
+			instructions[i].offset = int16(next - i - 1)
+		}
+	}
+
+	return append(instructions, bpfMoveImmediate(0, 0), bpfExit())
+}
+
+func bpfLoadWord(destination, source uint8, offset int16) bpfInstruction {
+	return bpfInstruction{code: bpfLoadWordCode, dstSource: bpfRegisters(destination, source), offset: offset}
+}
+
+func bpfMoveRegister(destination, source uint8) bpfInstruction {
+	return bpfInstruction{code: bpfMoveRegisterCode, dstSource: bpfRegisters(destination, source)}
+}
+
+func bpfRightShift(destination uint8, immediate int32) bpfInstruction {
+	return bpfInstruction{code: bpfRightShiftCode, dstSource: bpfRegisters(destination, 0), immediate: immediate}
+}
+
+func bpfAnd(destination uint8, immediate int32) bpfInstruction {
+	return bpfInstruction{code: bpfAndCode, dstSource: bpfRegisters(destination, 0), immediate: immediate}
+}
+
+func bpfJumpNotEqual(destination uint8, immediate int32) bpfInstruction {
+	return bpfInstruction{code: bpfJumpNotEqualCode, dstSource: bpfRegisters(destination, 0), immediate: immediate}
+}
+
+func bpfJumpSet(destination uint8, immediate int32) bpfInstruction {
+	return bpfInstruction{code: bpfJumpSetCode, dstSource: bpfRegisters(destination, 0), immediate: immediate}
+}
+
+func bpfMoveImmediate(destination uint8, immediate int32) bpfInstruction {
+	return bpfInstruction{code: bpfMoveImmediateCode, dstSource: bpfRegisters(destination, 0), immediate: immediate}
+}
+
+func bpfExit() bpfInstruction {
+	return bpfInstruction{code: bpfExitCode}
+}
+
+func bpfRegisters(destination, source uint8) uint8 {
+	return destination | source<<4
+}

--- a/cmd/minimega/container_cgroup_devices_linux_test.go
+++ b/cmd/minimega/container_cgroup_devices_linux_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestContainerDeviceFilterProgram(t *testing.T) {
+	rules := make([]containerDeviceRule, 0, len(containerDevices))
+	for _, value := range containerDevices {
+		rule, err := parseContainerDeviceRule(value)
+		if err != nil {
+			t.Fatalf("parse %q: %v", value, err)
+		}
+		rules = append(rules, rule)
+	}
+
+	program := containerDeviceFilterProgram(rules)
+	tests := []struct {
+		name       string
+		deviceType int32
+		major      int32
+		minor      int32
+		access     int32
+		want       bool
+	}{
+		{"read null", bpfDeviceChar, 1, 3, bpfAccessRead, true},
+		{"write null", bpfDeviceChar, 1, 3, bpfAccessWrite, true},
+		{"create char device", bpfDeviceChar, 8, 0, bpfAccessMknod, true},
+		{"read unlisted char device", bpfDeviceChar, 8, 0, bpfAccessRead, false},
+		{"create block device", bpfDeviceBlock, 8, 0, bpfAccessMknod, true},
+		{"read block device", bpfDeviceBlock, 8, 0, bpfAccessRead, false},
+		{"read unlisted device", bpfDeviceChar, 10, 229, bpfAccessRead, false},
+		{"read and create unlisted device", bpfDeviceChar, 8, 0, bpfAccessRead | bpfAccessMknod, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := evaluateContainerDeviceFilter(t, program, test.deviceType, test.major, test.minor, test.access)
+			if got != test.want {
+				t.Fatalf("device access = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestParseContainerDeviceRuleErrors(t *testing.T) {
+	for _, value := range []string{"", "x 1:2 r", "c 1 r", "c -1:2 r", "c 1:2 x"} {
+		if _, err := parseContainerDeviceRule(value); err == nil {
+			t.Errorf("parseContainerDeviceRule(%q) succeeded", value)
+		}
+	}
+}
+
+func TestContainerCgroupV2Integration(t *testing.T) {
+	if os.Getenv("MINIMEGA_CGROUP_TEST") == "" {
+		t.Skip("set MINIMEGA_CGROUP_TEST to test against the host cgroup hierarchy")
+	}
+
+	root := os.Getenv("MINIMEGA_CGROUP_ROOT")
+	if root == "" {
+		root = "/sys/fs/cgroup"
+	}
+	if !containerCgroupV2(root) {
+		t.Skip("requires cgroup v2")
+	}
+	if err := containerInitV2(root); err != nil {
+		t.Fatalf("initialize cgroup v2: %v", err)
+	}
+
+	parent := containerCgroupParent(root, "")
+	cgroup := filepath.Join(parent, "1625")
+	cleanupCgroup := filepath.Join(root, "test-cleanup")
+	if err := os.Mkdir(cleanupCgroup, 0755); err != nil && !os.IsExist(err) {
+		t.Fatalf("create cleanup cgroup: %v", err)
+	}
+	defer func() {
+		pid := []byte(strconv.Itoa(os.Getpid()))
+		if err := os.WriteFile(filepath.Join(cleanupCgroup, "cgroup.procs"), pid, 0644); err != nil {
+			t.Errorf("move test process to cleanup cgroup: %v", err)
+			return
+		}
+		if err := os.Remove(cgroup); err != nil {
+			t.Errorf("remove test cgroup: %v", err)
+		}
+		if err := os.Remove(parent); err != nil {
+			t.Errorf("remove minimega cgroup: %v", err)
+		}
+	}()
+
+	if err := containerPopulateCgroupsV2(root, 1625, 2, 512); err != nil {
+		t.Fatalf("populate cgroup v2: %v", err)
+	}
+	assertCgroupFile(t, filepath.Join(cgroup, "cpu.max"), "2000000 1000000")
+	assertCgroupFile(t, filepath.Join(cgroup, "memory.max"), "536870912")
+
+	allowed, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatalf("open allowed device: %v", err)
+	}
+	allowed.Close()
+
+	blockedPath := filepath.Join(t.TempDir(), "blocked-device")
+	if err := unix.Mknod(blockedPath, unix.S_IFCHR|0600, int(unix.Mkdev(1, 1))); err != nil {
+		t.Fatalf("create test device: %v", err)
+	}
+	if blocked, err := os.Open(blockedPath); err == nil {
+		blocked.Close()
+		t.Fatal("opened device absent from allow list")
+	}
+}
+
+func evaluateContainerDeviceFilter(t *testing.T, program []bpfInstruction, deviceType, major, minor, access int32) bool {
+	t.Helper()
+
+	var registers [6]int32
+	context := [3]int32{access<<16 | deviceType, major, minor}
+	for pc := 0; pc < len(program); pc++ {
+		instruction := program[pc]
+		destination := instruction.dstSource & 0xf
+		source := instruction.dstSource >> 4
+
+		switch instruction.code {
+		case bpfLoadWordCode:
+			registers[destination] = context[instruction.offset/4]
+		case bpfMoveRegisterCode:
+			registers[destination] = registers[source]
+		case bpfRightShiftCode:
+			registers[destination] = int32(uint32(registers[destination]) >> instruction.immediate)
+		case bpfAndCode:
+			registers[destination] &= instruction.immediate
+		case bpfJumpNotEqualCode:
+			if registers[destination] != instruction.immediate {
+				pc += int(instruction.offset)
+			}
+		case bpfJumpSetCode:
+			if registers[destination]&instruction.immediate != 0 {
+				pc += int(instruction.offset)
+			}
+		case bpfMoveImmediateCode:
+			registers[destination] = instruction.immediate
+		case bpfExitCode:
+			return registers[0] != 0
+		default:
+			t.Fatalf("unsupported BPF instruction %#x", instruction.code)
+		}
+	}
+
+	t.Fatal("BPF program did not exit")
+	return false
+}

--- a/cmd/minimega/container_cgroup_devices_other.go
+++ b/cmd/minimega/container_cgroup_devices_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import "errors"
+
+func containerAttachDeviceFilter(string, []string) error {
+	return errors.New("cgroup device filtering requires Linux")
+}

--- a/cmd/minimega/container_cgroup_test.go
+++ b/cmd/minimega/container_cgroup_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestContainerCgroupV1(t *testing.T) {
+	root := t.TempDir()
+
+	if containerCgroupV2(root) {
+		t.Fatal("empty cgroup root detected as v2")
+	}
+	if err := containerInitV1(root); err != nil {
+		t.Fatalf("initialize cgroup v1: %v", err)
+	}
+	if err := containerPopulateCgroupsV1(root, 7, 2, 512); err != nil {
+		t.Fatalf("populate cgroup v1: %v", err)
+	}
+
+	assertCgroupFile(t, filepath.Join(root, "cpu", "minimega", "7", "cpu.cfs_period_us"), "1000000")
+	assertCgroupFile(t, filepath.Join(root, "cpu", "minimega", "7", "cpu.cfs_quota_us"), "2000000")
+	assertCgroupFile(t, filepath.Join(root, "memory", "minimega", "7", "memory.limit_in_bytes"), "512M")
+
+	for _, cgroup := range containerCgroupPaths(root, "7") {
+		assertCgroupFile(t, filepath.Join(cgroup, "cgroup.procs"), strconv.Itoa(os.Getpid()))
+	}
+
+	freezer := filepath.Join(root, "freezer", "minimega", "7")
+	path, value := containerCgroupFreezeSetting(root, freezer, true)
+	if path != filepath.Join(freezer, "freezer.state") || value != "FROZEN" {
+		t.Fatalf("unexpected v1 freeze setting: %q %q", path, value)
+	}
+	if got := containerCgroupProcessFile(root, freezer); got != filepath.Join(freezer, "tasks") {
+		t.Fatalf("unexpected v1 process file: %q", got)
+	}
+}
+
+func TestContainerCgroupV2(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "cgroup.controllers"), []byte("cpu memory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !containerCgroupV2(root) {
+		t.Fatal("unified cgroup root not detected as v2")
+	}
+	if err := containerInitV2(root); err != nil {
+		t.Fatalf("initialize cgroup v2: %v", err)
+	}
+
+	parent := filepath.Join(root, "minimega")
+	assertCgroupFile(t, filepath.Join(root, "cgroup.subtree_control"), "+cpu +memory")
+	assertCgroupFile(t, filepath.Join(parent, "cgroup.subtree_control"), "+cpu +memory")
+
+	var filterCgroup string
+	var filterDevices []string
+	attachDeviceFilter := func(cgroup string, devices []string) error {
+		filterCgroup = cgroup
+		filterDevices = append([]string(nil), devices...)
+		return nil
+	}
+	if err := containerPopulateCgroupsV2WithDeviceFilter(root, 7, 2, 512, attachDeviceFilter); err != nil {
+		t.Fatalf("populate cgroup v2: %v", err)
+	}
+
+	cgroup := filepath.Join(parent, "7")
+	if filterCgroup != cgroup {
+		t.Fatalf("device filter cgroup = %q, want %q", filterCgroup, cgroup)
+	}
+	if len(filterDevices) != len(containerDevices) {
+		t.Fatalf("device filter has %d rules, want %d", len(filterDevices), len(containerDevices))
+	}
+
+	assertCgroupFile(t, filepath.Join(cgroup, "cpu.max"), "2000000 1000000")
+	assertCgroupFile(t, filepath.Join(cgroup, "memory.max"), "536870912")
+	assertCgroupFile(t, filepath.Join(cgroup, "cgroup.procs"), strconv.Itoa(os.Getpid()))
+
+	paths := containerCgroupPaths(root, "7")
+	if len(paths) != 1 || paths[0] != cgroup {
+		t.Fatalf("unexpected v2 cgroup paths: %v", paths)
+	}
+
+	path, value := containerCgroupFreezeSetting(root, cgroup, true)
+	if path != filepath.Join(cgroup, "cgroup.freeze") || value != "1" {
+		t.Fatalf("unexpected v2 freeze setting: %q %q", path, value)
+	}
+	path, value = containerCgroupFreezeSetting(root, cgroup, false)
+	if path != filepath.Join(cgroup, "cgroup.freeze") || value != "0" {
+		t.Fatalf("unexpected v2 thaw setting: %q %q", path, value)
+	}
+	if got := containerCgroupProcessFile(root, cgroup); got != filepath.Join(cgroup, "cgroup.procs") {
+		t.Fatalf("unexpected v2 process file: %q", got)
+	}
+}
+
+func TestContainerNukeWalker(t *testing.T) {
+	tests := []struct {
+		name         string
+		v2           bool
+		processFile  string
+		freezerFile  string
+		freezerValue string
+	}{
+		{"v1", false, "tasks", "freezer.state", "THAWED"},
+		{"v2", true, "cgroup.procs", "cgroup.freeze", "0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			if test.v2 {
+				if err := os.WriteFile(filepath.Join(root, "cgroup.controllers"), nil, 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			setContainerCgroupRoot(t, root)
+
+			cgroup := filepath.Join(containerCgroupParent(root, "freezer"), "7")
+			if err := os.MkdirAll(cgroup, 0755); err != nil {
+				t.Fatal(err)
+			}
+			freezer := filepath.Join(cgroup, test.freezerFile)
+			if err := os.WriteFile(freezer, nil, 0644); err != nil {
+				t.Fatal(err)
+			}
+			processes := filepath.Join(cgroup, test.processFile)
+			if err := os.WriteFile(processes, []byte("99999999"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			info, err := os.Stat(processes)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := containerNukeWalker(processes, info, nil); err != nil {
+				t.Fatalf("walk process file: %v", err)
+			}
+			assertCgroupFile(t, freezer, test.freezerValue)
+		})
+	}
+}
+
+func TestContainerCleanCgroupDirs(t *testing.T) {
+	for _, v2 := range []bool{false, true} {
+		name := "v1"
+		if v2 {
+			name = "v2"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			if v2 {
+				if err := os.WriteFile(filepath.Join(root, "cgroup.controllers"), nil, 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			setContainerCgroupRoot(t, root)
+
+			for _, parent := range containerCgroupParents(root) {
+				if err := os.MkdirAll(filepath.Join(parent, "7"), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			containerCleanCgroupDirs()
+			for _, parent := range containerCgroupParents(root) {
+				if _, err := os.Stat(parent); !os.IsNotExist(err) {
+					t.Errorf("cgroup parent still exists: %q", parent)
+				}
+			}
+		})
+	}
+}
+
+func setContainerCgroupRoot(t *testing.T, root string) {
+	t.Helper()
+
+	original := *f_cgroup
+	*f_cgroup = root
+	t.Cleanup(func() {
+		*f_cgroup = original
+	})
+}
+
+func assertCgroupFile(t *testing.T, path, want string) {
+	t.Helper()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %q: %v", path, err)
+	}
+	if strings.TrimSpace(string(got)) != want {
+		t.Fatalf("%s = %q, want %q", path, got, want)
+	}
+}


### PR DESCRIPTION
## Description ##

- Detect unified cgroup v2 hierarchies and delegate CPU and memory controllers to the minimega subtree.
- Configure per-container CPU, memory, freezer, and process membership through cgroup v2 interfaces.
- Preserve the existing device allow list with a cgroup-device eBPF program.
- Make teardown, process waiting, nuke, and stale-directory cleanup hierarchy-aware while preserving cgroup v1 behavior.
- Add unit coverage for both hierarchy versions plus an opt-in privileged cgroup v2 integration test.

## Motivation and context ##

Modern Linux distributions default to cgroup v2, requiring minimega users to disable the unified hierarchy before containers can launch. This adds native support without requiring special kernel configuration.

Closes #1625.

Related: #1641 implements the same feature using an alternate approach.

## Testing ##

Validated in the repository Linux builder image after rebasing onto current upstream `master`:

- `go test ./cmd/minimega`
- `go vet ./cmd/minimega`
- `go build ./cmd/minimega`
- Privileged cgroup v2 integration test verifying `cpu.max`, `memory.max`, allowed `/dev/null` access, and denial of an unlisted device.

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [ ] All GitHub Actions are passing.

## Additional Notes ##

No documentation changes are included because this introduces no new CLI or configuration surface. The v2 device policy uses eBPF because the v1 devices controller is not available in a unified hierarchy.