### PR TITLE
feat(cc): report issued command count

### DIFF
--- a/cmd/minimega/cc_cli.go
+++ b/cmd/minimega/cc_cli.go
@@ -786,7 +786,7 @@ func cliCCClients(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 // command
 func cliCCCommand(ns *Namespace, c *minicli.Command, resp *minicli.Response) error {
 	resp.Header = []string{
-		"id", "prefix", "command", "responses", "background", "once",
+		"id", "prefix", "command", "responses", "issued", "background", "once",
 		"sent", "received", "connectivity", "level", "filter",
 	}
 	resp.Tabular = [][]string{}
@@ -807,6 +807,7 @@ func cliCCCommand(ns *Namespace, c *minicli.Command, resp *minicli.Response) err
 			v.Prefix,
 			fmt.Sprintf("%v", v.Command),
 			strconv.Itoa(len(v.CheckedIn)),
+			strconv.Itoa(v.Issued),
 			strconv.FormatBool(v.Background),
 			strconv.FormatBool(v.Once),
 			fmt.Sprintf("%v", v.FilesSend),

--- a/internal/ron/command.go
+++ b/internal/ron/command.go
@@ -59,6 +59,9 @@ type Command struct {
 	// clients that have responded to this command
 	CheckedIn []string
 
+	// Issued is the number of times this command was sent to a client.
+	Issued int
+
 	// Prefix is an optional field that can be used to track commands. It is
 	// not used by the server or client.
 	Prefix string
@@ -136,6 +139,7 @@ func (c *Command) Copy() *Command {
 		PID:        c.PID,
 		KillAll:    c.KillAll,
 		Prefix:     c.Prefix,
+		Issued:     c.Issued,
 		Once:       c.Once,
 		Sent:       c.Sent,
 		Stdin:      c.Stdin,

--- a/internal/ron/server.go
+++ b/internal/ron/server.go
@@ -1050,6 +1050,7 @@ func (s *Server) sendFile(c *client, filename string) error {
 // route an outgoing message to one or all clients, according to UUID
 func (s *Server) route(m *Message) {
 	var maxCommandID int
+	var issuedLock sync.Mutex
 	for i := range m.Commands {
 		if i > maxCommandID {
 			maxCommandID = i
@@ -1122,6 +1123,12 @@ func (s *Server) route(m *Message) {
 				log.Debug("client disconnected: %v", uuid)
 			} else {
 				log.Info("unable to send message to %v: %v", uuid, err)
+			}
+		} else if m.Type == MESSAGE_COMMAND {
+			issuedLock.Lock()
+			defer issuedLock.Unlock()
+			for id := range m.Commands {
+				s.commands[id].Issued++
 			}
 		}
 	}

--- a/internal/ron/server_test.go
+++ b/internal/ron/server_test.go
@@ -4,7 +4,11 @@
 
 package ron
 
-import "testing"
+import (
+	"encoding/gob"
+	"net"
+	"testing"
+)
 
 func TestBindClientUUIDUsesSerialIdentity(t *testing.T) {
 	want := "3b440429-067f-5b75-a0c3-f436519f8ccb"
@@ -38,5 +42,60 @@ func TestBindClientUUIDRejectsUnboundIdentity(t *testing.T) {
 				t.Fatal("expected an unbound client identity error")
 			}
 		})
+	}
+}
+
+func TestSendCommandsTracksIssuedCommands(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	dec := gob.NewDecoder(clientConn)
+	s := &Server{
+		commands: map[int]*Command{
+			1: {ID: 1, Command: []string{"echo", "hello"}},
+		},
+		clients: map[string]*client{
+			"client": {
+				Client: &Client{UUID: "client"},
+				conn:   serverConn,
+				enc:    gob.NewEncoder(serverConn),
+			},
+		},
+	}
+
+	readCommand := func() {
+		t.Helper()
+
+		m := new(Message)
+		if err := dec.Decode(m); err != nil {
+			t.Fatal(err)
+		}
+		if len(m.Commands) != 1 {
+			t.Fatalf("received %d commands, want 1", len(m.Commands))
+		}
+	}
+
+	sendAndRead := func() {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			readCommand()
+		}()
+		s.sendCommands("")
+		<-done
+	}
+
+	sendAndRead()
+
+	if got := s.GetCommand(1).Issued; got != 1 {
+		t.Fatalf("issued after first send = %d, want 1", got)
+	}
+
+	s.clients["client"].maxCommandID = 0
+	sendAndRead()
+
+	if got := s.GetCommand(1).Issued; got != 2 {
+		t.Fatalf("issued after reconnect = %d, want 2", got)
 	}
 }

--- a/tests/cc
+++ b/tests/cc
@@ -29,10 +29,10 @@ namespace foo cc responses all
 namespace bar cc responses all
 
 # make sure that commands ended up being attributed correctly
-.columns id,responses,filter namespace foo cc commands
-.columns id,responses,filter namespace bar cc commands
+.columns id,responses,issued,filter namespace foo cc commands
+.columns id,responses,issued,filter namespace bar cc commands
 
 # clear commands in one namespace
 namespace foo clear cc commands
-namespace foo .columns id,responses,filter cc commands
-namespace bar .columns id,responses,filter cc commands
+namespace foo .columns id,responses,issued,filter cc commands
+namespace bar .columns id,responses,issued,filter cc commands

--- a/tests/cc.want
+++ b/tests/cc.want
@@ -37,16 +37,16 @@ foo
 bar
 
 ## # make sure that commands ended up being attributed correctly
-## .columns id,responses,filter namespace foo cc commands
-id   | responses | filter
-1    | 1         |
-## .columns id,responses,filter namespace bar cc commands
-id   | responses | filter
-1    | 1         |
+## .columns id,responses,issued,filter namespace foo cc commands
+id   | responses | issued | filter
+1    | 1         | 1      |
+## .columns id,responses,issued,filter namespace bar cc commands
+id   | responses | issued | filter
+1    | 1         | 1      |
 
 ## # clear commands in one namespace
 ## namespace foo clear cc commands
-## namespace foo .columns id,responses,filter cc commands
-## namespace bar .columns id,responses,filter cc commands
-id   | responses | filter
-1    | 1         |
+## namespace foo .columns id,responses,issued,filter cc commands
+## namespace bar .columns id,responses,issued,filter cc commands
+id   | responses | issued | filter
+1    | 1         | 1      |

--- a/tests/cc_filter_vm_info.want
+++ b/tests/cc_filter_vm_info.want
@@ -20,11 +20,11 @@
 ## shell sleep 10
 
 ## cc commands
-id   | prefix | command             | responses | background | sent | received | level | filter
-1    |        | [echo hello, world] | 1         | false      | []   | []       |       | name=foo
-2    |        | [echo hello, world] | 1         | false      | []   | []       |       | state=RUNNING
-3    |        | [echo hello, world] | 1         | false      | []   | []       |       | type=container
-4    |        | [echo hello, world] | 1         | false      | []   | []       |       | name=foo && state=RUNNING && type=container
+id   | prefix | command             | responses | issued | background | sent | received | level | filter
+1    |        | [echo hello, world] | 1         | 1      | false      | []   | []       |       | name=foo
+2    |        | [echo hello, world] | 1         | 1      | false      | []   | []       |       | state=RUNNING
+3    |        | [echo hello, world] | 1         | 1      | false      | []   | []       |       | type=container
+4    |        | [echo hello, world] | 1         | 1      | false      | []   | []       |       | name=foo && state=RUNNING && type=container
 
 ## # check responses
 ## cc responses all

--- a/tests/cc_io.want
+++ b/tests/cc_io.want
@@ -36,11 +36,11 @@ aa559b4e3523a6c931f08f4df52d58f2  /tmp/miniccc/files/cc_io.bigfile
 
 ## shell sleep 20s
 ## cc commands
-id   | prefix | command                                   | responses | background | sent            | received                           | level | filter
-1    |        | []                                        | 1         | false      | [cc_io.bigfile] | []                                 |       | 
-2    |        | [du -sb /tmp/miniccc/files/cc_io.bigfile] | 1         | false      | []              | []                                 |       | 
-3    |        | [md5sum /tmp/miniccc/files/cc_io.bigfile] | 1         | false      | []              | []                                 |       | 
-4    |        | []                                        | 1         | false      | []              | [/tmp/miniccc/files/cc_io.bigfile] |       |
+id   | prefix | command                                   | responses | issued | background | sent            | received                           | level | filter
+1    |        | []                                        | 1         | 1      | false      | [cc_io.bigfile] | []                                 |       |
+2    |        | [du -sb /tmp/miniccc/files/cc_io.bigfile] | 1         | 1      | false      | []              | []                                 |       |
+3    |        | [md5sum /tmp/miniccc/files/cc_io.bigfile] | 1         | 1      | false      | []              | []                                 |       |
+4    |        | []                                        | 1         | 1      | false      | []              | [/tmp/miniccc/files/cc_io.bigfile] |       |
 
 ## # sanity check
 ## shell du -sb /tmp/minimega/files/cc_io.bigfile


### PR DESCRIPTION
## Description ##
Track successful miniccc command deliveries and expose the count through `cc commands` as `issued`. Add reconnect coverage and update functional test fixtures.

## Motivation and context ##
Responses alone do not show command resends after a client reconnects or VM reboot. The new count lets operators compare commands issued with responses received. Resolves #1330.

## Testing ##

Tested with a topology. Didn't do in-depth testing.

```shell
$ mm namespace helloworld .columns id,command,responses,issued cc commands
host   | id | command                                                      | responses | issued
host01 | 1  | [ip addr]                                                    | 1         | 1
host01 | 2  | [ip addr]                                                    | 1         | 1
host01 | 3  | [ip addr]                                                    | 1         | 1
host01 | 4  | [ip route]                                                   | 1         | 1
host01 | 5  | [ip route]                                                   | 1         | 1
host01 | 6  | [ping -c 1 192.168.1.1]                                      | 1         | 1
```

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested my code using the methods described above.
- [x] All GitHub Actions are passing.

## Additional Notes ##
The `issued` value increments only after a command message is successfully encoded to the client connection, including resends after reconnects.