### PR TITLE
docs: update GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,7 +1,8 @@
 name: "Bug report"
 description: Describe a bug, error, unexpected behavior, or other problem
-labels:
-  - bug
+title: "[BUG] "
+labels: ["bug"]
+type: Bug
 
 body:
   - type: input
@@ -43,3 +44,22 @@ body:
       description: What did you expect to happen that didn't?
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context, such as logs, stack traces, screenshots, or related issues/PRs.
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Please confirm the following before submitting your issue.
+      options:
+        - label: "I have included no proprietary/sensitive information in my issue."
+          required: true
+        - label: "I have searched the existing issues and believe this is not a duplicate of an existing bug report. If this bug is not the same as another bug, but closely related, please link to the related issue(s). If it's a duplicate, add your information to an existing issue instead of creating a new one."
+          required: true

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,7 +1,8 @@
 name: "Submit a feature request / idea"
 description: Describe an idea, feature, or improvement
-labels:
-  - enhancement
+title: "[FEATURE] "
+labels: ["enhancement"]
+type: Feature
 
 body:
   - type: textarea
@@ -33,3 +34,12 @@ body:
         - [ ] Any other criteria
     validations:
       required: true
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Please confirm the following before submitting your feature request.
+      options:
+        - label: "I have included no proprietary/sensitive information in my issue."
+          required: true
+        - label: "I have searched the existing issues and believe this is not a duplicate of an existing feature request."
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,18 @@
 <!-- Mention any related issue(s) here using appropriate keywords such -->
 <!-- as "closes" or "resolves" to auto-close them on merge. -->
 
+## Related Issues/PRs ##
+<!-- If applicable, link to related issue(s) or PRs here (e.g. #123). -->
+
+## Type of Change ##
+<!-- Select the types that apply. -->
+- [ ] Bugfix (`fix`)
+- [ ] Feature (`feat`)
+- [ ] Documentation (`docs`)
+- [ ] Refactor (`refactor`)
+- [ ] Chore (CI, build, dependencies, etc.) (`chore`)
+- [ ] Other (please describe):
+
 ## Testing ##
 <!-- How did you test your changes? How could someone else test this PR? -->
 <!-- Include details of your testing environment, and the tests you ran to -->
@@ -20,12 +32,12 @@
 <!-- Draft PRs may have one or more unchecked boxes. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. -->
 <!-- We're here to help! -->
-- [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).  
-- [ ] I have included no proprietary/sensitive information in my code. 
+- [ ] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
+- [ ] I have included no proprietary/sensitive information in my code or the PR.
 - [ ] I have performed a self-review of my code.
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have made corresponding changes to the documentation.
-- [ ] I have tested my code using the methods described above.
+- [ ] I have tested my code (describe above).
 - [ ] All GitHub Actions are passing.
 
 ## Additional Notes ##


### PR DESCRIPTION
## Description ##
Refresh the GitHub issue and PR templates to match the current issue-form conventions and make the contribution flow clearer for contributors.

This mirrors the template updates made in sceptre-phenix PR 392, adapted to this repo’s conventions and naming.

## Motivation and context ##
The repository was still using older markdown issue templates and a generic pull request template. This update makes the issue intake more structured, adds explicit checklist requirements, and standardizes the PR template around the project’s contribution process.

## Related Issues/PRs ##
- https://github.com/sandialabs/sceptre-phenix/pull/392

## Type of Change ##
- [ ] Bugfix (`fix`)
- [ ] Feature (`feat`)
- [x] Documentation (`docs`)
- [ ] Refactor (`refactor`)
- [ ] Chore (CI, build, dependencies, etc.) (`chore`)
- [ ] Other (please describe):

## Testing ##
Validated the YAML templates and markdown formatting with `git diff --check` to ensure there are no whitespace issues and the issue form files are in a clean state.

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code or the PR.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code (describe above).
- [ ] All GitHub Actions are passing.

## Additional Notes ##
This is a documentation-only template refresh; no runtime code or behavior was changed.