### PR TITLE
ron: prevent UFS nil connection crash

### DIFF
--- a/internal/ron/ufs.go
+++ b/internal/ron/ufs.go
@@ -135,5 +135,14 @@ func (s *Server) DisconnectUFS(uuid string) error {
 }
 
 func (c *client) ufsMessage(m *Message) {
-	c.ufsConn.Write(m.Tunnel)
+	c.Lock()
+	conn := c.ufsConn
+	c.Unlock()
+
+	if conn == nil {
+		log.Debug("dropping ufs message for %v: no active connection", c.UUID)
+		return
+	}
+
+	conn.Write(m.Tunnel)
 }


### PR DESCRIPTION
## Summary
- guard UFS data forwarding against concurrent connection teardown
- synchronize access to the active UFS connection
- drop stale data messages instead of dereferencing a nil connection

## Why
miniccc file copies over mounted filesystems could crash with a segmentation fault when the UFS connection closed while a data message was in flight. The server-side handler read `ufsConn` without the same lock used by teardown paths and unconditionally called `Write`.

## Validation
- `go test ./internal/ron/...`
- `go vet ./internal/ron/...`
- `GOOS=linux go build ./cmd/miniccc/...`

Closes #1519
