### PR TITLE
fix(cc): fix wildcard file sends

### DIFF
--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -510,10 +510,11 @@ func cliCCFilter(ns *Namespace, c *minicli.Command, resp *minicli.Response) erro
 
 // send
 func cliCCFileSend(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
-	files := make([]string, len(c.ListArgs["file"]))
+	var files []string
 
-	// Ensure each file to be sent to the VM is present locally before sending.
-	for i, file := range c.ListArgs["file"] {
+	// Expand globs before fetching files through iomeshage, which only accepts
+	// individual filenames.
+	for _, file := range c.ListArgs["file"] {
 		original := file
 
 		// Strip base path from the file if it's present since the base path gets
@@ -527,23 +528,52 @@ func cliCCFileSend(ns *Namespace, c *minicli.Command, resp *minicli.Response) er
 			file = rel
 		}
 
-		_, err := iomHelper(file, c.Source)
-		if err != nil {
-			// There's no namespace directory created for the default namespace.
-			if ns.Name == DefaultNamespace {
-				return fmt.Errorf("unable to get file %s via the mesh: %w", original, err)
+		expanded := []string{file}
+		if !filepath.IsAbs(file) {
+			matches, err := filepath.Glob(filepath.Join(*f_iomBase, file))
+			if err != nil {
+				return err
 			}
 
-			file = filepath.Join(ns.Name, file)
+			if len(matches) == 0 && ns.Name != DefaultNamespace {
+				matches, err = filepath.Glob(filepath.Join(*f_iomBase, ns.Name, file))
+				if err != nil {
+					return err
+				}
+			}
 
-			// Try again, but this time with the namespace directory prepended.
-			_, err := iomHelper(file, c.Source)
-			if err != nil {
-				return fmt.Errorf("unable to get file %s via the mesh: %w", original, err)
+			if len(matches) > 0 {
+				expanded = make([]string, len(matches))
+				for i, match := range matches {
+					rel, err := filepath.Rel(*f_iomBase, match)
+					if err != nil {
+						return err
+					}
+
+					expanded[i] = rel
+				}
 			}
 		}
 
-		files[i] = file
+		for _, file := range expanded {
+			_, err := iomHelper(file, c.Source)
+			if err != nil {
+				// There's no namespace directory created for the default namespace.
+				if ns.Name == DefaultNamespace {
+					return fmt.Errorf("unable to get file %s via the mesh: %w", original, err)
+				}
+
+				file = filepath.Join(ns.Name, file)
+
+				// Try again, but this time with the namespace directory prepended.
+				_, err := iomHelper(file, c.Source)
+				if err != nil {
+					return fmt.Errorf("unable to get file %s via the mesh: %w", original, err)
+				}
+			}
+
+			files = append(files, file)
+		}
 	}
 
 	cmd, err := ns.ccServer.NewFilesSendCommand(files)

--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -529,29 +529,26 @@ func cliCCFileSend(ns *Namespace, c *minicli.Command, resp *minicli.Response) er
 		}
 
 		expanded := []string{file}
-		if !filepath.IsAbs(file) {
-			matches, err := filepath.Glob(filepath.Join(*f_iomBase, file))
+		if filepath.IsAbs(file) {
+			matches, err := filepath.Glob(file)
 			if err != nil {
 				return err
 			}
 
-			if len(matches) == 0 && ns.Name != DefaultNamespace {
-				matches, err = filepath.Glob(filepath.Join(*f_iomBase, ns.Name, file))
-				if err != nil {
-					return err
-				}
+			if len(matches) > 0 {
+				expanded = matches
+			}
+		} else {
+			var matches []string
+			if ns.Name != DefaultNamespace {
+				matches = iom.Info(filepath.Join(ns.Name, file))
+			}
+			if len(matches) == 0 {
+				matches = iom.Info(file)
 			}
 
 			if len(matches) > 0 {
-				expanded = make([]string, len(matches))
-				for i, match := range matches {
-					rel, err := filepath.Rel(*f_iomBase, match)
-					if err != nil {
-						return err
-					}
-
-					expanded[i] = rel
-				}
+				expanded = matches
 			}
 		}
 

--- a/internal/ron/server.go
+++ b/internal/ron/server.go
@@ -1024,7 +1024,7 @@ func (s *Server) NewFilesSendCommand(files []string) (*Command, error) {
 			return nil, fmt.Errorf("no such file: %v", f)
 		}
 
-		cmd.FilesSend = send
+		cmd.FilesSend = append(cmd.FilesSend, send...)
 	}
 
 	return cmd, nil

--- a/internal/ron/server_test.go
+++ b/internal/ron/server_test.go
@@ -4,7 +4,12 @@
 
 package ron
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
 
 func TestBindClientUUIDUsesSerialIdentity(t *testing.T) {
 	want := "3b440429-067f-5b75-a0c3-f436519f8ccb"
@@ -38,5 +43,30 @@ func TestBindClientUUIDRejectsUnboundIdentity(t *testing.T) {
 				t.Fatal("expected an unbound client identity error")
 			}
 		})
+	}
+}
+
+func TestNewFilesSendCommandExpandsMultipleGlobs(t *testing.T) {
+	path := t.TempDir()
+	for _, name := range []string{"one.txt", "two.txt", "three.log"} {
+		if err := os.WriteFile(filepath.Join(path, name), nil, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	server, err := NewServer(path, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Destroy()
+
+	command, err := server.NewFilesSendCommand([]string{"*.txt", "*.log"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"one.txt", "two.txt", "three.log"}
+	if !reflect.DeepEqual(command.FilesSend, want) {
+		t.Fatalf("files sent = %v, want %v", command.FilesSend, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes [issue #1480](https://github.com/sandia-minimega/minimega/issues/1480), where `cc send` failed with wildcard paths.
- Expand wildcard paths before miniccc file retrieval.
- Preserve all matched files in the RON send command.
- Add regression coverage for multiple globs.

Closes #1480.

## Why
`cc send *.txt` previously sent the literal wildcard to clients, causing file-not-found errors.

## Validation
- `go test ./internal/ron`
- Full minimega tests remain platform-blocked on macOS due to missing Linux headers/libpcap.