### PR TITLE
feat(miniccc): add client auto-update support

### DIFF
--- a/cmd/miniccc/mux.go
+++ b/cmd/miniccc/mux.go
@@ -85,7 +85,15 @@ func mux(done chan struct{}) {
 		case ron.MESSAGE_COMMAND:
 			client.commandChan <- m.Commands
 		case ron.MESSAGE_FILE:
-			client.fileChan <- &m
+			if m.File != nil && m.File.Update {
+				if m.Error != "" {
+					log.Error("miniccc auto-update: %v", m.Error)
+				} else if err := handleUpdateFile(m.File); err != nil {
+					log.Error("miniccc auto-update: %v", err)
+				}
+			} else {
+				client.fileChan <- &m
+			}
 		case ron.MESSAGE_TUNNEL:
 			_, err = remote.Write(m.Tunnel)
 		case ron.MESSAGE_PIPE:

--- a/cmd/miniccc/update.go
+++ b/cmd/miniccc/update.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sandia-minimega/minimega/v2/internal/ron"
+)
+
+var updateState struct {
+	path string
+	tmp  string
+	perm os.FileMode
+	file *os.File
+}
+
+func handleUpdateFile(f *ron.File) error {
+	if f == nil {
+		return fmt.Errorf("missing update file")
+	}
+
+	if f.Offset == 0 {
+		if updateState.file != nil {
+			updateState.file.Close()
+		}
+
+		path, err := os.Executable()
+		if err != nil {
+			return err
+		}
+		updateState.path = path
+		updateState.tmp = updateTempPath(path)
+		updateState.perm = f.Perm
+		if err := os.Remove(updateState.tmp); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		updateState.file, err = os.OpenFile(updateState.tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Perm)
+		if err != nil {
+			return err
+		}
+	}
+
+	if updateState.file == nil {
+		return fmt.Errorf("update started at offset %d", f.Offset)
+	}
+	if _, err := updateState.file.WriteAt(f.Data, f.Offset); err != nil {
+		return err
+	}
+	if !f.EOF {
+		return nil
+	}
+
+	if err := updateState.file.Close(); err != nil {
+		return err
+	}
+	updateState.file = nil
+	if err := os.Chmod(updateState.tmp, updateState.perm); err != nil {
+		return err
+	}
+	return restartUpdated(updateState.path, updateState.tmp)
+}
+
+func updateTempPath(path string) string {
+	return filepath.Clean(path) + ".update"
+}

--- a/cmd/miniccc/update_linux.go
+++ b/cmd/miniccc/update_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func restartUpdated(path, update string) error {
+	if err := os.Rename(update, path); err != nil {
+		return err
+	}
+	return syscall.Exec(path, os.Args, os.Environ())
+}

--- a/cmd/miniccc/update_windows.go
+++ b/cmd/miniccc/update_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func restartUpdated(path, update string) error {
+	const script = `$update = $args[0]
+$target = $args[1]
+$clientArgs = @()
+if ($args.Length -gt 2) { $clientArgs = $args[2..($args.Length - 1)] }
+for ($i = 0; $i -lt 100; $i++) {
+	try {
+		Move-Item -LiteralPath $update -Destination $target -Force -ErrorAction Stop
+		Start-Process -FilePath $target -ArgumentList $clientArgs
+		exit 0
+	} catch {
+		Start-Sleep -Milliseconds 100
+	}
+}
+exit 1`
+
+	args := append([]string{"-NoProfile", "-NonInteractive", "-Command", script, update, path}, os.Args[1:]...)
+	if err := exec.Command("powershell.exe", args...).Start(); err != nil {
+		return err
+	}
+	os.Exit(0)
+	return nil
+}

