### PR TITLE
fix(bridge): prevent packet capture ID reuse

### DIFF
--- a/cmd/minimega/capture.go
+++ b/cmd/minimega/capture.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/sandia-minimega/minimega/v2/internal/bridge"
@@ -264,19 +265,24 @@ func (c *captures) StopBridge(s, typ string) error {
 	})
 }
 
-// stop stops all captures that fn returns true for.
+// stop stops all captures that fn returns true for. Captures are always
+// removed from the map, even if stopping them failed, so that a single bad
+// capture doesn't prevent the rest from being stopped or leave a permanently
+// unstoppable entry behind. Any errors encountered are aggregated.
 func (c *captures) stop(fn func(capture) bool) error {
+	var errs []error
+
 	for id, v := range c.m {
 		if fn(v) {
 			if err := v.Stop(); err != nil {
-				return err
+				errs = append(errs, err)
 			}
 
 			delete(c.m, id)
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // getOrCreateNetflow wraps calls to getBridge and getNetflowFromBridge,

--- a/cmd/minimega/capture_test.go
+++ b/cmd/minimega/capture_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+type stopTestCapture struct {
+	err   error
+	stops *int
+}
+
+func (c stopTestCapture) Type() string {
+	return "pcap"
+}
+
+func (c stopTestCapture) Stop() error {
+	(*c.stops)++
+
+	return c.err
+}
+
+func TestCapturesStopContinuesAfterError(t *testing.T) {
+	stopErr := errors.New("stop failed")
+	var stops int
+	captures := captures{
+		m: map[int]capture{
+			0: stopTestCapture{err: stopErr, stops: &stops},
+			1: stopTestCapture{stops: &stops},
+		},
+	}
+
+	err := captures.stop(func(capture) bool {
+		return true
+	})
+	if !errors.Is(err, stopErr) {
+		t.Fatalf("expected joined stop error, got %v", err)
+	}
+	if stops != 2 {
+		t.Fatalf("expected both captures to be stopped, got %d stops", stops)
+	}
+	if len(captures.m) != 0 {
+		t.Fatalf("expected all stopped captures to be removed, got %d entries", len(captures.m))
+	}
+}

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -38,6 +38,11 @@ type Bridge struct {
 	// we want to stop a capture.
 	captures map[int]capture
 
+	// captureID is a monotonically increasing counter used to assign unique
+	// IDs to captures. IDs must never be reused, even after captures are
+	// stopped and removed from the captures map or the bridge is recreated.
+	captureID *int
+
 	trunks  map[string]bool
 	tunnels map[string]bool
 

--- a/internal/bridge/bridges.go
+++ b/internal/bridge/bridges.go
@@ -25,6 +25,8 @@ type Bridges struct {
 	bondChan chan string
 
 	bridges map[string]*Bridge
+
+	captureIDs map[string]*int
 }
 
 // openflow filters to redirect arp and icmp6 traffic to the local tap
@@ -74,10 +76,11 @@ func NewBridges(d, tf, bf string) *Bridges {
 	}()
 
 	b := &Bridges{
-		Default:  d,
-		tapChan:  tapChan,
-		bondChan: bondChan,
-		bridges:  map[string]*Bridge{},
+		Default:    d,
+		tapChan:    tapChan,
+		bondChan:   bondChan,
+		bridges:    map[string]*Bridge{},
+		captureIDs: map[string]*int{},
 	}
 
 	// Start a goroutine to collect bandwidth stats every 5 seconds
@@ -96,17 +99,24 @@ func NewBridges(d, tf, bf string) *Bridges {
 func (b Bridges) newBridge(name string) error {
 	log.Info("creating new bridge: %v", name)
 
+	captureID := b.captureIDs[name]
+	if captureID == nil {
+		captureID = new(int)
+		b.captureIDs[name] = captureID
+	}
+
 	br := &Bridge{
-		Name:     name,
-		taps:     make(map[string]*Tap),
-		trunks:   make(map[string]bool),
-		tunnels:  make(map[string]bool),
-		mirrors:  make(map[string]bool),
-		bonds:    make(map[string]map[string]int),
-		captures: make(map[int]capture),
-		tapChan:  b.tapChan,
-		bondChan: b.bondChan,
-		config:   make(map[string]string),
+		Name:      name,
+		taps:      make(map[string]*Tap),
+		trunks:    make(map[string]bool),
+		tunnels:   make(map[string]bool),
+		mirrors:   make(map[string]bool),
+		bonds:     make(map[string]map[string]int),
+		captures:  make(map[int]capture),
+		captureID: captureID,
+		tapChan:   b.tapChan,
+		bondChan:  b.bondChan,
+		config:    make(map[string]string),
 	}
 
 	// Create the bridge

--- a/internal/bridge/capture.go
+++ b/internal/bridge/capture.go
@@ -103,7 +103,9 @@ func (b *Bridge) captureTap(tap, fname string, config ...CaptureConfig) (int, er
 		return 0, err
 	}
 
-	id := len(b.captures)
+	id := *b.captureID
+	*b.captureID++
+
 	stopped := uint64(0)
 	ack := make(chan bool)
 

--- a/tests/capture
+++ b/tests/capture
@@ -51,7 +51,11 @@ namespace foo capture pcap vm multi 1 /dev/null
 namespace foo capture
 namespace foo capture pcap delete vm multi 0
 namespace foo capture
+namespace foo capture pcap vm multi 0 /dev/null
+namespace foo capture
 namespace foo capture pcap delete vm multi 1
+namespace foo capture
+namespace foo capture pcap delete vm multi 0
 namespace foo capture
 
 # Deleting a nonexistent interface capture should fail

--- a/tests/capture.want
+++ b/tests/capture.want
@@ -74,7 +74,15 @@ mega_bridge | pcap | multi:1   |      |          | /dev/null
 ## namespace foo capture
 bridge      | type | interface | mode | compress | path
 mega_bridge | pcap | multi:1   |      |          | /dev/null
+## namespace foo capture pcap vm multi 0 /dev/null
+## namespace foo capture
+bridge      | type | interface | mode | compress | path
+mega_bridge | pcap | multi:0   |      |          | /dev/null
 ## namespace foo capture pcap delete vm multi 1
+## namespace foo capture
+bridge      | type | interface | mode | compress | path
+mega_bridge | pcap | multi:0   |      |          | /dev/null
+## namespace foo capture pcap delete vm multi 0
 ## namespace foo capture
 
 ## # Deleting a nonexistent interface capture should fail


### PR DESCRIPTION
## Description ##

Use a per-bridge counter for packet capture IDs instead of the number of currently active captures. Also aggregate capture-stop errors while removing stopped entries.

## Motivation and context ##

Capture IDs were reused after an earlier capture stopped. Starting captures on two VM interfaces, stopping one, and starting another could overwrite the remaining capture's entry. A subsequent `capture pcap delete vm <name>` then failed with `unknown capture ID` and left a capture running.

This preserves all active capture entries and lets stop-all continue across individual stop errors.

## Related Issues/PRs ##

- Phenix PR [#395](https://github.com/sandialabs/sceptre-phenix/pull/395), which exposed per-interface VM capture start/stop in the UI and CLI.

## Type of Change ##
- [x] Bugfix (`fix`)
- [ ] Feature (`feat`)
- [ ] Documentation (`docs`)
- [ ] Refactor (`refactor`)
- [ ] Chore (CI, build, dependencies, etc.) (`chore`)
- [ ] Other (please describe):

## Testing ##

- Manually tested with an experiment, starting and stopping captures on a VM in phenix UI and CLI, and stopping multiple captures from a VM in phenix UI.
- Unit tests pass

## Checklist ##
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandia-minimega/minimega/blob/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code or the PR.
- [x] I have performed a self-review of my code.
- [x] My branch is rebased onto `master` and has one commit unless multiple commits are intentionally reviewable.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested my code (describe above).
- [x] All GitHub Actions are passing.

## Additional Notes ##

Tested.

