### PR TITLE
fix(vlans): propagate manually added VLAN aliases to mesh nodes

### DIFF
--- a/cmd/minimega/misc.go
+++ b/cmd/minimega/misc.go
@@ -13,7 +13,6 @@ import (
 	"image"
 	"image/png"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
@@ -104,7 +103,7 @@ func unreachable() error {
 
 func generateUUID() string {
 	log.Debugln("generateUUID")
-	uuid, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
+	uuid, err := os.ReadFile("/proc/sys/kernel/random/uuid")
 	if err != nil {
 		log.Error("generateUUID: %v", err)
 		return "00000000-0000-0000-0000-000000000000"
@@ -297,7 +296,7 @@ func hasWildcard(v map[string]bool) bool {
 func mustWrite(fpath, data string) {
 	log.Debug("writing to %v", fpath)
 
-	if err := ioutil.WriteFile(fpath, []byte(data), 0664); err != nil {
+	if err := os.WriteFile(fpath, []byte(data), 0664); err != nil {
 		log.Fatal("write %v failed: %v", fpath, err)
 	}
 }
@@ -353,32 +352,36 @@ func lookupVLAN(namespace, alias string) (int, error) {
 		// update file so that we have a copy of the vlans if minimega crashes
 		mustWrite(filepath.Join(*f_base, "vlans"), vlanInfo())
 
-		// broadcast out the alias to the cluster so that the other nodes can
-		// print the alias correctly
-		cmd := minicli.MustCompilef("namespace %v vlans add %q %v", namespace, alias, vlan)
-		cmd.SetRecord(false)
-		cmd.SetSource(namespace)
-
-		respChan, err := meshageSend(cmd, Wildcard)
-		if err != nil {
-			// don't propagate the error since this is supposed to be best-effort.
-			log.Error("unable to broadcast alias update: %v", err)
-			return vlan, nil
-		}
-
-		// read all the responses, looking for errors
-		go func() {
-			for resps := range respChan {
-				for _, resp := range resps {
-					if resp.Error != "" {
-						log.Error("unable to send alias %v -> %v to %v: %v", alias, vlan, resp.Host, resp.Error)
-					}
-				}
-			}
-		}()
+		broadcastVLANAlias(namespace, alias, vlan)
 	}
 
 	return vlan, nil
+}
+
+// broadcastVLANAlias sends an alias update to all mesh nodes. The source
+// marker prevents recipients from broadcasting the update again.
+func broadcastVLANAlias(namespace, alias string, vlan int) {
+	cmd := minicli.MustCompilef("namespace %v vlans add %q %v", namespace, alias, vlan)
+	cmd.SetRecord(false)
+	cmd.SetSource(namespace)
+
+	respChan, err := meshageSend(cmd, Wildcard)
+	if err != nil {
+		// Alias updates are best-effort; the local mapping remains valid.
+		log.Error("unable to broadcast alias update: %v", err)
+		return
+	}
+
+	// Read all the responses, looking for errors.
+	go func() {
+		for resps := range respChan {
+			for _, resp := range resps {
+				if resp.Error != "" {
+					log.Error("unable to send alias %v -> %v to %v: %v", alias, vlan, resp.Host, resp.Error)
+				}
+			}
+		}
+	}()
 }
 
 func recoverVLANs() error {
@@ -474,11 +477,11 @@ func writeInt(filename string, value int) error {
 	log.Debug("writing %v to %v", value, filename)
 
 	b := []byte(strconv.Itoa(value))
-	return ioutil.WriteFile(filename, b, 0644)
+	return os.WriteFile(filename, b, 0644)
 }
 
 func readInt(filename string) (int, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return 0, fmt.Errorf("unable to read %v: %v", filename, err)
 	}

--- a/cmd/minimega/vlans_cli.go
+++ b/cmd/minimega/vlans_cli.go
@@ -92,6 +92,10 @@ func cliVLANsAdd(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 	if err == nil {
 		// update file so that we have a copy of the vlans if minimega crashes
 		mustWrite(filepath.Join(*f_base, "vlans"), vlanInfo())
+
+		if c.Source == "" {
+			broadcastVLANAlias(ns.Name, alias, vlan)
+		}
 	}
 
 	return err

--- a/cmd/minimega/vlans_cli_test.go
+++ b/cmd/minimega/vlans_cli_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+// Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
+// rights in this software.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sandia-minimega/minimega/v2/internal/vlans"
+	"github.com/sandia-minimega/minimega/v2/pkg/minicli"
+)
+
+func TestVLANsAddMeshageSourceDoesNotBroadcast(t *testing.T) {
+	var (
+		originalVLANs       = vlans.Default
+		originalBase        = *f_base
+		originalMeshageNode = meshageNode
+	)
+
+	defer func() {
+		vlans.Default = originalVLANs
+		*f_base = originalBase
+		meshageNode = originalMeshageNode
+	}()
+
+	vlans.Default = vlans.NewVLANs()
+	*f_base = t.TempDir()
+	meshageNode = nil
+
+	c := &minicli.Command{
+		StringArgs: map[string]string{
+			"alias": "mesh-alias",
+			"vlan":  "101",
+		},
+		Source: "meshage",
+	}
+
+	if err := cliVLANsAdd(&Namespace{Name: "test"}, c, &minicli.Response{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if vlan, err := vlans.ParseVLAN("test", "mesh-alias"); err != nil || vlan != 101 {
+		t.Fatalf("got VLAN %d, %v; want 101, nil", vlan, err)
+	}
+
+	if _, err := os.Stat(filepath.Join(*f_base, "vlans")); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Description ##
Make `vlans add <alias> <id>` propagate VLAN aliases to all current mesh nodes.

## Motivation and context ##
Manual VLAN alias creation now has the same mesh behavior as automatic alias allocation during VM network configuration.

fixes #1645

## Testing ##
See #1645 for details on reproducing. This PR also includes a new test.

## Checklist ##
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
- [x] I have included no proprietary/sensitive information in my code. 
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
<!-- Please provide any additional information or context for your pull request here. -->