--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -123,6 +123,7 @@ For more documentation, see the article "Command and Control API Tutorial".`,
 		Patterns: []string{
 			"cc",
 			"cc <listen,> <port>",
+			"cc <auto-update,> <true,false>",
 			"cc <clients,>",
 			"cc <filter,> [filter]...",
 			"cc <commands,>",
@@ -214,6 +215,7 @@ var ccCliSubHandlers = map[string]wrappedCLIFunc{
 	"send":            cliCCFileSend,
 	"tunnel":          cliCCTunnel,
 	"listen":          cliCCListen,
+	"auto-update":     cliCCAutoUpdate,
 	"test-conn":       cliCCTestConn,
 }
 
@@ -238,6 +240,17 @@ func cliCC(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 		},
 	}
 
+	return nil
+}
+
+func cliCCAutoUpdate(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
+	if c.BoolArgs["true"] || c.BoolArgs["false"] {
+		ns.ccAutoUpdate = c.BoolArgs["true"]
+		ns.ccServer.SetAutoUpdate(ns.ccAutoUpdate)
+		return nil
+	}
+
+	resp.Response = strconv.FormatBool(ns.ccAutoUpdate)
 	return nil
 }
 

--- a/cmd/minimega/namespace.go
+++ b/cmd/minimega/namespace.go
@@ -85,9 +85,10 @@ type Namespace struct {
 	*vnc.Player   // embed vnc player for this namespace
 
 	// Command and control for this namespace
-	ccServer *ron.Server
-	ccFilter *ron.Filter
-	ccPrefix string
+	ccServer     *ron.Server
+	ccFilter     *ron.Filter
+	ccPrefix     string
+	ccAutoUpdate bool
 
 	ccMounts map[string]ccMount
 

--- a/doc/content/articles/tutorials/cc.article
+++ b/doc/content/articles/tutorials/cc.article
@@ -93,6 +93,11 @@ Client information is stored by UUID in minimega. When a client responds to a
 command, the response is logged by minimega in a subdirectory named after the
 UUID for that client. We'll discuss responses later.
 
+Miniccc can update itself when it connects to minimega. Enable this per
+namespace with `cc auto-update true`; minimega serves `miniccc` (or
+`miniccc.exe`) from its files directory when the client version differs.
+Disable it with `cc auto-update false`.
+
 * Executing Commands
 
 Executing commands is simple - just issue `cc`exec` with the command you want

--- a/internal/ron/file.go
+++ b/internal/ron/file.go
@@ -17,9 +17,10 @@ import (
 // uniquely identify the transfer. Perm is only used for the first chunk. EOF
 // signals that this is the last data chunk.
 type File struct {
-	ID   int         // command that requested the file
-	Name string      // name of the file
-	Perm os.FileMode // permissions
+	ID     int         // command that requested the file
+	Name   string      // name of the file
+	Perm   os.FileMode // permissions
+	Update bool        // file is a miniccc auto-update binary
 
 	Data   []byte // data chunk
 	Offset int64  // offset for this chunk

--- a/internal/ron/server.go
+++ b/internal/ron/server.go
@@ -56,6 +56,7 @@ type Server struct {
 	clients    map[string]*client // map of active clients, each of which have a running handler
 	vms        map[string]VM      // map of uuid -> VM
 	clientLock sync.Mutex         // lock for clients and vms
+	autoUpdate bool
 
 	path string // path for serving files
 
@@ -101,6 +102,13 @@ func NewServer(path, subpath string, plumber *miniplumber.Plumber) (*Server, err
 	log.Info("registered new ron server: %v", filepath.Join(path, subpath))
 
 	return s, nil
+}
+
+// SetAutoUpdate enables or disables miniccc binary updates on client connect.
+func (s *Server) SetAutoUpdate(enabled bool) {
+	s.clientLock.Lock()
+	defer s.clientLock.Unlock()
+	s.autoUpdate = enabled
 }
 
 func (s *Server) Destroy() {
@@ -795,6 +803,18 @@ func (s *Server) handshake(conn net.Conn, expectedUUID string) (*client, error) 
 
 	s.clients[c.UUID] = c
 
+	if s.autoUpdate && m.Client.Version != version.Revision {
+		filename := "miniccc"
+		if m.Client.OS == "windows" {
+			filename += ".exe"
+		}
+		go func() {
+			if err := s.sendUpdateFile(c, filename); err != nil {
+				log.Error("miniccc auto-update for %v: %v", c.UUID, err)
+			}
+		}()
+	}
+
 	return c, nil
 }
 
@@ -1045,6 +1065,24 @@ func (s *Server) sendFile(c *client, filename string) error {
 	dir = s.path
 	fpath = filepath.Join(dir, filename)
 	return SendFile(dir, fpath, 0, PART_SIZE, c.sendMessage)
+}
+
+func (s *Server) sendUpdateFile(c *client, filename string) error {
+	send := func(m *Message) error {
+		if m.File != nil {
+			m.File.Update = true
+		}
+		return c.sendMessage(m)
+	}
+
+	dir := filepath.Join(s.path, s.subpath)
+	fpath := filepath.Join(dir, filename)
+	if _, err := os.Stat(fpath); err != nil {
+		dir = s.path
+		fpath = filepath.Join(dir, filename)
+	}
+
+	return SendFile(dir, fpath, 0, PART_SIZE, send)
 }
 
 // route an outgoing message to one or all clients, according to UUID


### PR DESCRIPTION
## Summary

- Add per-namespace `cc auto-update true|false` configuration.
- Deliver platform-specific miniccc binaries when client and RON versions differ.
- Replace and restart the client after receiving the update.
- Document the feature.

## Testing

- `go test ./internal/ron`
- Linux miniccc compilation with `GOOS=linux CGO_ENABLED=0`
- Windows miniccc compilation with `GOOS=windows CGO_ENABLED=0`

## Feedback requested

I am specifically looking for feedback on whether this remains a feature worth implementing and maintaining, including the operational and cross-platform tradeoffs.

Closes #1106