### PR TITLE
fix(minimega): avoid bridge file writes in qos info

### DIFF
--- a/cmd/minimega/vmconfig.go
+++ b/cmd/minimega/vmconfig.go
@@ -226,8 +226,11 @@ func (vm *BaseConfig) BondString(namespace string) string {
 
 func (vm *BaseConfig) QosString(b, t, i string) string {
 	var val string
-	br, err := getBridge(b)
-	if err != nil {
+
+	// This is a read-only VM info lookup; use a non-creating bridge lookup so we
+	// don't create or mutate bridge state when formatting QoS output.
+	br, ok := bridges.Lookup(b)
+	if !ok {
 		return val
 	}
 

--- a/internal/bridge/bridges.go
+++ b/internal/bridge/bridges.go
@@ -175,6 +175,21 @@ func (b Bridges) Names() []string {
 	return res
 }
 
+// Lookup returns a bridge by name without creating it if it does not already
+// exist. This is intended for read-only lookups where side effects are not
+// acceptable.
+func (b Bridges) Lookup(name string) (*Bridge, bool) {
+	bridgeLock.Lock()
+	defer bridgeLock.Unlock()
+
+	if name == "" {
+		name = b.Default
+	}
+
+	br, ok := b.bridges[name]
+	return br, ok
+}
+
 // Get a bridge by name. If one doesn't exist, it will be created.
 func (b Bridges) Get(name string) (*Bridge, error) {
 	bridgeLock.Lock()


### PR DESCRIPTION
## Summary

Avoid writing the bridge state file during read-only QoS lookups made while rendering `vm info` output.

Fixes #1444

## Testing

Can't test the performance regression, but it doesn't break anything. Tested by launching experiment and running `vm info`.

