### PR TITLE
fix(docker): clean stale minimega pid state

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -52,8 +52,10 @@ docker run -d \
 ```
 
 The container runs the `start-minimega.sh` script as PID 1, which takes care of
-starting openvswitch, miniweb, and finally minimega. This means the minimega
-logs will be available in the container logs via Docker (`docker logs minimega`).
+starting openvswitch, miniweb, and finally minimega. On container stop, it
+forwards the shutdown signal to minimega and removes stale PID/socket state.
+This means the minimega logs will be available in the container logs via Docker
+(`docker logs minimega`).
 
 # Using Docker Compose
 

--- a/docker/start-minimega.sh
+++ b/docker/start-minimega.sh
@@ -47,6 +47,48 @@ fi
 : "${OVS_APPEND:=}"
 : "${OVS_HOST_IFACE:=}"
 
+MM_SOCKET="${MM_BASE}/minimega"
+MM_PIDFILE="${MM_BASE}/minimega.pid"
+MINIWEB_PID=""
+MINIMEGA_PID=""
+
+# Remove stale minimega socket/PID state left behind by crashes or container stops.
+cleanup_stale_minimega_state() {
+  if [[ -f "${MM_PIDFILE}" ]]; then
+    local pid exe
+
+    pid="$(<"${MM_PIDFILE}")"
+    exe="$(readlink "/proc/${pid}/exe" 2>/dev/null || true)"
+    # If the PID is missing or no longer belongs to minimega, discard stale state.
+    if [[ ! "${pid}" =~ ^[0-9]+$ || "${exe}" != "/opt/minimega/bin/minimega" ]]; then
+      rm -f "${MM_PIDFILE}" "${MM_SOCKET}"
+    fi
+  elif [[ -S "${MM_SOCKET}" ]]; then
+    # A socket without a valid pidfile means the old daemon is gone but leftovers remain.
+    rm -f "${MM_SOCKET}"
+  fi
+}
+
+# Stop the background processes we started and clean any stale state before exit.
+shutdown() {
+  if [[ -n "${MINIMEGA_PID}" ]] && kill -0 "${MINIMEGA_PID}" 2>/dev/null; then
+    kill "${MINIMEGA_PID}"
+    wait "${MINIMEGA_PID}"
+  fi
+
+  if [[ -n "${MINIWEB_PID}" ]] && kill -0 "${MINIWEB_PID}" 2>/dev/null; then
+    kill "${MINIWEB_PID}"
+    wait "${MINIWEB_PID}"
+  fi
+
+  cleanup_stale_minimega_state
+}
+
+trap shutdown EXIT
+trap 'exit 143' TERM INT
+
+cleanup_stale_minimega_state
+
 # Start Open vSwitch
 /usr/share/openvswitch/scripts/ovs-ctl start ${OVS_APPEND} |& tee -a ${MM_LOGFILE}
 if [ ${PIPESTATUS[0]} -ne 0 ]; then
@@ -99,6 +141,7 @@ fi
 
 echo "starting miniweb..." | tee -a ${MM_LOGFILE}
 /opt/minimega/bin/miniweb -root=${MINIWEB_ROOT} -addr=${MINIWEB_HOST}:${MINIWEB_PORT} &
+MINIWEB_PID=$!
 echo "miniweb started on ${MINIWEB_HOST}:${MINIWEB_PORT}" | tee -a ${MM_LOGFILE}
 
 echo "starting minimega..." | tee -a ${MM_LOGFILE}
@@ -117,4 +160,6 @@ echo "starting minimega..." | tee -a ${MM_LOGFILE}
   -logfile=${MM_LOGFILE} \
   -cgroup=${MM_CGROUP} \
   -abssnapshot=${MM_ABSSNAPSHOT} \
-  ${MM_APPEND}
+  ${MM_APPEND} &
+MINIMEGA_PID=$!
+wait "${MINIMEGA_PID}"


### PR DESCRIPTION
## Description ##
This change removes stale minimega socket/PID state before startup and on shutdown so Docker restarts do not trip the stale "already running" warning.

`2026/08/28 20:01:32 WARN main.go:209: minimega may already be running, proceed with caution`

## Motivation and context ##
Container shutdowns can leave behind a dead socket or pidfile. minimega interprets that as a live instance and warns on the next startup. The script now verifies the PID still belongs to minimega before trusting it and cleans up child processes on exit.

## Testing ##

Started minimega and phenix. Verified that stopping the container cleans up the PID and socket files. Experiments still start. No more warnings.

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
The change is limited to the Docker startup script and its inline documentation.
