### PR TITLE
fix(minimega): load env defaults and remove deprecated variables

### DIFF
--- a/cmd/minimega/environment.go
+++ b/cmd/minimega/environment.go
@@ -1,0 +1,308 @@
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"unicode/utf8"
+)
+
+const environmentFile = "/etc/minimega/minimega.conf"
+
+type environmentFlag struct {
+	environment string
+	flag        string
+}
+
+var baseEnvironmentFlag = environmentFlag{"MM_BASE", "base"}
+
+var environmentFlags = []environmentFlag{
+	baseEnvironmentFlag,
+	{"MM_DEGREE", "degree"},
+	{"MM_MSA", "msa"},
+	{"MM_BROADCAST", "broadcast"},
+	{"MM_VLANRANGE", "vlanrange"},
+	{"MM_PORT", "port"},
+	{"MM_FORCE", "force"},
+	{"MM_RECOVER", "recover"},
+	{"MM_DAEMON", "nostdin"},
+	{"MM_CONTEXT", "context"},
+	{"MM_FILEPATH", "filepath"},
+	{"MM_LOGLEVEL", "level"},
+	{"MM_LOGFILE", "logfile"},
+	{"MM_CGROUP", "cgroup"},
+	{"MM_PANIC", "panic"},
+	{"MM_ABSSNAPSHOT", "abssnapshot"},
+}
+
+func setEnvironmentFlagDefault(fs *flag.FlagSet, mapping environmentFlag, value string) error {
+	f := fs.Lookup(mapping.flag)
+	if f == nil {
+		return fmt.Errorf("environment variable %s references unknown flag -%s", mapping.environment, mapping.flag)
+	}
+
+	if err := f.Value.Set(value); err != nil {
+		return fmt.Errorf("invalid value %q for environment variable %s: %w", value, mapping.environment, err)
+	}
+	f.DefValue = f.Value.String()
+	return nil
+}
+
+// setEnvironmentFlagDefaults applies mapped environment values unless their flags were explicitly set.
+func setEnvironmentFlagDefaults(fs *flag.FlagSet, mappings []environmentFlag, lookupEnv func(string) (string, bool)) error {
+	commandLine := make(map[string]struct{})
+	fs.Visit(func(f *flag.Flag) {
+		commandLine[f.Name] = struct{}{}
+	})
+
+	for _, mapping := range mappings {
+		if _, ok := commandLine[mapping.flag]; ok {
+			continue
+		}
+
+		value, ok := lookupEnv(mapping.environment)
+		if !ok {
+			continue
+		}
+
+		if err := setEnvironmentFlagDefault(fs, mapping, value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type environmentFileState int
+
+const (
+	environmentPreKey environmentFileState = iota
+	environmentKey
+	environmentPreValue
+	environmentValue
+	environmentValueEscape
+	environmentSingleQuoteValue
+	environmentDoubleQuoteValue
+	environmentDoubleQuoteValueEscape
+	environmentComment
+	environmentCommentEscape
+)
+
+// readBaseEnvironmentFile reads MM_BASE from a systemd-compatible environment file.
+func readBaseEnvironmentFile(path string) (string, bool, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, err
+	}
+
+	base, found, err := parseBaseEnvironmentFile(contents)
+	if err != nil {
+		return "", false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return base, found, nil
+}
+
+// parseBaseEnvironmentFile parses MM_BASE from systemd EnvironmentFile contents.
+func parseBaseEnvironmentFile(contents []byte) (string, bool, error) {
+	var base string
+	var found bool
+	var key, value []byte
+	lastKeyWhitespace := -1
+	lastValueWhitespace := -1
+	state := environmentPreKey
+
+	reset := func() {
+		key = nil
+		value = nil
+		lastKeyWhitespace = -1
+		lastValueWhitespace = -1
+	}
+	store := func(trimValue bool) error {
+		if lastKeyWhitespace >= 0 {
+			key = key[:lastKeyWhitespace]
+		}
+		if trimValue && lastValueWhitespace >= 0 {
+			value = value[:lastValueWhitespace]
+		}
+		if !utf8.Valid(key) || !utf8.Valid(value) {
+			return fmt.Errorf("invalid UTF-8 in environment assignment")
+		}
+
+		if string(key) == "MM_BASE" {
+			base = string(value)
+			found = true
+		}
+		reset()
+		return nil
+	}
+
+	for _, c := range contents {
+		switch state {
+		case environmentPreKey:
+			if isEnvironmentComment(c) {
+				state = environmentComment
+			} else if !isEnvironmentWhitespace(c) {
+				state = environmentKey
+				key = append(key, c)
+			}
+		case environmentKey:
+			if isEnvironmentNewline(c) {
+				state = environmentPreKey
+				reset()
+			} else if c == '=' {
+				state = environmentPreValue
+				lastValueWhitespace = -1
+			} else {
+				if isEnvironmentWhitespace(c) {
+					if lastKeyWhitespace < 0 {
+						lastKeyWhitespace = len(key)
+					}
+				} else {
+					lastKeyWhitespace = -1
+				}
+				key = append(key, c)
+			}
+		case environmentPreValue:
+			if isEnvironmentNewline(c) {
+				if err := store(false); err != nil {
+					return "", false, err
+				}
+				state = environmentPreKey
+			} else if c == '\'' {
+				state = environmentSingleQuoteValue
+			} else if c == '"' {
+				state = environmentDoubleQuoteValue
+			} else if c == '\\' {
+				state = environmentValueEscape
+			} else if !isEnvironmentWhitespace(c) {
+				state = environmentValue
+				value = append(value, c)
+			}
+		case environmentValue:
+			if isEnvironmentNewline(c) {
+				if err := store(true); err != nil {
+					return "", false, err
+				}
+				state = environmentPreKey
+			} else if c == '\\' {
+				state = environmentValueEscape
+				lastValueWhitespace = -1
+			} else {
+				if isEnvironmentWhitespace(c) {
+					if lastValueWhitespace < 0 {
+						lastValueWhitespace = len(value)
+					}
+				} else {
+					lastValueWhitespace = -1
+				}
+				value = append(value, c)
+			}
+		case environmentValueEscape:
+			state = environmentValue
+			if !isEnvironmentNewline(c) {
+				value = append(value, c)
+			}
+		case environmentSingleQuoteValue:
+			if c == '\'' {
+				state = environmentPreValue
+			} else {
+				value = append(value, c)
+			}
+		case environmentDoubleQuoteValue:
+			if c == '"' {
+				state = environmentPreValue
+			} else if c == '\\' {
+				state = environmentDoubleQuoteValueEscape
+			} else {
+				value = append(value, c)
+			}
+		case environmentDoubleQuoteValueEscape:
+			state = environmentDoubleQuoteValue
+			if isEnvironmentDoubleQuoteEscape(c) {
+				value = append(value, c)
+			} else if c != '\n' {
+				value = append(value, '\\', c)
+			}
+		case environmentComment:
+			if c == '\\' {
+				state = environmentCommentEscape
+			} else if isEnvironmentNewline(c) {
+				state = environmentPreKey
+			}
+		case environmentCommentEscape:
+			if isEnvironmentNewline(c) {
+				state = environmentPreKey
+			} else {
+				state = environmentComment
+			}
+		}
+	}
+
+	switch state {
+	case environmentPreValue,
+		environmentValue,
+		environmentValueEscape,
+		environmentSingleQuoteValue,
+		environmentDoubleQuoteValue,
+		environmentDoubleQuoteValueEscape:
+		if err := store(state == environmentValue); err != nil {
+			return "", false, err
+		}
+	}
+
+	return base, found, nil
+}
+
+func isEnvironmentNewline(c byte) bool {
+	return c == '\n' || c == '\r'
+}
+
+func isEnvironmentWhitespace(c byte) bool {
+	return c == ' ' || c == '\t' || isEnvironmentNewline(c)
+}
+
+func isEnvironmentComment(c byte) bool {
+	return c == '#' || c == ';'
+}
+
+func isEnvironmentDoubleQuoteEscape(c byte) bool {
+	return c == '"' || c == '\\' || c == '$' || c == '`'
+}
+
+func flagSet(fs *flag.FlagSet, name string) bool {
+	set := false
+	fs.Visit(func(f *flag.Flag) {
+		set = set || f.Name == name
+	})
+	return set
+}
+
+// applyEnvironmentFlagDefaultsFrom combines config and process environment defaults.
+// lookupEnv is injectable so tests can use an isolated environment.
+func applyEnvironmentFlagDefaultsFrom(fs *flag.FlagSet, path string, readConfig bool, lookupEnv func(string) (string, bool)) error {
+	_, baseSet := lookupEnv("MM_BASE")
+	if readConfig && !flagSet(fs, "base") && !baseSet {
+		base, found, err := readBaseEnvironmentFile(path)
+		if errors.Is(err, os.ErrPermission) {
+			fmt.Fprintf(os.Stderr, "warning: unable to read minimega environment: %v\n", err)
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("load minimega environment: %w", err)
+		}
+		if err == nil && found {
+			if err := setEnvironmentFlagDefault(fs, baseEnvironmentFlag, base); err != nil {
+				return err
+			}
+		}
+	}
+
+	return setEnvironmentFlagDefaults(fs, environmentFlags, lookupEnv)
+}
+
+func applyEnvironmentFlagDefaults(readConfig bool) error {
+	return applyEnvironmentFlagDefaultsFrom(flag.CommandLine, environmentFile, readConfig, os.LookupEnv)
+}

--- a/cmd/minimega/environment_test.go
+++ b/cmd/minimega/environment_test.go
@@ -1,0 +1,316 @@
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetEnvironmentFlagDefaults(t *testing.T) {
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	base := fs.String("base", BASE_PATH, "")
+	port := fs.Int("port", 9000, "")
+
+	env := map[string]string{
+		"MM_BASE": "/var/run/minimega",
+		"MM_PORT": "9100",
+	}
+	lookupEnv := func(key string) (string, bool) {
+		value, ok := env[key]
+		return value, ok
+	}
+	mappings := []environmentFlag{
+		{"MM_BASE", "base"},
+		{"MM_PORT", "port"},
+	}
+
+	if err := setEnvironmentFlagDefaults(fs, mappings, lookupEnv); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := *base, "/var/run/minimega"; got != want {
+		t.Errorf("base: got %q, want %q", got, want)
+	}
+	if got, want := *port, 9100; got != want {
+		t.Errorf("port: got %d, want %d", got, want)
+	}
+	if got, want := fs.Lookup("base").DefValue, "/var/run/minimega"; got != want {
+		t.Errorf("base default: got %q, want %q", got, want)
+	}
+
+	var visited []string
+	fs.Visit(func(f *flag.Flag) {
+		visited = append(visited, f.Name)
+	})
+	if len(visited) != 0 {
+		t.Errorf("environment defaults marked flags as command-line arguments: %v", visited)
+	}
+
+	if err := fs.Parse([]string{"-base", "/cli/minimega"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := *base, "/cli/minimega"; got != want {
+		t.Errorf("command-line base: got %q, want %q", got, want)
+	}
+	if got, want := *port, 9100; got != want {
+		t.Errorf("environment port after parsing: got %d, want %d", got, want)
+	}
+}
+
+func TestSetEnvironmentFlagDefaultsInvalidValue(t *testing.T) {
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	fs.Int("port", 9000, "")
+
+	err := setEnvironmentFlagDefaults(
+		fs,
+		[]environmentFlag{{"MM_PORT", "port"}},
+		func(string) (string, bool) { return "not-a-port", true },
+	)
+	if err == nil {
+		t.Fatal("expected invalid environment value to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "MM_PORT") || !strings.Contains(got, "not-a-port") {
+		t.Errorf("error %q does not identify the environment variable and value", got)
+	}
+}
+
+func TestLocalClientRequested(t *testing.T) {
+	tests := []struct {
+		name    string
+		attach  bool
+		execute bool
+		pipe    string
+		want    bool
+	}{
+		{name: "server", want: false},
+		{name: "attach", attach: true, want: true},
+		{name: "execute", execute: true, want: true},
+		{name: "pipe", pipe: "minimega//test", want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := localClientRequested(test.attach, test.execute, test.pipe); got != test.want {
+				t.Errorf("localClientRequested() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestApplyEnvironmentFlagDefaultsFromConfigForPipe(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "minimega.conf")
+	config := `
+MM_BASE='/from config'
+MM_PORT=9100
+`
+	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	base := fs.String("base", BASE_PATH, "")
+	registerEnvironmentFlags(fs)
+
+	readConfig := localClientRequested(false, false, "minimega//test")
+	if err := applyEnvironmentFlagDefaultsFrom(fs, path, readConfig, func(string) (string, bool) {
+		return "", false
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := *base, "/from config"; got != want {
+		t.Errorf("base: got %q, want %q", got, want)
+	}
+	if got, want := fs.Lookup("port").DefValue, "9000"; got != want {
+		t.Errorf("port default: got %q, want %q; config file should only supply the client base", got, want)
+	}
+}
+
+func TestApplyEnvironmentFlagDefaultsCommandLineSkipsConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "minimega.conf")
+	if err := os.WriteFile(path, []byte("MM_BASE=\xff\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	base := fs.String("base", BASE_PATH, "")
+	registerEnvironmentFlags(fs)
+
+	if err := fs.Parse([]string{"-base", "/from-command-line"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyEnvironmentFlagDefaultsFrom(fs, path, true, func(name string) (string, bool) {
+		return "", false
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := *base, "/from-command-line"; got != want {
+		t.Errorf("base: got %q, want %q", got, want)
+	}
+}
+
+func TestApplyEnvironmentFlagDefaultsEnvironmentSkipsConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "minimega.conf")
+	if err := os.WriteFile(path, []byte("MM_BASE=\xff\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	base := fs.String("base", BASE_PATH, "")
+	registerEnvironmentFlags(fs)
+
+	if err := applyEnvironmentFlagDefaultsFrom(fs, path, true, func(name string) (string, bool) {
+		if name == "MM_BASE" {
+			return "/from-environment", true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := *base, "/from-environment"; got != want {
+		t.Errorf("base: got %q, want %q", got, want)
+	}
+}
+
+func TestParseBaseEnvironmentFileInvalidUTF8(t *testing.T) {
+	_, _, err := parseBaseEnvironmentFile([]byte("MM_BASE=\xff\n"))
+	if err == nil {
+		t.Fatal("expected invalid UTF-8 to fail")
+	}
+}
+
+func TestParseBaseEnvironmentFileSystemdSyntax(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "unquoted escape",
+			input: "MM_BASE=/tmp/minimega\\ data   \n",
+			want:  "/tmp/minimega data",
+		},
+		{
+			name:  "unquoted continuation",
+			input: "MM_BASE=/tmp/minimega\\\n-data\n",
+			want:  "/tmp/minimega-data",
+		},
+		{
+			name:  "single quoted multiline",
+			input: "MM_BASE=' /tmp/minimega\n data '\n",
+			want:  " /tmp/minimega\n data ",
+		},
+		{
+			name:  "double quoted escapes",
+			input: "MM_BASE=\"/tmp/\\$minimega\\q\"\n",
+			want:  "/tmp/$minimega\\q",
+		},
+		{
+			name:  "quoted fragments",
+			input: "MM_BASE=\"/tmp/\" 'minimega' data\n",
+			want:  "/tmp/minimegadata",
+		},
+		{
+			name:  "comment markers in value",
+			input: "; ignored\nMM_BASE=/tmp/minimega #active\n",
+			want:  "/tmp/minimega #active",
+		},
+		{
+			name:  "last assignment wins",
+			input: "MM_BASE=/old\nMM_BASE=/new\n",
+			want:  "/new",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base, found, err := parseBaseEnvironmentFile([]byte(test.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !found {
+				t.Fatal("MM_BASE not found")
+			}
+			if got := base; got != test.want {
+				t.Errorf("MM_BASE: got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestParseBaseEnvironmentFileMissing(t *testing.T) {
+	base, found, err := parseBaseEnvironmentFile([]byte("MM_PORT=9000\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Errorf("MM_BASE unexpectedly found with value %q", base)
+	}
+}
+
+func TestApplyEnvironmentFlagDefaultsMissingConfig(t *testing.T) {
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	fs.String("base", BASE_PATH, "")
+	registerEnvironmentFlags(fs)
+
+	err := applyEnvironmentFlagDefaultsFrom(
+		fs,
+		filepath.Join(t.TempDir(), "missing"),
+		true,
+		func(string) (string, bool) { return "", false },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestApplyEnvironmentFlagDefaultsSkipsConfigForServer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "minimega.conf")
+	if err := os.WriteFile(path, []byte("MM_BASE=/from-config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	base := fs.String("base", BASE_PATH, "")
+	registerEnvironmentFlags(fs)
+
+	if err := applyEnvironmentFlagDefaultsFrom(fs, path, false, func(string) (string, bool) {
+		return "", false
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := *base, BASE_PATH; got != want {
+		t.Errorf("base: got %q, want %q", got, want)
+	}
+}
+
+func TestEnvironmentFlagsRegistered(t *testing.T) {
+	for _, mapping := range environmentFlags {
+		if flag.Lookup(mapping.flag) == nil {
+			t.Errorf("%s references unknown flag -%s", mapping.environment, mapping.flag)
+		}
+	}
+}
+
+func registerEnvironmentFlags(fs *flag.FlagSet) {
+	fs.Uint("degree", 0, "")
+	fs.Uint("msa", 10, "")
+	fs.String("broadcast", "", "")
+	fs.String("vlanrange", "", "")
+	fs.Int("port", 9000, "")
+	fs.Bool("force", false, "")
+	fs.Bool("recover", false, "")
+	fs.Bool("nostdin", false, "")
+	fs.String("context", "", "")
+	fs.String("filepath", "", "")
+	fs.String("level", "", "")
+	fs.String("logfile", "", "")
+	fs.String("cgroup", "", "")
+	fs.Bool("panic", false, "")
+	fs.Bool("abssnapshot", false, "")
+}

--- a/cmd/minimega/main.go
+++ b/cmd/minimega/main.go
@@ -103,6 +103,14 @@ func suggestSet() bool {
 	return set
 }
 
+func containerShimRequested() bool {
+	return flag.NArg() > 1 && flag.Arg(0) == CONTAINER_MAGIC
+}
+
+func localClientRequested(attach, execute bool, pipe string) bool {
+	return attach || execute || pipe != ""
+}
+
 func main() {
 	var err error
 
@@ -122,11 +130,25 @@ func main() {
 		os.Exit(0)
 	}
 
+	if suggestSet() {
+		cliSetup()
+		fmt.Println(strings.Join(minicli.Suggest(*f_suggest), "\n"))
+		os.Exit(0)
+	}
+
+	// Apply environment-backed defaults unless this is an internal container shim.
+	if !containerShimRequested() {
+		if err := applyEnvironmentFlagDefaults(localClientRequested(*f_attach, *f_e, *f_pipe)); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
+
 	log.Init()
 	logLevel = log.LevelFlag
 
 	// see containerShim()
-	if flag.NArg() > 1 && flag.Arg(0) == CONTAINER_MAGIC {
+	if containerShimRequested() {
 		containerShim()
 	}
 
@@ -135,17 +157,6 @@ func main() {
 	}
 
 	cliSetup()
-
-	// used by the bash completion script to complete minicli commands
-	// passed to -e/-attach without needing a running minimega instance. We
-	// can't just check `*f_suggest != ""` here because the empty string is
-	// itself a valid (and common) partial command -- e.g. completing right
-	// after `-e ` with nothing typed yet -- so instead check whether the
-	// flag was actually set on the command line.
-	if suggestSet() {
-		fmt.Println(strings.Join(minicli.Suggest(*f_suggest), "\n"))
-		os.Exit(0)
-	}
 
 	if *f_cli {
 		if err := minicli.Validate(); err != nil {

--- a/misc/daemon/minimega.conf
+++ b/misc/daemon/minimega.conf
@@ -1,19 +1,17 @@
+# minimega reads MM_BASE from this file so client commands can find a daemon
+# using a non-default base path. Exported MM_* variables are also used as
+# command-line flag defaults; explicit flags take precedence.
+
 # minimega source/build directory
 MINIMEGA_DIR="/opt/minimega/"
 
 # Runtime directory for minimega to use also known as the BASE directory
-# "MM_RUN_PATH" is deprecated and will be removed in a future release
-# Please use "MM_BASE" instead.
-MM_RUN_PATH="/tmp/minimega"
 MM_BASE="/tmp/minimega"
 
 # Directory to serve files from
 MM_FILEPATH="/tmp/minimega/files"
 
 # Number of meshage peers to find
-# "MM_MESH_DEGREE" is deprecated and will be removed in a future release
-# Please use "MM_DEGREE" instead.
-MM_MESH_DEGREE=0
 MM_DEGREE=0
 
 # meshage MSA timeout
@@ -29,15 +27,9 @@ MM_PORT=9000
 MM_DAEMON=true
 
 # Logging level - options are "debug","info","warn","error","fatal"
-# "MM_LOG_LEVEL" is deprecated and will be removed in a future release
-# Please use "MM_LOGLEVEL" instead.
-MM_LOG_LEVEL="error"
 MM_LOGLEVEL="error"
 
 # Location for log file
-# "MM_LOG_FILE" is deprecated and will be removed in a future release
-# Please use "MM_LOGFILE" instead.
-MM_LOG_FILE="/tmp/minimega.log"
 MM_LOGFILE="/var/log/minimega.log"
 
 # Panic on quit, producing stack traces for debugging

--- a/misc/daemon/minimega.init
+++ b/misc/daemon/minimega.init
@@ -40,7 +40,7 @@ install() {
   fi
   source "$REPLY/minimega.conf" 2> /dev/null # don't display "no file or directory" error message
   # create minimega directories
-  log_dir=$(dirname $MM_LOG_FILE)
+  log_dir=$(dirname $MM_LOGFILE)
   mkdir -p $log_dir
   mkdir -p /etc/minimega/saved_vms/
   # create some links to 'install' the init script
@@ -54,7 +54,7 @@ uninstall() {
   unlink /etc/init.d/minimega
   unlink /etc/minimega/minimega.conf
   systemctl disable minimega
-  log_dir=$(dirname $MM_LOG_FILE)
+  log_dir=$(dirname $MM_LOGFILE)
   echo "Uninstallation complete. The config directory (/etc/minimega) and log directory ($log_dir) were not removed."
 }
 
@@ -65,26 +65,26 @@ update() {
 start() {
   check_if_running
   if [ "$?" == "0" ]; then # if there's already a process running
-    old_pid=`cat $MM_RUN_PATH/minimega.pid 2> /dev/null`
+    old_pid=`cat $MM_BASE/minimega.pid 2> /dev/null`
     echo "minimega already running as pid $old_pid"
     return 1
   fi
   ulimit -n 1024000 -u 4096000
-  mkdir -p $MM_RUN_PATH
+  mkdir -p $MM_BASE
   pushd $MINIMEGA_DIR &>/dev/null
-  $MINIMEGA_DIR/bin/minimega -base=$MM_RUN_PATH -filepath=$MM_FILEPATH -degree=$MM_MESH_DEGREE -nostdin=$MM_DAEMON -context=$MM_CONTEXT -port=$MM_PORT -level=$MM_LOG_LEVEL -logfile=$MM_LOG_FILE ${@:1} &> /dev/null &
+  $MINIMEGA_DIR/bin/minimega -base=$MM_BASE -filepath=$MM_FILEPATH -degree=$MM_DEGREE -nostdin=$MM_DAEMON -context=$MM_CONTEXT -port=$MM_PORT -level=$MM_LOGLEVEL -logfile=$MM_LOGFILE ${@:1} &> /dev/null &
   popd &>/dev/null
   sleep 1
-  new_pid=`cat $MM_RUN_PATH/minimega.pid 2> /dev/null`
+  new_pid=`cat $MM_BASE/minimega.pid 2> /dev/null`
   if [ "$?" != "0" ]; then # if the process has already died
     echo "minimega did not start"
     return 1
   fi
   # set minimega group permissions
-  chgrp -R minimega $MM_RUN_PATH
-  chmod -R g=u $MM_RUN_PATH
-  chmod g+s $MM_RUN_PATH ${MM_RUN_PATH}/minimega
-  echo "minimega started as process `cat $MM_RUN_PATH/minimega.pid`"
+  chgrp -R minimega $MM_BASE
+  chmod -R g=u $MM_BASE
+  chmod g+s $MM_BASE ${MM_BASE}/minimega
+  echo "minimega started as process `cat $MM_BASE/minimega.pid`"
   return 0
 }
 
@@ -94,10 +94,10 @@ stop() {
     echo "minimega is not running."
     return 1
   fi
-  pid=`cat $MM_RUN_PATH/minimega.pid 2> /dev/null`
+  pid=`cat $MM_BASE/minimega.pid 2> /dev/null`
   kill $pid
-  rm $MM_RUN_PATH/minimega.pid
-  rm $MM_RUN_PATH/minimega
+  rm $MM_BASE/minimega.pid
+  rm $MM_BASE/minimega
   echo "minimega stopped"
   return 0
 }
@@ -105,7 +105,7 @@ stop() {
 status() {
   check_if_running
   if [ "$?" == "0" ]; then # if it is running
-    pid=`cat $MM_RUN_PATH/minimega.pid 2> /dev/null`
+    pid=`cat $MM_BASE/minimega.pid 2> /dev/null`
     echo "minimega is running at pid $pid."
     return 0
   else
@@ -130,7 +130,7 @@ recover() {
 }
 
 check_if_running() {
-  pid=`cat $MM_RUN_PATH/minimega.pid 2> /dev/null`
+  pid=`cat $MM_BASE/minimega.pid 2> /dev/null`
   if [ "$?" == "0" ]; then # if it is supposed to be running
     check=`ps aux | grep minimega | grep $pid 2>/dev/null` # TODO: check for a minimega running with a different pid
     if [ "$?" == "0" ]; then # if it is running
@@ -190,5 +190,3 @@ if [ "$rtn" == "0" ]; then
 else
   exit 1
 fi
-
-

--- a/misc/daemon/minimega.service
+++ b/misc/daemon/minimega.service
@@ -18,13 +18,13 @@ LimitNPROC=4096000
 EnvironmentFile=/etc/minimega/minimega.conf
 # Pre Start script
 ExecStartPre=/bin/mkdir -p /etc/minimega/saved_vms/
-ExecStartPre=/bin/mkdir -p ${MM_RUN_PATH}
+ExecStartPre=/bin/mkdir -p ${MM_BASE}
 # Starting minimega
 ExecStart=/usr/bin/minimega -nostdin=${MM_DAEMON} -force=${MM_FORCE} -recover=${MM_RECOVER} -base=${MM_BASE} -filepath=${MM_FILEPATH} -broadcast=${MM_BROADCAST} -vlanrange=${MM_VLANRANGE} -port=${MM_PORT} -degree=${MM_DEGREE} -context=${MM_CONTEXT} -level=${MM_LOGLEVEL} -logfile=${MM_LOGFILE} -cgroup=${MM_CGROUP} -panic=${MM_PANIC} -msa=${MM_MSA} -abssnapshot=${MM_ABSSNAPSHOT}
 # After start options
 ExecStartPost=/bin/sleep 1
-ExecStartPost=/bin/chgrp -R minimega ${MM_RUN_PATH}
-ExecStartPost=/bin/chmod -R g=u ${MM_RUN_PATH}
-ExecStartPost=/bin/chmod g+s ${MM_RUN_PATH} ${MM_RUN_PATH}/minimega
+ExecStartPost=/bin/chgrp -R minimega ${MM_BASE}
+ExecStartPost=/bin/chmod -R g=u ${MM_BASE}
+ExecStartPost=/bin/chmod g+s ${MM_BASE} ${MM_BASE}/minimega
 # Post stop instructions
-ExecStopPost=/bin/rm -f ${MM_RUN_PATH}/minimega
+ExecStopPost=/bin/rm -f ${MM_BASE}/minimega


### PR DESCRIPTION
## Description ##

- Use `MM_*` environment variables as defaults for corresponding CLI flags
- Remove deprecated variables: `MM_RUN_PATH`, `MM_MESH_DEGREE`, `MM_LOG_LEVEL`, `MM_LOG_FILE`

Allow `minimega -attach`, `minimega -e`, and `minimega -pipe` to discover `MM_BASE` from `/etc/minimega/minimega.conf` when it is not exported into the client process. This fallback reads only `MM_BASE`; its parser matches systemd `EnvironmentFile` quoting and escaping. Offline completion helpers and internal container re-execution skip runtime configuration loading.

Remove the deprecated `MM_RUN_PATH`, `MM_MESH_DEGREE`, `MM_LOG_LEVEL`, and `MM_LOG_FILE` variables from runtime compatibility mappings, packaged daemon configuration, init and systemd scripts, tests, and documentation. Their supported replacements are `MM_BASE`, `MM_DEGREE`, `MM_LOGLEVEL`, and `MM_LOGFILE`.

## Motivation and context ##

A daemon using a custom base path could be configured through the packaged systemd environment file, but client commands still searched `/tmp/minimega` unless users repeated `-base` manually.

The removed aliases were explicitly deprecated on January 30, 2025 in #1549. Removing them now keeps all shipped configuration and runtime behavior aligned on the supported names.

Fixes #1640.

## Configuration precedence ##

1. Explicit command-line flag.
2. Corresponding supported variable in the process environment.
3. For `-attach`, `-e`, and `-pipe` only, `MM_BASE` from `/etc/minimega/minimega.conf`.
4. Built-in flag default.

## Testing ##

- Ran the full Go test suite on Linux using Go 1.24.
- Ran `gofmt` and `go vet` through `scripts/check.bash`.
- Verified shell syntax for `misc/daemon/minimega.init` with `bash -n`.
- Verified a repository-wide search contains no references to the removed variable names.
- Verified `MM_BASE` selects the attach and pipe socket paths.
- Verified systemd-style escaped values in `/etc/minimega/minimega.conf` select the same socket path as the daemon.
- Verified an explicit `-base` bypasses and overrides environment-file configuration.
- Verified process environment values override environment-file configuration.
- Verified completion generation and suggestions bypass invalid runtime environment values.
- Verified by the issue reporter with their non-default `MM_BASE` systemd setup.

## Checklist ##

- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##

N/A
